### PR TITLE
fix(app): keep side panel NSHostingView alive across re-renders

### DIFF
--- a/Sources/App/MenuBarContent.swift
+++ b/Sources/App/MenuBarContent.swift
@@ -1018,6 +1018,7 @@ private final class SecondaryPanelController: ObservableObject {
 
     private weak var hostWindow: NSWindow?
     private var panelWindow: SecondaryPanelWindow?
+    private var panelHostingView: NSHostingView<AnyView>?
     private var hostWindowObservers: [NSObjectProtocol] = []
     var onHostWindowDismissRequest: (() -> Void)?
 
@@ -1052,18 +1053,35 @@ private final class SecondaryPanelController: ObservableObject {
         // isVisible 已经变为 false，以此拦截竞态导致的侧栏重新展示。
         guard hostWindow.isVisible else { return }
 
-        let rootView = SecondarySlidingPanel(
-            title: panel.title,
-            controls: panel.controls,
-            onSelectionChange: onSelectionChange,
-            onNavigationSelectionChange: onNavigationSelectionChange,
-            onDateChange: onDateChange,
-            onHoverChange: onHoverChange,
-            onSliderChange: onSliderChange
+        let rootView = AnyView(
+            SecondarySlidingPanel(
+                title: panel.title,
+                controls: panel.controls,
+                onSelectionChange: onSelectionChange,
+                onNavigationSelectionChange: onNavigationSelectionChange,
+                onDateChange: onDateChange,
+                onHoverChange: onHoverChange,
+                onSliderChange: onSliderChange
+            )
+            .frame(width: MenuBarPanelLayout.secondaryPanelWidth)
         )
-        .frame(width: MenuBarPanelLayout.secondaryPanelWidth)
 
-        let hostingView = NSHostingView(rootView: rootView)
+        let panelWindow = panelWindow ?? makePanel()
+        // 复用同一个 NSHostingView —— 如果每次 show() 都重建 contentView，
+        // 鼠标按下到释放之间命中的 SwiftUI Button 会被整棵销毁，导致点击丢失
+        // （现象：侧栏里点分辨率毫无反应）。保留原视图并就地更新 rootView，
+        // 既保住按钮的 pressed 状态，也保留 hover 追踪。
+        let hostingView: NSHostingView<AnyView>
+        if let existing = panelHostingView, panelWindow.contentView === existing {
+            existing.rootView = rootView
+            hostingView = existing
+        } else {
+            let newHosting = NSHostingView(rootView: rootView)
+            panelWindow.contentView = newHosting
+            panelHostingView = newHosting
+            hostingView = newHosting
+        }
+
         let fittingSize = hostingView.fittingSize
         let width = MenuBarPanelLayout.secondaryPanelWidth
         let height = max(fittingSize.height, 160)
@@ -1073,8 +1091,6 @@ private final class SecondaryPanelController: ObservableObject {
         )
         let frame = CGRect(origin: origin, size: CGSize(width: width, height: height))
 
-        let panelWindow = panelWindow ?? makePanel()
-        panelWindow.contentView = hostingView
         panelWindow.setFrame(frame, display: true)
         // 运行时把 panel level 动态对齐到 hostWindow.level + 1，保证 Z 序高于 popover。
         // MenuBarExtra popover 的 level 是 SwiftUI 私有实现细节，不能硬编码。
@@ -1086,7 +1102,9 @@ private final class SecondaryPanelController: ObservableObject {
     func hide() {
         guard let panelWindow else { return }
         panelWindow.orderOut(nil)
+        panelWindow.contentView = nil
         self.panelWindow = nil
+        self.panelHostingView = nil
     }
 
     private func makePanel() -> SecondaryPanelWindow {
@@ -1151,18 +1169,48 @@ private final class SecondaryPanelController: ObservableObject {
 private struct MenuWindowAccessor: NSViewRepresentable {
     let onWindowChange: (NSWindow?) -> Void
 
+    final class Coordinator {
+        weak var lastWindow: NSWindow?
+        var hasFiredOnce = false
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
-        DispatchQueue.main.async {
-            onWindowChange(view.window)
+        DispatchQueue.main.async { [coordinator = context.coordinator, onWindowChange] in
+            Self.signalIfNeeded(
+                coordinator: coordinator,
+                window: view.window,
+                onWindowChange: onWindowChange
+            )
         }
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async {
-            onWindowChange(nsView.window)
+        DispatchQueue.main.async { [coordinator = context.coordinator, onWindowChange] in
+            Self.signalIfNeeded(
+                coordinator: coordinator,
+                window: nsView.window,
+                onWindowChange: onWindowChange
+            )
         }
+    }
+
+    // 只在 NSWindow 真正变化时回调上层 —— SwiftUI 每次 body 重算都会触发 updateNSView，
+    // 如果无条件回调，会反复调用 syncSecondaryPanelWindow → show() → 替换侧栏 contentView，
+    // 把点击中的 SwiftUI Button 整棵销毁。
+    private static func signalIfNeeded(
+        coordinator: Coordinator,
+        window: NSWindow?,
+        onWindowChange: (NSWindow?) -> Void
+    ) {
+        let windowChanged = coordinator.lastWindow !== window
+        guard windowChanged || !coordinator.hasFiredOnce else { return }
+        coordinator.lastWindow = window
+        coordinator.hasFiredOnce = true
+        onWindowChange(window)
     }
 }
 


### PR DESCRIPTION
## Summary

修复显示器分辨率侧栏「点了没反应」的问题。

## 根因

`SecondaryPanelController.show()` 每次调用都会 `new` 一个 `NSHostingView` 并赋给 `panelWindow.contentView`，整棵 SwiftUI 视图树被替换。而 `MenuWindowAccessor.updateNSView` 在 SwiftUI 每次 body 重算时都无条件派发 `onWindowChange` → `syncSecondaryPanelWindow()` → `show()`。

结果：mouseDown 命中侧栏里的 `SelectListRow` Button → SwiftUI 因任意状态变化 re-render → `show()` 替换 contentView → 原 Button 视图被销毁 → mouseUp 到达时目标视图已不在 → action 不触发。

## 修复

1. `SecondaryPanelController` 持有 `NSHostingView<AnyView>`，`show()` 复用同一个 host，仅就地更新 `rootView`；`hide()` 清空引用。
2. `MenuWindowAccessor` 增加 `Coordinator`，只在 `NSWindow` 引用真正变化时才回调上层，砍掉反复触发 `show()` 的源头。

## Test plan

- [x] \`xcodebuild ... build\` 通过
- [x] \`xcodebuild ... test\` 全部通过（含 `DisplayResolutionPluginSidePanelTests`、`HoverSecondaryPanelCoordinatorTests`）
- [x] 本地运行 Debug build，点击侧栏中非当前分辨率，分辨率正确切换

🤖 Generated with [Claude Code](https://claude.com/claude-code)