### PR TITLE
fix(app): keep side panel alive on click + add open-display-settings shortcut

### DIFF
--- a/Sources/App/MenuBarContent.swift
+++ b/Sources/App/MenuBarContent.swift
@@ -176,6 +176,11 @@ struct MenuBarContent: View {
         let isOn: Bool
     }
 
+    private struct DeferredActionInvocation {
+        let pluginID: String
+        let controlID: String
+    }
+
     @StateObject private var secondaryPanelController = SecondaryPanelController()
     @StateObject private var hoverCoordinator = HoverSecondaryPanelCoordinator()
     @Environment(\.dismiss) private var dismiss
@@ -183,6 +188,7 @@ struct MenuBarContent: View {
 
     @ObservedObject var pluginHost: PluginHost
     @State private var deferredPanelSwitchAction: DeferredPanelSwitchAction?
+    @State private var deferredActionInvocation: DeferredActionInvocation?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -225,6 +231,7 @@ struct MenuBarContent: View {
         }
         .onDisappear {
             flushDeferredPanelSwitchActionIfNeeded()
+            flushDeferredActionInvocationIfNeeded()
             hoverCoordinator.dismissImmediately()
             hoverCoordinator.onDismissRequest = nil
             secondaryPanelController.onHostWindowDismissRequest = nil
@@ -260,6 +267,36 @@ struct MenuBarContent: View {
         pluginHost.setSwitchValue(
             deferredPanelSwitchAction.isOn,
             for: deferredPanelSwitchAction.pluginID
+        )
+    }
+
+    private func handleActionInvoke(
+        controlID: String,
+        for item: PluginPanelItem,
+        behavior: PluginMenuActionBehavior
+    ) {
+        switch behavior {
+        case .keepPresented:
+            pluginHost.invokePanelAction(controlID: controlID, for: item.id)
+        case .dismissBeforeHandling:
+            // 先收 popover 再执行，避免动作打开新窗口时菜单还浮在屏上挡视线。
+            deferredActionInvocation = DeferredActionInvocation(
+                pluginID: item.id,
+                controlID: controlID
+            )
+            dismiss()
+        }
+    }
+
+    private func flushDeferredActionInvocationIfNeeded() {
+        guard let deferred = deferredActionInvocation else {
+            return
+        }
+
+        self.deferredActionInvocation = nil
+        pluginHost.invokePanelAction(
+            controlID: deferred.controlID,
+            for: deferred.pluginID
         )
     }
 
@@ -385,6 +422,13 @@ struct MenuBarContent: View {
                             for: item.id,
                             phase: phase
                         )
+                    },
+                    onActionInvoke: { controlID, behavior in
+                        handleActionInvoke(
+                            controlID: controlID,
+                            for: item,
+                            behavior: behavior
+                        )
                     }
                 )
             }
@@ -423,6 +467,7 @@ struct FeatureRowView: View {
     let onDateChange: (String, Date) -> Void
     @State private var isHovered = false
     let onSliderChange: (String, Double, PluginPanelAction.SliderPhase) -> Void
+    let onActionInvoke: (String, PluginMenuActionBehavior) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: detailToDisplay == nil ? 0 : 12) {
@@ -450,7 +495,8 @@ struct FeatureRowView: View {
                     onNavigationHoverChange: onNavigationHoverChange,
                     onNavigationRowFrameChange: onNavigationRowFrameChange,
                     onDateChange: onDateChange,
-                    onSliderChange: onSliderChange
+                    onSliderChange: onSliderChange,
+                    onActionInvoke: onActionInvoke
                 )
                 .padding(.leading, FeatureRowLayout.detailLeadingInset)
             }
@@ -534,10 +580,16 @@ private struct PluginPanelDetailView: View {
     let onNavigationRowFrameChange: (String, String, CGRect?) -> Void
     let onDateChange: (String, Date) -> Void
     let onSliderChange: (String, Double, PluginPanelAction.SliderPhase) -> Void
+    let onActionInvoke: (String, PluginMenuActionBehavior) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             ForEach(detail.primaryControls) { control in
+                if control.showsLeadingDivider {
+                    Divider()
+                        .padding(.horizontal, FeatureRowLayout.detailControlHorizontalPadding)
+                }
+
                 panelControl(control)
             }
         }
