### PR TITLE
Fix: 风扇助手 rpm 越界崩溃 + STUN IPv6 地址解析

### DIFF
--- a/Plugins/FanControl/SMCHelper/Sources/main.swift
+++ b/Plugins/FanControl/SMCHelper/Sources/main.swift
@@ -211,6 +211,11 @@ private final class SMCConnection {
 }
 
 private func setFanSpeed(_ rpm: Int, fanIndex: Int, connection: SMCConnection) throws {
+    // Defensive clamp: this runs as a setuid-root helper and must never trap on
+    // out-of-range input from the CLI. FPE2 encodes (rpm << 2) into a UInt16, so
+    // rpm must stay within 0...0x3FFF; negative speeds are meaningless for FLT too.
+    let safeRPM = min(max(rpm, 0), 0x3FFF)
+
     try setFanMode(1, fanIndex: fanIndex, connection: connection)
 
     let key = "F\(fanIndex)Tg"
@@ -218,10 +223,10 @@ private func setFanSpeed(_ rpm: Int, fanIndex: Int, connection: SMCConnection) t
 
     switch (value.dataType, value.dataSize) {
     case (typeFLT, 4):
-        var float = Float32(rpm)
+        var float = Float32(safeRPM)
         value.bytes = withUnsafeBytes(of: &float) { Array($0) }
     case (typeFPE2, 2):
-        let encoded = UInt16(rpm << 2)
+        let encoded = UInt16(safeRPM << 2)
         value.bytes[0] = UInt8((encoded >> 8) & 0xff)
         value.bytes[1] = UInt8(encoded & 0xff)
     default:

--- a/Plugins/IPOverview/Sources/IPOverviewLeakTestService.swift
+++ b/Plugins/IPOverview/Sources/IPOverviewLeakTestService.swift
@@ -167,7 +167,7 @@ struct IPOverviewLeakTestService: IPOverviewLeakTesting {
     }
 }
 
-private struct STUNClient {
+struct STUNClient {
     enum Error: LocalizedError {
         case invalidPort
         case timedOut
@@ -262,7 +262,7 @@ private struct STUNClient {
         return Data(bytes)
     }
 
-    private static func parseMappedAddress(_ data: Data, transactionID: [UInt8]) -> String? {
+    static func parseMappedAddress(_ data: Data, transactionID: [UInt8]) -> String? {
         let bytes = [UInt8](data)
         guard bytes.count >= 20,
               bytes[0] == 0x01,
@@ -282,7 +282,7 @@ private struct STUNClient {
 
             if type == 0x0020 || type == 0x0001 {
                 let value = Array(bytes[valueStart..<valueEnd])
-                if let address = mappedAddress(value, isXOR: type == 0x0020) {
+                if let address = mappedAddress(value, isXOR: type == 0x0020, transactionID: transactionID) {
                     return address
                 }
             }
@@ -293,7 +293,7 @@ private struct STUNClient {
         return nil
     }
 
-    private static func mappedAddress(_ value: [UInt8], isXOR: Bool) -> String? {
+    private static func mappedAddress(_ value: [UInt8], isXOR: Bool, transactionID: [UInt8]) -> String? {
         guard value.count >= 8 else { return nil }
         let family = value[1]
         if family == 0x01 {
@@ -310,8 +310,10 @@ private struct STUNClient {
         if family == 0x02, value.count >= 20 {
             var address = Array(value[4..<20])
             if isXOR {
-                let mask: [UInt8] = [0x21, 0x12, 0xA4, 0x42]
-                for index in 0..<4 {
+                // RFC 5389: XOR-MAPPED-ADDRESS for IPv6 XORs all 16 bytes with
+                // the magic cookie concatenated with the 96-bit transaction ID.
+                let mask: [UInt8] = [0x21, 0x12, 0xA4, 0x42] + transactionID
+                for index in 0..<min(address.count, mask.count) {
                     address[index] ^= mask[index]
                 }
             }

--- a/Plugins/IPOverview/Tests/STUNClientTests.swift
+++ b/Plugins/IPOverview/Tests/STUNClientTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import IPOverviewPlugin
+
+final class STUNClientTests: XCTestCase {
+    private let cookie: [UInt8] = [0x21, 0x12, 0xA4, 0x42]
+
+    /// Build a STUN Binding Success Response carrying a single XOR-MAPPED-ADDRESS
+    /// attribute, so the parser can be exercised without any network I/O.
+    private func bindingSuccessResponse(
+        transactionID: [UInt8],
+        family: UInt8,
+        xPort: [UInt8],
+        xAddress: [UInt8]
+    ) -> Data {
+        let attributeValue: [UInt8] = [0x00, family] + xPort + xAddress
+        let attributeLength = attributeValue.count
+
+        var bytes: [UInt8] = [0x01, 0x01] // Binding Success Response
+        let messageLength = attributeLength + 4
+        bytes += [UInt8((messageLength >> 8) & 0xff), UInt8(messageLength & 0xff)]
+        bytes += cookie
+        bytes += transactionID
+        bytes += [0x00, 0x20] // attribute type: XOR-MAPPED-ADDRESS
+        bytes += [UInt8((attributeLength >> 8) & 0xff), UInt8(attributeLength & 0xff)]
+        bytes += attributeValue
+        return Data(bytes)
+    }
+
+    func testDecodesXorMappedIPv6AddressAcrossAllSixteenBytes() {
+        // Non-zero transaction ID is essential: with it, the previous bug (only
+        // XOR-ing the first 4 bytes) decodes bytes 4...15 incorrectly, so this
+        // test fails against the old code and passes only with the full-16-byte XOR.
+        let transactionID: [UInt8] = [0xBA, 0xD0, 0xCA, 0xFE, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]
+        let mask = cookie + transactionID // 16 bytes per RFC 5389
+        // 2001:db8::1
+        let address: [UInt8] = [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01]
+        let xAddress = zip(address, mask).map { $0 ^ $1 }
+
+        let data = bindingSuccessResponse(
+            transactionID: transactionID,
+            family: 0x02,
+            xPort: [0x21, 0x12],
+            xAddress: xAddress
+        )
+
+        XCTAssertEqual(STUNClient.parseMappedAddress(data, transactionID: transactionID), "2001:db8:0:0:0:0:0:1")
+    }
+
+    func testDecodesXorMappedIPv4Address() {
+        let transactionID: [UInt8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC]
+        let address: [UInt8] = [203, 0, 113, 5]
+        let xAddress = zip(address, cookie).map { $0 ^ $1 }
+
+        let data = bindingSuccessResponse(
+            transactionID: transactionID,
+            family: 0x01,
+            xPort: [0x21, 0x12],
+            xAddress: xAddress
+        )
+
+        XCTAssertEqual(STUNClient.parseMappedAddress(data, transactionID: transactionID), "203.0.113.5")
+    }
+
+    func testRejectsResponseWithMismatchedTransactionID() {
+        let transactionID: [UInt8] = Array(repeating: 0xAB, count: 12)
+        let address: [UInt8] = [203, 0, 113, 5]
+        let xAddress = zip(address, cookie).map { $0 ^ $1 }
+        let data = bindingSuccessResponse(
+            transactionID: transactionID,
+            family: 0x01,
+            xPort: [0x21, 0x12],
+            xAddress: xAddress
+        )
+
+        let wrongTransactionID: [UInt8] = Array(repeating: 0x00, count: 12)
+        XCTAssertNil(STUNClient.parseMappedAddress(data, transactionID: wrongTransactionID))
+    }
+}


### PR DESCRIPTION
## 问题

两个独立的小修复，合并提交：

### 1. 风扇 SMC 助手 rpm 越界崩溃（`mactools-fan-smc-helper`）
`setFanSpeed` 用 `UInt16(rpm << 2)` 编码 FPE2。`rpm` 来自 CLI（`set <FAN#> <RPM>`）且未校验，当 `rpm > 16383` 或为负数时 `UInt16(rpm << 2)` 会 trap，使这个 setuid-root 助手崩溃。改为先钳制到 `0...0x3FFF`。

### 2. STUN IPv6 XOR-MAPPED-ADDRESS 解析错误（IP 检测 / VPN 泄漏测试）
`STUNClient` 对 IPv6（family `0x02`）只异或了前 4 字节（magic cookie），后 12 字节本应与 transaction ID 异或（RFC 5389），导致 IPv6 反射地址解析错误。补充 transaction ID 并异或全 16 字节。

## 测试
- 新增 `STUNClientTests`：覆盖 IPv4 / IPv6 XOR-MAPPED-ADDRESS 解码与 transaction ID 校验（用**非零** transaction ID，可捕获旧 bug）。
- 全量测试套件本地通过：**706 passed / 0 failed**。
- ⚠️ 风扇助手钳制仅编译验证，未在 root 环境实跑；STUN IPv6 未用真实服务器验证。

