### PR TITLE
feat: adjust app icon preview size and padding for better layout

### DIFF
--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -793,7 +793,7 @@ struct AboutSettingsView: View {
 
             Text(AppMetadata.appName)
                 .font(.system(size: 22, weight: .bold))
-                .padding(.top, 18)
+                .padding(.top, 8)
 
             Text("版本 \(AppMetadata.versionDescription)")
                 .font(.title3)
@@ -892,21 +892,23 @@ private struct AboutUpdatePrimaryButtonStyle: ButtonStyle {
 }
 
 private struct AppIconPreview: View {
+    private static let iconSize: CGFloat = 82
+
     var body: some View {
-        Group {
-            if let appIcon = AppMetadata.appIcon {
-                Image(nsImage: appIcon)
-                    .resizable()
-            } else {
-                Image(systemName: "wrench.and.screwdriver.fill")
-                    .resizable()
-                    .scaledToFit()
-                    .padding(12)
-                    .foregroundStyle(.secondary)
-                    .background(PluginSettingsTheme.Palette.nativeCardBackground)
-            }
+        if let appIcon = AppMetadata.appIcon {
+            Image(nsImage: appIcon)
+                .resizable()
+                .interpolation(.high)
+                .frame(width: Self.iconSize, height: Self.iconSize)
+        } else {
+            Image(systemName: "wrench.and.screwdriver.fill")
+                .resizable()
+                .scaledToFit()
+                .padding(12)
+                .foregroundStyle(.secondary)
+                .background(PluginSettingsTheme.Palette.nativeCardBackground)
+                .frame(width: Self.iconSize, height: Self.iconSize)
+                .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
         }
-        .frame(width: 64, height: 64)
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }


### PR DESCRIPTION
Before:
<img width="408" height="472" alt="image" src="https://github.com/user-attachments/assets/f170690e-ebfc-4fd6-b29d-93e7e5adc1ae" />

After:
<img width="386" height="466" alt="image" src="https://github.com/user-attachments/assets/5ecfbba4-4b2e-4ef3-870b-2890dbfe3d23" />