@@ -621,7 +673,54 @@ private struct PluginPanelDetailView: View {
                     onSliderChange(control.id, value, phase)
                 }
             )
+        case .actionRow:
+            ActionRowControl(
+                control: control,
+                onInvoke: {
+                    onActionInvoke(control.id, control.actionBehavior)
+                }
+            )
         }
+    }
+}
+
+private struct ActionRowControl: View {
+    let control: PluginPanelControl
+    let onInvoke: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            guard control.isEnabled else { return }
+            onInvoke()
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: control.actionIconSystemName ?? "arrow.up.right.square")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16, height: 16)
+
+                Text(control.actionTitle ?? "")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer()
+            }
+            .padding(.horizontal, FeatureRowLayout.detailControlHorizontalPadding)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .background(alignment: .center) {
+                RoundedRectangle(cornerRadius: MenuBarHoverStyle.navigationCornerRadius, style: .continuous)
+                    .inset(by: MenuBarHoverStyle.inset)
+                    .fill(control.isEnabled && isHovered ? MenuBarHoverStyle.fill : Color.clear)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(!control.isEnabled)
+        .onHover { isHovered = $0 }
     }
 }
 
@@ -949,7 +1048,8 @@ private struct SecondarySlidingPanel: View {
                 onNavigationHoverChange: { _, _, _ in },
                 onNavigationRowFrameChange: { _, _, _ in },
                 onDateChange: onDateChange,
-                onSliderChange: onSliderChange
+                onSliderChange: onSliderChange,
+                onActionInvoke: { _, _ in }
             )
         }
         .padding(12)
@@ -1176,6 +1276,11 @@ private struct MenuWindowAccessor: NSViewRepresentable {
         return view
     }
 
