### PR TITLE
fix: align plugin market action buttons

### DIFF
--- a/Sources/App/PluginManagementSettingsView.swift
+++ b/Sources/App/PluginManagementSettingsView.swift
@@ -154,10 +154,12 @@ private struct PluginManagementRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text(item.statusText)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(statusColor)
-                .frame(width: 58, alignment: .trailing)
+            if let visibleStatusText {
+                Text(visibleStatusText)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(statusColor)
+                    .frame(width: 58, alignment: .trailing)
+            }
 
             actionButtons
         }
@@ -180,7 +182,8 @@ private struct PluginManagementRow: View {
                 PluginManagementActionLabel(
                     title: "安装",
                     busyTitle: "安装中",
-                    isBusy: isBusy
+                    isBusy: isBusy,
+                    width: actionButtonLabelWidth
                 )
             }
             .buttonStyle(.borderedProminent)
@@ -192,7 +195,8 @@ private struct PluginManagementRow: View {
                 PluginManagementActionLabel(
                     title: "更新",
                     busyTitle: "更新中",
-                    isBusy: isBusy
+                    isBusy: isBusy,
+                    width: actionButtonLabelWidth
                 )
             }
             .buttonStyle(.borderedProminent)
@@ -200,10 +204,26 @@ private struct PluginManagementRow: View {
         }
 
         if item.canUninstall {
-            Button("卸载", role: .destructive, action: onUninstall)
-                .buttonStyle(.bordered)
-                .disabled(isBusy)
+            Button(role: .destructive, action: onUninstall) {
+                Text("卸载")
+                    .frame(width: actionButtonLabelWidth)
+            }
+            .buttonStyle(.bordered)
+            .disabled(isBusy)
         }
+    }
+
+    private var visibleStatusText: String? {
+        switch item.state {
+        case .available, .enabled, .disabled:
+            return nil
+        case .localDevelopment, .updateAvailable, .restartRequired, .failed, .incompatible, .revoked:
+            return item.statusText
+        }
+    }
+
+    private var actionButtonLabelWidth: CGFloat {
+        64
     }
 
     private var statusColor: Color {
@@ -245,6 +265,7 @@ private struct PluginManagementActionLabel: View {
     let title: String
     let busyTitle: String
     let isBusy: Bool
+    let width: CGFloat
 
     var body: some View {
         HStack(spacing: 6) {
@@ -256,6 +277,6 @@ private struct PluginManagementActionLabel: View {
 
             Text(isBusy ? busyTitle : title)
         }
-        .frame(minWidth: 52)
+        .frame(width: width)
     }
 }


### PR DESCRIPTION
<img width="1140" height="904" alt="1Capture_2026-05-18_16 37 15" src="https://github.com/user-attachments/assets/516199c8-194e-4c57-845c-4e8d5125b189" />


**插件-市场**页面:

1. 去掉了安装状态（可安装/已安装），因为右侧按钮已经完全告知用户安装状态
2. 将右侧的按钮在不同状态下宽度保持一致，UI 看起来整洁