### PR TITLE
Fix Homebrew cask sync environment export

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,7 +424,12 @@ jobs:
           export GH_TOKEN="$HOMEBREW_GITHUB_API_TOKEN"
 
           SHA256="$(awk '{ print $1; exit }' "$SHA256_PATH")"
+          if [[ -z "$SHA256" ]]; then
+            echo "Unable to read SHA256 from ${SHA256_PATH}." >&2
+            exit 1
+          fi
           DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${PROJECT_NAME}.dmg"
+          export SHA256 DOWNLOAD_URL
           TAP_DIR="$(mktemp -d)"
           BRANCH="update-mactools-${VERSION}"
 


### PR DESCRIPTION
## Summary
- export the computed SHA256 and download URL before the Ruby cask generator reads them from ENV
- fail clearly when the generated SHA256 file cannot be read

## Verification
- git diff --check upstream/main..HEAD
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml parsed"'