+    // 每次重渲染都把窗口回传给上层 ——上层会调用 syncSecondaryPanelWindow()，
+    // 充当侧栏的兜底刷新（屏幕分辨率切换、popover 短暂不可见等场景下，仅靠 onChange
+    // 钩子可能错过一次需要重新 show() 的时机）。
+    // 必须配合 SecondaryPanelController.show() 中的 NSHostingView 复用，否则会
+    // 在 mouseDown→mouseUp 之间反复重建 contentView，导致按钮点击丢失。
     func updateNSView(_ nsView: NSView, context: Context) {
         DispatchQueue.main.async {
             onWindowChange(nsView.window)

--- a/Sources/App/MenuBarContent.swift
+++ b/Sources/App/MenuBarContent.swift
@@ -1018,6 +1018,7 @@ private final class SecondaryPanelController: ObservableObject {
 
     private weak var hostWindow: NSWindow?
     private var panelWindow: SecondaryPanelWindow?
+    private var panelHostingView: NSHostingView<AnyView>?
     private var hostWindowObservers: [NSObjectProtocol] = []
     var onHostWindowDismissRequest: (() -> Void)?
 
@@ -1052,18 +1053,35 @@ private final class SecondaryPanelController: ObservableObject {
         // isVisible 已经变为 false，以此拦截竞态导致的侧栏重新展示。
         guard hostWindow.isVisible else { return }
 
-        let rootView = SecondarySlidingPanel(
-            title: panel.title,
-            controls: panel.controls,
-            onSelectionChange: onSelectionChange,
-            onNavigationSelectionChange: onNavigationSelectionChange,
-            onDateChange: onDateChange,
-            onHoverChange: onHoverChange,
-            onSliderChange: onSliderChange
+        let rootView = AnyView(
+            SecondarySlidingPanel(
+                title: panel.title,
+                controls: panel.controls,
+                onSelectionChange: onSelectionChange,
+                onNavigationSelectionChange: onNavigationSelectionChange,
+                onDateChange: onDateChange,
+                onHoverChange: onHoverChange,
+                onSliderChange: onSliderChange
+            )
+            .frame(width: MenuBarPanelLayout.secondaryPanelWidth)
         )
-        .frame(width: MenuBarPanelLayout.secondaryPanelWidth)
 
-        let hostingView = NSHostingView(rootView: rootView)
+        let panelWindow = panelWindow ?? makePanel()
+        // 复用同一个 NSHostingView —— 如果每次 show() 都重建 contentView，
+        // 鼠标按下到释放之间命中的 SwiftUI Button 会被整棵销毁，导致点击丢失
+        // （现象：侧栏里点分辨率毫无反应）。保留原视图并就地更新 rootView，
+        // 既保住按钮的 pressed 状态，也保留 hover 追踪。
+        let hostingView: NSHostingView<AnyView>
+        if let existing = panelHostingView, panelWindow.contentView === existing {
+            existing.rootView = rootView
+            hostingView = existing
+        } else {
+            let newHosting = NSHostingView(rootView: rootView)
+            panelWindow.contentView = newHosting
+            panelHostingView = newHosting
+            hostingView = newHosting
+        }
+
         let fittingSize = hostingView.fittingSize
         let width = MenuBarPanelLayout.secondaryPanelWidth
         let height = max(fittingSize.height, 160)
@@ -1073,8 +1091,6 @@ private final class SecondaryPanelController: ObservableObject {
         )
         let frame = CGRect(origin: origin, size: CGSize(width: width, height: height))
 
-        let panelWindow = panelWindow ?? makePanel()
-        panelWindow.contentView = hostingView
         panelWindow.setFrame(frame, display: true)
         // 运行时把 panel level 动态对齐到 hostWindow.level + 1，保证 Z 序高于 popover。
         // MenuBarExtra popover 的 level 是 SwiftUI 私有实现细节，不能硬编码。
@@ -1087,6 +1103,7 @@ private final class SecondaryPanelController: ObservableObject {
         guard let panelWindow else { return }
         panelWindow.orderOut(nil)
         self.panelWindow = nil
+        self.panelHostingView = nil
     }
 
     private func makePanel() -> SecondaryPanelWindow {

--- a/Sources/Core/Plugins/PluginHost.swift
+++ b/Sources/Core/Plugins/PluginHost.swift
@@ -179,6 +179,15 @@ final class PluginHost: ObservableObject {
         rebuildDerivedState()
     }
 
+    func invokePanelAction(controlID: String, for pluginID: String) {
+        guard let plugin = plugin(for: pluginID) else {
+            return
+        }
+
+        plugin.handlePanelAction(.invokeAction(controlID: controlID))
+        rebuildDerivedState()
+    }
+
     func performSettingsAction(pluginID: String, actionID: String) {
         guard let plugin = plugin(for: pluginID) else {
             return

--- a/Sources/Core/Plugins/PluginModels.swift
+++ b/Sources/Core/Plugins/PluginModels.swift
@@ -19,6 +19,7 @@ enum PluginPanelAction: Equatable {
     case clearNavigationSelection(controlID: String)
     case setDate(controlID: String, value: Date)
     case setSlider(controlID: String, value: Double, phase: SliderPhase)
+    case invokeAction(controlID: String)
 }
 
 enum PluginPanelDescriptionTone {
@@ -74,6 +75,7 @@ enum PluginPanelControlKind {
     case selectList
     case navigationList
     case slider
+    case actionRow
 }
 
 enum PluginPanelDatePickerStyle {
@@ -107,6 +109,10 @@ struct PluginPanelControl: Identifiable {
     let sliderBounds: ClosedRange<Double>?
     let sliderStep: Double?
     let valueLabel: String?
+    let actionTitle: String?
+    let actionIconSystemName: String?
+    let actionBehavior: PluginMenuActionBehavior
+    let showsLeadingDivider: Bool
     let isEnabled: Bool
 
     init(
@@ -123,6 +129,10 @@ struct PluginPanelControl: Identifiable {
         sliderBounds: ClosedRange<Double>? = nil,
         sliderStep: Double? = nil,
         valueLabel: String? = nil,
+        actionTitle: String? = nil,
+        actionIconSystemName: String? = nil,
+        actionBehavior: PluginMenuActionBehavior = .keepPresented,
+        showsLeadingDivider: Bool = false,
         isEnabled: Bool
     ) {
         self.id = id
@@ -138,6 +148,10 @@ struct PluginPanelControl: Identifiable {
         self.sliderBounds = sliderBounds
         self.sliderStep = sliderStep
         self.valueLabel = valueLabel
+        self.actionTitle = actionTitle
+        self.actionIconSystemName = actionIconSystemName
+        self.actionBehavior = actionBehavior
+        self.showsLeadingDivider = showsLeadingDivider
         self.isEnabled = isEnabled
     }
 }

--- a/Sources/Features/CleanMode/PhysicalCleanModePlugin.swift
+++ b/Sources/Features/CleanMode/PhysicalCleanModePlugin.swift
@@ -123,7 +123,8 @@ final class PhysicalCleanModePlugin: FeaturePlugin {
              .setNavigationSelection,
              .clearNavigationSelection,
              .setDate,
-             .setSlider:
+             .setSlider,
+             .invokeAction:
             break
         }
     }

--- a/Sources/Features/DisplayBrightness/DisplayBrightnessPlugin.swift
+++ b/Sources/Features/DisplayBrightness/DisplayBrightnessPlugin.swift
@@ -88,7 +88,8 @@ final class DisplayBrightnessPlugin: FeaturePlugin {
              .setSelection,
              .setNavigationSelection,
              .clearNavigationSelection,
-             .setDate:
+             .setDate,
+             .invokeAction:
             return
         }
     }

--- a/Sources/Features/DisplayResolution/DisplayResolutionPlugin.swift
+++ b/Sources/Features/DisplayResolution/DisplayResolutionPlugin.swift
@@ -1,14 +1,36 @@
+import AppKit
 import CoreGraphics
 import Foundation
 import SwiftUI
 
 private enum ControlID {
     static let displayNavigation = "display-navigation"
+    static let openSystemSettings = "display-open-system-settings"
+}
+
+@MainActor
+protocol DisplaySystemSettingsLauncher {
+    @discardableResult
+    func openDisplaySettings() -> Bool
+}
+
+@MainActor
+struct WorkspaceDisplaySystemSettingsLauncher: DisplaySystemSettingsLauncher {
+    // 直接打开「系统设置 → 显示器」，对 Ventura+ 的 System Settings 与
+    // 旧版 System Preferences 都有效。
+    private static let systemDisplaySettingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.displays")!
+
+    @discardableResult
+    func openDisplaySettings() -> Bool {
+        NSWorkspace.shared.open(Self.systemDisplaySettingsURL)
+    }
 }
 
 @MainActor
 final class DisplayResolutionPlugin: FeaturePlugin {
     private static let unavailableModesSubtitle = "未检测到可用分辨率"
+    private static let openSystemSettingsTitle = "打开系统显示器设置"
+    private static let openSystemSettingsIcon = "gearshape"
 
     let manifest = PluginManifest(
         id: "display-resolution",
@@ -29,9 +51,14 @@ final class DisplayResolutionPlugin: FeaturePlugin {
     private var selectedDisplayID: CGDirectDisplayID?
     private var lastErrorMessage: String?
     private let controller: DisplayResolutionControlling
+    private let systemSettingsLauncher: DisplaySystemSettingsLauncher
 
-    init(controller: DisplayResolutionControlling = DisplayResolutionController()) {
+    init(
+        controller: DisplayResolutionControlling = DisplayResolutionController(),
+        systemSettingsLauncher: DisplaySystemSettingsLauncher = WorkspaceDisplaySystemSettingsLauncher()
+    ) {
         self.controller = controller
+        self.systemSettingsLauncher = systemSettingsLauncher
     }
 
     var panelState: PluginPanelState {
@@ -146,6 +173,15 @@ final class DisplayResolutionPlugin: FeaturePlugin {
             case .failure(let error):
                 handleApplyFailure(error, displayID: displayID, modeId: modeId)
             }
+        case let .invokeAction(controlID):
+            guard controlID == ControlID.openSystemSettings else {
+                return
+            }
+
+            let opened = systemSettingsLauncher.openDisplaySettings()
+            if !opened {
+                AppLog.displayResolutionPlugin.error("failed to open system display settings via NSWorkspace")
+            }
         case .setSwitch, .setDate, .setSlider:
             return
         }
@@ -219,6 +255,23 @@ final class DisplayResolutionPlugin: FeaturePlugin {
             isEnabled: true
         )
 
+        let openSystemSettings = PluginPanelControl(
+            id: ControlID.openSystemSettings,
+            kind: .actionRow,
+            options: [],
+            selectedOptionID: nil,
+            dateValue: nil,
+            minimumDate: nil,
+            displayedComponents: nil,
+            datePickerStyle: nil,
+            sectionTitle: nil,
+            actionTitle: Self.openSystemSettingsTitle,
+            actionIconSystemName: Self.openSystemSettingsIcon,
+            actionBehavior: .dismissBeforeHandling,
+            showsLeadingDivider: true,
+            isEnabled: true
+        )
+
         let secondaryPanel = selectedDisplayID.flatMap { selectedID -> PluginPanelSecondaryPanel? in
             guard let display = displays.first(where: { $0.display.id == selectedID }) else {
                 return nil
@@ -247,7 +300,7 @@ final class DisplayResolutionPlugin: FeaturePlugin {
         }
 
         return PluginPanelDetail(
-            primaryControls: [displayNavigation],
+            primaryControls: [displayNavigation, openSystemSettings],
             secondaryPanel: secondaryPanel
         )
     }

--- a/Sources/Features/KeepAwake/KeepAwakePlugin.swift
+++ b/Sources/Features/KeepAwake/KeepAwakePlugin.swift
@@ -99,7 +99,7 @@ final class KeepAwakePlugin: FeaturePlugin {
             }
 
             updateDurationPreset(using: optionID)
-        case .setDate, .setSlider:
+        case .setDate, .setSlider, .invokeAction:
             return
         }
     }

--- a/Tests/Core/Plugins/PluginHostNavigationSelectionTests.swift
+++ b/Tests/Core/Plugins/PluginHostNavigationSelectionTests.swift
@@ -40,6 +40,18 @@ final class PluginHostNavigationSelectionTests: XCTestCase {
         }
     }
 
+    func testInvokePanelActionForwardsInvokeActionToPlugin() {
+        let plugin = MockNavigationPlugin()
+        let host = makeHost(plugin: plugin)
+
+        host.invokePanelAction(controlID: "open-system-settings", for: plugin.manifest.id)
+
+        XCTAssertEqual(
+            plugin.receivedActions,
+            [.invokeAction(controlID: "open-system-settings")]
+        )
+    }
+
     private func makeHost(plugin: MockNavigationPlugin) -> PluginHost {
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)

--- a/Tests/Features/DisplayResolution/DisplayResolutionPluginSidePanelTests.swift
+++ b/Tests/Features/DisplayResolution/DisplayResolutionPluginSidePanelTests.swift
@@ -28,8 +28,9 @@ final class DisplayResolutionPluginSidePanelTests: XCTestCase {
 
         let detail = try XCTUnwrap(plugin.panelState.detail)
 
-        XCTAssertEqual(detail.primaryControls.count, 1)
+        XCTAssertEqual(detail.primaryControls.count, 2)
         XCTAssertEqual(detail.primaryControls[0].kind, .navigationList)
+        XCTAssertEqual(detail.primaryControls[1].kind, .actionRow)
         XCTAssertNil(detail.secondaryPanel)
     }
 
@@ -133,6 +134,57 @@ final class DisplayResolutionPluginSidePanelTests: XCTestCase {
         XCTAssertNil(state.detail)
     }
 
+    func testExpandedDetailExposesOpenSystemSettingsActionRow() throws {
+        let plugin = makePlugin()
+        plugin.handlePanelAction(.setDisclosureExpanded(true))
+
+        let controls = try XCTUnwrap(plugin.panelState.detail?.primaryControls)
+        let actionRow = try XCTUnwrap(controls.last)
+
+        XCTAssertEqual(actionRow.kind, .actionRow)
+        XCTAssertEqual(actionRow.id, "display-open-system-settings")
+        XCTAssertEqual(actionRow.actionTitle, "打开系统显示器设置")
+        XCTAssertEqual(actionRow.actionIconSystemName, "gearshape")
+        XCTAssertEqual(actionRow.actionBehavior, .dismissBeforeHandling)
+        XCTAssertTrue(actionRow.showsLeadingDivider)
+    }
+
+    func testInvokeOpenSystemSettingsActionAsksLauncherToOpen() {
+        let launcher = MockSystemSettingsLauncher()
+        let controller = MockDisplayResolutionController()
+        controller.displays = [makeDisplay(id: 2, name: "Studio Display", isMain: true)]
+        controller.modesByDisplayID = [
+            2: [makeMode(modeId: 8, width: 1920, height: 1080, isCurrent: true)]
+        ]
+
+        let plugin = DisplayResolutionPlugin(
+            controller: controller,
+            systemSettingsLauncher: launcher
+        )
+        plugin.handlePanelAction(.setDisclosureExpanded(true))
+        plugin.handlePanelAction(.invokeAction(controlID: "display-open-system-settings"))
+
+        XCTAssertEqual(launcher.openCallCount, 1)
+    }
+
+    func testInvokeUnknownActionDoesNotInvokeLauncher() {
+        let launcher = MockSystemSettingsLauncher()
+        let plugin = DisplayResolutionPlugin(
+            controller: MockDisplayResolutionController(),
+            systemSettingsLauncher: launcher
+        )
+
+        plugin.handlePanelAction(.invokeAction(controlID: "something-else"))
+
+        XCTAssertEqual(launcher.openCallCount, 0)
+    }
+
+    func testCollapsedPluginDoesNotExposeActionRow() {
+        let plugin = makePlugin()
+
+        XCTAssertNil(plugin.panelState.detail)
+    }
+
     func testSelectingDifferentDisplayClearsLastErrorMessage() throws {
         let controller = MockDisplayResolutionController()
         controller.displays = [
@@ -214,6 +266,17 @@ final class DisplayResolutionPluginSidePanelTests: XCTestCase {
             modelNumber: nil,
             serialNumber: nil
         )
+    }
+}
+
+@MainActor
+private final class MockSystemSettingsLauncher: DisplaySystemSettingsLauncher {
+    private(set) var openCallCount = 0
+
+    @discardableResult
+    func openDisplaySettings() -> Bool {
+        openCallCount += 1
+        return true
     }
 }
 


### PR DESCRIPTION
## Summary

两个相关改动，按 commit 拆分：

1. **fix(app): keep side panel NSHostingView alive across re-renders** — 修复点击侧栏分辨率没反应的问题
2. **feat(app): add shortcut to open system display settings** — 在「显示器分辨率」展开区底部新增「打开系统显示器设置」快捷入口

## Fix 详情

`SecondaryPanelController.show()` 之前每次都 \`new\` 一个 `NSHostingView` 并赋给 `panelWindow.contentView`，整棵 SwiftUI 视图树被替换。鼠标按下到释放之间命中的 `SelectListRow` Button 在 mouseUp 到达前已被销毁，action 不触发。

修复：`SecondaryPanelController` 持有一个 `NSHostingView<AnyView>`，`show()` 复用同一个 host，仅就地更新 `rootView`；`hide()` 清空引用。按钮 pressed 状态、hover 追踪都不再被刷新清空。

## Feature 详情

通用化「带行为的按钮行」，让任何插件都能复用：

- `PluginPanelControlKind.actionRow` + `PluginPanelAction.invokeAction(controlID:)`
- `PluginPanelControl` 新增 `actionTitle` / `actionIconSystemName` / `actionBehavior` / `showsLeadingDivider`
- `PluginHost.invokePanelAction(controlID:for:)` 转发
- `DisplayResolutionPlugin` 注入 `DisplaySystemSettingsLauncher` 协议（默认走 `NSWorkspace.shared.open(URL("x-apple.systempreferences:com.apple.preference.displays"))`），方便 mock
- `MenuBarContent` 渲染 `ActionRowControl`，仿照已有 `DeferredPanelSwitchAction` 增加 `DeferredActionInvocation`：`dismissBeforeHandling` 行为下先 dismiss popover、再在 `onDisappear` 里 flush，避免新窗口起来时菜单还浮在屏上挡视线

## Test plan

- [x] \`xcodebuild ... build\` 通过
- [x] \`xcodebuild ... test\` 全部通过（含新增的 actionRow / invokeAction 测试）
- [x] 本地：点侧栏分辨率正确切换 ✅
- [x] 本地：「打开系统显示器设置」按钮可见，点击后 popover 收起、系统设置打开 ✅
- [x] 本地：先点分辨率切换，再 hover 显示器名字，侧栏正确重新出现 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)