### PR TITLE
fix(app): render display side panel by disabling hidesOnDeactivate

### DIFF
--- a/Sources/App/MenuBarContent.swift
+++ b/Sources/App/MenuBarContent.swift
@@ -655,8 +655,13 @@ private final class SecondaryPanelController: ObservableObject {
             defer: false
         )
         panel.isFloatingPanel = true
-        // app 被切到后台时自动隐藏侧栏，作为正常 dismiss 路径之外的防御性兜底。
-        panel.hidesOnDeactivate = true
+        // 必须保持为 false：在 `.nonactivatingPanel` + 菜单栏 app 的组合下，
+        // `hidesOnDeactivate = true` 会让这个 panel 在 orderFront 之后陷入
+        // 「NSWindow.isVisible 仍为 true 但实际像素不上屏」的半死状态，侧栏完全
+        // 看不见（被 popover 右侧的其他 app 窗口内容透出来）。
+        // 侧栏生命周期已经由 MenuBarContent.onDisappear → SecondaryPanelController.hide()
+        // 负责级联清理，不需要 hidesOnDeactivate 作为兜底。
+        panel.hidesOnDeactivate = false
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true


### PR DESCRIPTION
## Symptom
In shipped builds, clicking "显示器分辨率" → selecting a display never shows the resolution side panel. The area where the panel should appear remains transparent — you can see straight through to whatever window is behind MacTools.

## Root cause
\`panel.hidesOnDeactivate = true\` combined with \`.nonactivatingPanel\` styling on a menu-bar app puts the side panel into a broken state:

- NSWindow API reports \`isVisible = true\`
- \`isOnActiveSpace = true\`
- \`orderFrontRegardless()\` returns successfully
- The panel's \`contentView\` has a valid non-zero frame
- Level is correctly set to \`hostWindow.level + 1\`

...**but the backing store never gets composited to the screen.** Pixels simply don't appear.

## Evidence
Verified empirically in both Debug and Release builds by toggling the single flag with all other settings held constant:

| Configuration | Panel visible on screen? |
|---|---|
| \`hidesOnDeactivate = true\`  | ❌ no (matches shipped bug) |
| \`hidesOnDeactivate = false\` | ✅ yes (renders correctly) |

Temporarily setting \`isOpaque = true\` and \`backgroundColor = .red\` confirmed that when \`hidesOnDeactivate\` was restored to \`false\`, the window drew normally. The bug was isolated to this single flag.

## Why it was there in the first place
The original comment said it was a "defensive fallback for when the app gets deactivated". That was wrong on two counts:

1. The side panel's lifecycle is already fully handled by \`MenuBarContent.onDisappear → SecondaryPanelController.hide()\`
2. The \`hostWindow.isVisible\` guard in \`show()\` handles the post-dismiss async race from \`MenuWindowAccessor.updateNSView\`

\`hidesOnDeactivate\` was adding zero defensive value and introducing a rendering bug. Removing it is strictly an improvement.

## Test plan
- [x] Debug build: \`xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug test\` — 38 tests pass
- [x] Release build: \`xcodebuild ... -configuration Release build\` — succeeds
- [x] Manual (Debug): expand "显示器分辨率" → select a display → side panel appears immediately
- [x] Manual (Debug): click outside the app → main menu and side panel dismiss together
- [x] Manual (Debug): click on another app → MacTools dismisses cleanly, other app is interactive

## Context
This is a follow-up to #1 (display resolution control plugin). The original PR introduced \`hidesOnDeactivate = true\` as a supposed safety net; this PR removes it with a clear explanation of why it must stay \`false\` for \`.nonactivatingPanel\` + menu-bar-app contexts.