### PR TITLE
Use project Homebrew tap for cask distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,37 +405,82 @@ jobs:
             gh release create "$TAG" "$DMG_PATH#${PROJECT_NAME}.dmg" "$SHA256_PATH#${PROJECT_NAME}.sha256" "${RELEASE_ARGS[@]}"
           fi
 
-      - name: Open Homebrew Cask update PR
+      - name: Open Homebrew tap update PR
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         run: |
+          TAP_REPOSITORY="ggbond268/homebrew-mactools"
+
           if [[ "$PRERELEASE" == "true" ]]; then
-            echo "Skipping Homebrew Cask update for prerelease ${TAG}."
+            echo "Skipping Homebrew tap update for prerelease ${TAG}."
             exit 0
           fi
 
           if [[ -z "$HOMEBREW_GITHUB_API_TOKEN" ]]; then
-            echo "Skipping Homebrew Cask update because HOMEBREW_GITHUB_API_TOKEN is not configured."
+            echo "Skipping Homebrew tap update because HOMEBREW_GITHUB_API_TOKEN is not configured."
             exit 0
           fi
+
+          export GH_TOKEN="$HOMEBREW_GITHUB_API_TOKEN"
 
           SHA256="$(awk '{ print $1; exit }' "$SHA256_PATH")"
           DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${PROJECT_NAME}.dmg"
+          TAP_DIR="$(mktemp -d)"
+          BRANCH="update-mactools-${VERSION}"
 
-          brew update --quiet
-          brew tap homebrew/cask
-          if ! brew info --cask mactools >/dev/null 2>&1; then
-            echo "Skipping Homebrew Cask update because mactools is not available in Homebrew/homebrew-cask yet."
-            echo "Submit homebrew/Casks/mactools.rb first, then future stable releases will open update PRs automatically."
+          gh repo clone "$TAP_REPOSITORY" "$TAP_DIR"
+          cd "$TAP_DIR"
+          gh auth setup-git
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+
+          mkdir -p Casks
+          ruby -e 'File.write("Casks/mactools.rb", <<~CASK)
+            cask "mactools" do
+              version "#{ENV.fetch("VERSION")}"
+              sha256 "#{ENV.fetch("SHA256")}"
+
+              url "#{ENV.fetch("DOWNLOAD_URL")}"
+              name "MacTools"
+              desc "Menu bar toolbox"
+              homepage "https://github.com/#{ENV.fetch("GITHUB_REPOSITORY")}"
+
+              livecheck do
+                url :url
+                strategy :github_latest
+              end
+
+              auto_updates true
+              depends_on macos: ">= :sonoma"
+
+              app "MacTools.app"
+            end
+          CASK'
+
+          brew style Casks/mactools.rb
+
+          if git diff --quiet -- Casks/mactools.rb; then
+            echo "Homebrew tap cask is already up to date."
             exit 0
           fi
 
-          brew bump-cask-pr \
-            --version "$VERSION" \
-            --sha256 "$SHA256" \
-            --url "$DOWNLOAD_URL" \
-            --no-browse \
-            mactools
+          git add Casks/mactools.rb
+          git commit -m "Update mactools to ${VERSION}"
+          git push --force-with-lease origin "$BRANCH"
+
+          existing_pr="$(gh pr list --repo "$TAP_REPOSITORY" --head "$BRANCH" --json number --jq '.[0].number // empty')"
+          if [[ -n "$existing_pr" ]]; then
+            echo "Homebrew tap update PR already exists: #${existing_pr}"
+          else
+            gh pr create \
+              --repo "$TAP_REPOSITORY" \
+              --base main \
+              --head "$BRANCH" \
+              --title "Update mactools to ${VERSION}" \
+              --body "Updates the MacTools cask for ${TAG}."
+          fi
 
       - name: Commit appcast to main
         run: |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 ## 安装
 
 ```bash
+brew tap ggbond268/mactools
 brew install --cask mactools
 ```
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -20,7 +20,7 @@
 | `ASC_API_KEY_ID` | App Store Connect API Key ID。 |
 | `ASC_API_ISSUER_ID` | App Store Connect Issuer ID。 |
 | `SPARKLE_PRIVATE_KEY` | Sparkle EdDSA 私钥，必须与 `project.yml` 中的 `SPARKLE_PUBLIC_ED_KEY` 配对。 |
-| `HOMEBREW_GITHUB_API_TOKEN` | 可选。GitHub Personal Access Token，用于稳定版发布后自动向 `Homebrew/homebrew-cask` 提交 cask 更新 PR；未配置时跳过 Homebrew 同步。 |
+| `HOMEBREW_GITHUB_API_TOKEN` | 可选。GitHub Personal Access Token，用于稳定版发布后自动向 `ggbond268/homebrew-mactools` 提交 cask 更新 PR；未配置时跳过 Homebrew 同步。 |
 
 不要把 `LocalConfig.xcconfig`、`.p12`、`.p8`、Sparkle 私钥、证书密码或 Apple ID 写入仓库。
 
@@ -83,7 +83,7 @@ Release 工作流会校验 `v0.9.3` 与 `project.yml` 的 `MARKETING_VERSION: 0.
 
 也可以在 GitHub Actions 页面手动运行 `Release`，输入已存在的 tag，例如 `v0.9.3`；该 tag 指向的提交里仍必须已经更新 `project.yml`。
 
-稳定版发布成功创建 GitHub Release 后，Release 工作流会在配置了 `HOMEBREW_GITHUB_API_TOKEN` 时调用 `brew bump-cask-pr`，用刚生成的 DMG URL 和 SHA-256 向 `Homebrew/homebrew-cask` 打开更新 PR。预发布版本会跳过 Homebrew 同步；未配置该 secret 时也会跳过，不影响发布。
+稳定版发布成功创建 GitHub Release 后，Release 工作流会在配置了 `HOMEBREW_GITHUB_API_TOKEN` 时用刚生成的 DMG URL 和 SHA-256 更新 `ggbond268/homebrew-mactools` 中的 `Casks/mactools.rb`，并打开更新 PR。预发布版本会跳过 Homebrew 同步；未配置该 secret 时也会跳过，不影响发布。
 
 仓库设置中需要允许 workflow 写入：`Settings` → `Actions` → `General` → `Workflow permissions` 选择 `Read and write permissions`。
 

--- a/homebrew/Casks/mactools.rb
+++ b/homebrew/Casks/mactools.rb
@@ -2,8 +2,7 @@ cask "mactools" do
   version "0.11.0"
   sha256 "8bbd9bfb67c8b8cb0e8074174803ddb768d031d85acdb6a95079fe2ae4fb339f"
 
-  url "https://github.com/ggbond268/MacTools/releases/download/v#{version}/MacTools.dmg",
-      verified: "github.com/ggbond268/MacTools/"
+  url "https://github.com/ggbond268/MacTools/releases/download/v#{version}/MacTools.dmg"
   name "MacTools"
   desc "Menu bar toolbox"
   homepage "https://github.com/ggbond268/MacTools"


### PR DESCRIPTION
Switches Homebrew release automation from the official Homebrew cask repository to the project tap at ggbond268/homebrew-mactools.\n\nChanges:\n- Document tap-based installation in README.\n- Update release workflow to open cask update PRs against ggbond268/homebrew-mactools.\n- Update GitHub Actions docs for the tap workflow.\n- Keep the checked-in cask template aligned with Homebrew style.\n\nValidation:\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'\n- brew style homebrew/Casks/mactools.rb