### PR TITLE
fix: update blue light status logic in NightShiftPlugin

### DIFF
--- a/Sources/Core/CoreBrightness/CoreBrightness.h
+++ b/Sources/Core/CoreBrightness/CoreBrightness.h
@@ -6,8 +6,8 @@
 #include <Foundation/Foundation.h>
 
 typedef struct {
-    BOOL active; // whether night shift is currently reducing blue light
-    BOOL enabled;
+    BOOL active; // whether the blue light reduction session is active (always true on supported hardware)
+    BOOL enabled; // whether night shift is currently reducing blue light (user-controlled on/off state)
     BOOL sunSchedulePermitted;
     int mode; // 0 = off, 1 = scheduled (sunset to sunrise), 2 = always on
     struct {

--- a/Sources/Features/NightShift/NightShiftPlugin.swift
+++ b/Sources/Features/NightShift/NightShiftPlugin.swift
@@ -14,7 +14,7 @@ struct CBNightShiftController: NightShiftControlling {
     func getStatus() -> Bool {
         var status = CBBlueLightStatus()
         guard client.getBlueLightStatus(&status) else { return false }
-        return status.active.boolValue
+        return status.enabled.boolValue
     }
 
     func setEnabled(_ enabled: Bool) -> Bool {


### PR DESCRIPTION
This PR fixes an issue where the Night Shift plugin could not retrieve the correct status.