### PR TITLE
Fix: 插件信任校验在宿主 team 不可读时改为 fail-closed

### DIFF
--- a/Sources/Core/Plugins/Dynamic/PluginTrustValidator.swift
+++ b/Sources/Core/Plugins/Dynamic/PluginTrustValidator.swift
@@ -5,6 +5,7 @@ enum PluginTrustValidatorError: LocalizedError, Equatable {
     case signatureCheckFailed(String)
     case teamIdentifierUnavailable(URL)
     case teamIdentifierMismatch(expected: String, actual: String)
+    case hostTeamIdentifierUnavailable
 
     var errorDescription: String? {
         switch self {
@@ -14,6 +15,8 @@ enum PluginTrustValidatorError: LocalizedError, Equatable {
             return "无法读取插件签名团队：\(url.path)"
         case let .teamIdentifierMismatch(expected, actual):
             return "插件签名团队不匹配，期望 \(expected)，实际 \(actual)。"
+        case .hostTeamIdentifierUnavailable:
+            return "无法确定宿主签名团队，已拒绝加载插件。"
         }
     }
 }
@@ -25,20 +28,38 @@ protocol PluginTrustValidating {
 struct SameTeamPluginTrustValidator: PluginTrustValidating {
     private let hostTeamIdentifier: String?
     private let codeSignatureInfoProvider: CodeSignatureInfoProviding
+    private let allowsUntrustedHostTeam: Bool
 
     init(
         hostBundleURL: URL = Bundle.main.bundleURL,
-        codeSignatureInfoProvider: CodeSignatureInfoProviding = SecurityCodeSignatureInfoProvider()
+        codeSignatureInfoProvider: CodeSignatureInfoProviding = SecurityCodeSignatureInfoProvider(),
+        allowsUntrustedHostTeam: Bool = SameTeamPluginTrustValidator.defaultAllowsUntrustedHostTeam
     ) {
         self.codeSignatureInfoProvider = codeSignatureInfoProvider
         self.hostTeamIdentifier = try? codeSignatureInfoProvider.teamIdentifier(for: hostBundleURL)
+        self.allowsUntrustedHostTeam = allowsUntrustedHostTeam
+    }
+
+    // DEBUG host builds are often ad-hoc/unsigned and report no team identifier;
+    // default to permissive there. Release builds default to enforcing same-team.
+    static var defaultAllowsUntrustedHostTeam: Bool {
+        #if DEBUG
+        true
+        #else
+        false
+        #endif
     }
 
     func validatePluginBundle(at bundleURL: URL) throws {
         try codeSignatureInfoProvider.validateCodeSignature(at: bundleURL)
 
         guard let expectedTeamID = hostTeamIdentifier, !expectedTeamID.isEmpty else {
-            return
+            // Fail closed: an unreadable host team must not silently bypass the
+            // same-team check (which would otherwise accept any validly-signed bundle).
+            if allowsUntrustedHostTeam {
+                return
+            }
+            throw PluginTrustValidatorError.hostTeamIdentifierUnavailable
         }
 
         guard let actualTeamID = try codeSignatureInfoProvider.teamIdentifier(for: bundleURL), !actualTeamID.isEmpty else {

--- a/Tests/Core/Plugins/Dynamic/PluginTrustValidatorTests.swift
+++ b/Tests/Core/Plugins/Dynamic/PluginTrustValidatorTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import MacTools
+
+final class PluginTrustValidatorTests: XCTestCase {
+    private let hostURL = URL(fileURLWithPath: "/tmp/MacTools.app")
+    private let pluginURL = URL(fileURLWithPath: "/tmp/Example.mactoolsplugin")
+
+    /// Controllable signature/team source so the validator can be exercised
+    /// without touching the real Security framework.
+    private struct FakeCodeSignatureInfoProvider: CodeSignatureInfoProviding {
+        var hostURL: URL
+        var hostTeam: String?
+        var pluginTeam: String?
+        var pluginSignatureValid = true
+
+        func validateCodeSignature(at url: URL) throws {
+            if !pluginSignatureValid {
+                throw PluginTrustValidatorError.signatureCheckFailed("fake")
+            }
+        }
+
+        func teamIdentifier(for url: URL) throws -> String? {
+            url == hostURL ? hostTeam : pluginTeam
+        }
+    }
+
+    private func makeValidator(
+        hostTeam: String?,
+        pluginTeam: String?,
+        allowsUntrustedHostTeam: Bool
+    ) -> SameTeamPluginTrustValidator {
+        let provider = FakeCodeSignatureInfoProvider(
+            hostURL: hostURL,
+            hostTeam: hostTeam,
+            pluginTeam: pluginTeam
+        )
+        return SameTeamPluginTrustValidator(
+            hostBundleURL: hostURL,
+            codeSignatureInfoProvider: provider,
+            allowsUntrustedHostTeam: allowsUntrustedHostTeam
+        )
+    }
+
+    func testRejectsPluginWhenHostTeamUnavailableAndEnforcing() {
+        // Release-style behavior: an unreadable host team must NOT silently
+        // accept any validly-signed bundle (fail closed).
+        let validator = makeValidator(hostTeam: nil, pluginTeam: "ATTACKERTEAM", allowsUntrustedHostTeam: false)
+        XCTAssertThrowsError(try validator.validatePluginBundle(at: pluginURL)) { error in
+            XCTAssertEqual(error as? PluginTrustValidatorError, .hostTeamIdentifierUnavailable)
+        }
+    }
+
+    func testAllowsPluginWhenHostTeamUnavailableAndPermissive() {
+        // DEBUG-style behavior: local dev host has no team, keep loading plugins.
+        let validator = makeValidator(hostTeam: nil, pluginTeam: "ANYTEAM", allowsUntrustedHostTeam: true)
+        XCTAssertNoThrow(try validator.validatePluginBundle(at: pluginURL))
+    }
+
+    func testRejectsTeamMismatchWhenHostTeamKnown() {
+        let validator = makeValidator(hostTeam: "HOSTTEAM", pluginTeam: "OTHERTEAM", allowsUntrustedHostTeam: false)
+        XCTAssertThrowsError(try validator.validatePluginBundle(at: pluginURL)) { error in
+            XCTAssertEqual(
+                error as? PluginTrustValidatorError,
+                .teamIdentifierMismatch(expected: "HOSTTEAM", actual: "OTHERTEAM")
+            )
+        }
+    }
+
+    func testAcceptsMatchingTeam() {
+        let validator = makeValidator(hostTeam: "SAMETEAM", pluginTeam: "SAMETEAM", allowsUntrustedHostTeam: false)
+        XCTAssertNoThrow(try validator.validatePluginBundle(at: pluginURL))
+    }
+
+    func testRejectsPluginWithMissingTeamWhenHostTeamKnown() {
+        let validator = makeValidator(hostTeam: "HOSTTEAM", pluginTeam: nil, allowsUntrustedHostTeam: false)
+        XCTAssertThrowsError(try validator.validatePluginBundle(at: pluginURL)) { error in
+            XCTAssertEqual(error as? PluginTrustValidatorError, .teamIdentifierUnavailable(pluginURL))
+        }
+    }
+}


### PR DESCRIPTION
## 问题（安全加固 · 行为变更）

`SameTeamPluginTrustValidator` 在读不到**宿主自身**的 team identifier 时（init 里 `try?` 吞掉错误 → nil/空），会在仅校验插件签名有效后**直接放行**，等于跳过"同 team"强制校验、接受任意有效签名的插件包（fail-open）。

正常 Developer-ID 签名的生产版不受影响（能读到宿主 team）；但 ad-hoc / 未签名 / translocated 的构建会落入这个放行分支。

## 改动
- 改为 **fail-closed**：读不到宿主 team 时拒绝加载（抛 `hostTeamIdentifierUnavailable`）。
- 保留本地开发：`#if DEBUG` 默认仍放行；开关 `allowsUntrustedHostTeam` 通过 init 注入，便于测试，也方便上游按需调整默认值。

## 测试
- 新增 `PluginTrustValidatorTests`：覆盖 fail-closed 拒绝 / 宽松放行 / team 不匹配 / team 匹配 / 插件无 team 五种情形。
- 全量测试套件本地通过：706 passed / 0 failed。

## 说明
这是**行为变更**，是否在 release 强制由 maintainer 定夺——若想保持原放行行为，把 `defaultAllowsUntrustedHostTeam` 在 release 也设为 `true` 即可（注入点已留好）。故以 **draft** 形式提出供讨论。

