### PR TITLE
Document Homebrew upgrade tap refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ brew tap ggbond268/mactools
 brew install --cask mactools
 ```
 
+## 升级
+
+Homebrew 升级前需要先刷新 tap，确保本地拿到最新的 cask 配方：
+
+```bash
+brew update
+brew upgrade --cask --greedy ggbond268/mactools/mactools
+```
+
+如果仍提示已经是最新版本，可以先查看本地识别到的 cask 版本：
+
+```bash
+brew info --cask ggbond268/mactools/mactools
+```
+
 ## 状态栏图标自定义
 
 在“设置 > 通用”中可以自定义 MacTools 在 macOS 菜单栏里的图标：

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -83,7 +83,7 @@ Release 工作流会校验 `v0.9.3` 与 `project.yml` 的 `MARKETING_VERSION: 0.
 
 也可以在 GitHub Actions 页面手动运行 `Release`，输入已存在的 tag，例如 `v0.9.3`；该 tag 指向的提交里仍必须已经更新 `project.yml`。
 
-稳定版发布成功创建 GitHub Release 后，Release 工作流会在配置了 `HOMEBREW_GITHUB_API_TOKEN` 时用刚生成的 DMG URL 和 SHA-256 更新 `ggbond268/homebrew-mactools` 中的 `Casks/mactools.rb`，并打开更新 PR。预发布版本会跳过 Homebrew 同步；未配置该 secret 时也会跳过，不影响发布。
+稳定版发布成功创建 GitHub Release 后，Release 工作流会在配置了 `HOMEBREW_GITHUB_API_TOKEN` 时用刚生成的 DMG URL 和 SHA-256 更新 `ggbond268/homebrew-mactools` 中的 `Casks/mactools.rb`，并打开更新 PR。预发布版本会跳过 Homebrew 同步；未配置该 secret 时也会跳过，不影响发布。Homebrew PR 合并后，用户本地仍需要先运行 `brew update` 刷新 tap，才能通过 `brew upgrade --cask --greedy ggbond268/mactools/mactools` 检测到新版本。
 
 仓库设置中需要允许 workflow 写入：`Settings` → `Actions` → `General` → `Workflow permissions` 选择 `Read and write permissions`。
 


### PR DESCRIPTION
## Summary
- add README upgrade commands that run brew update before upgrading the MacTools cask
- mention that Homebrew tap PR merges still require users to refresh their local tap before brew can detect new versions

## Verification
- git diff --check