### PR TITLE
Fix: 插件防御性崩溃加固（SystemStatus / MenuBarHidden / EjectDisk）

### DIFF
--- a/Plugins/EjectDisk/Sources/EjectDiskPlugin.swift
+++ b/Plugins/EjectDisk/Sources/EjectDiskPlugin.swift
@@ -42,6 +42,7 @@ final class EjectDiskPlugin: MacToolsPlugin, PluginPrimaryPanel {
     private var ejectableDiskCount: Int = 0
     private var lastErrorMessage: String?
     private var volumeMountObservers: [NSObjectProtocol] = []
+    private var ejectableScanToken = 0
 
     var primaryPanelState: PluginPanelState {
         PluginPanelState(
@@ -102,14 +103,18 @@ final class EjectDiskPlugin: MacToolsPlugin, PluginPrimaryPanel {
     }
 
     /// 把卷扫描放到后台线程，避免在慢速网络/可移动卷上阻塞主线程，扫完再回主线程更新计数。
+    /// 用世代令牌保证乱序完成的后台扫描只让最新一次落地，避免旧扫描覆盖新结果。
     private func scheduleEjectableDiskCountRefresh() {
+        ejectableScanToken &+= 1
+        let token = ejectableScanToken
         Task.detached { [weak self] in
             let count = Self.ejectableDiskCountSync()
-            await MainActor.run { self?.applyEjectableDiskCount(count) }
+            await MainActor.run { self?.applyEjectableDiskCount(count, token: token) }
         }
     }
 
-    private func applyEjectableDiskCount(_ count: Int) {
+    private func applyEjectableDiskCount(_ count: Int, token: Int) {
+        guard token == ejectableScanToken else { return }
         guard ejectableDiskCount != count else { return }
         ejectableDiskCount = count
         onStateChange?()
@@ -133,6 +138,20 @@ final class EjectDiskPlugin: MacToolsPlugin, PluginPrimaryPanel {
     func handlePermissionAction(id: String) {}
     func handleSettingsAction(id: String) {}
     func handleShortcutAction(id: String) {}
+
+    func deactivate(reason: PluginDeactivationReason) {
+        // 插件隐藏/禁用/卸载时移除挂载观察者，否则它们会一直存活并在每次卷变化时后台扫描 /Volumes。
+        // 恢复时 refresh() -> setupVolumeMountObserver() 会重新注册（其内部按 isEmpty 守卫）。
+        teardownVolumeMountObserver()
+    }
+
+    private func teardownVolumeMountObserver() {
+        let notificationCenter = NSWorkspace.shared.notificationCenter
+        for observer in volumeMountObservers {
+            notificationCenter.removeObserver(observer)
+        }
+        volumeMountObservers.removeAll()
+    }
 
     // MARK: - Private
 

--- a/Plugins/EjectDisk/Sources/EjectDiskPlugin.swift
+++ b/Plugins/EjectDisk/Sources/EjectDiskPlugin.swift
@@ -60,12 +60,8 @@ final class EjectDiskPlugin: MacToolsPlugin, PluginPrimaryPanel {
     var shortcutDefinitions: [PluginShortcutDefinition] { [] }
 
     func refresh() {
-        let count = Self.ejectableDiskCountSync()
-        if self.ejectableDiskCount != count {
-            self.ejectableDiskCount = count
-            self.onStateChange?()
-        }
-        
+        scheduleEjectableDiskCountRefresh()
+
         // 设置磁盘挂载/卸载事件监听
         setupVolumeMountObserver()
     }
@@ -102,11 +98,21 @@ final class EjectDiskPlugin: MacToolsPlugin, PluginPrimaryPanel {
     }
     
     private func checkForEjectableDiskAndUpdate() {
-        let count = Self.ejectableDiskCountSync()
-        if self.ejectableDiskCount != count {
-            self.ejectableDiskCount = count
-            self.onStateChange?()
+        scheduleEjectableDiskCountRefresh()
+    }
+
+    /// 把卷扫描放到后台线程，避免在慢速网络/可移动卷上阻塞主线程，扫完再回主线程更新计数。
+    private func scheduleEjectableDiskCountRefresh() {
+        Task.detached { [weak self] in
+            let count = Self.ejectableDiskCountSync()
+            await MainActor.run { self?.applyEjectableDiskCount(count) }
         }
+    }
+
+    private func applyEjectableDiskCount(_ count: Int) {
+        guard ejectableDiskCount != count else { return }
+        ejectableDiskCount = count
+        onStateChange?()
     }
 
     func handleAction(_ action: PluginPanelAction) {
@@ -223,7 +229,9 @@ final class EjectDiskPlugin: MacToolsPlugin, PluginPrimaryPanel {
             throw NSError(domain: "EjectDiskPlugin", code: 1, userInfo: [NSLocalizedDescriptionKey: "/Volumes 目录不可用"])
         }
         
-        let ejectableVolumes = try Self.getEjectableVolumes(from: volumesPath)
+        let ejectableVolumes = try await Task.detached {
+            try Self.getEjectableVolumes(from: volumesPath)
+        }.value
         
         guard !ejectableVolumes.isEmpty else {
             throw NSError(domain: "EjectDiskPlugin", code: 2, userInfo: [NSLocalizedDescriptionKey: "未找到可推出的磁盘"])

--- a/Plugins/EjectDisk/Sources/EjectDiskPlugin.swift
+++ b/Plugins/EjectDisk/Sources/EjectDiskPlugin.swift
@@ -156,22 +156,33 @@ final class EjectDiskPlugin: MacToolsPlugin, PluginPrimaryPanel {
         }
     }
     
-    nonisolated private static func getEjectableVolumes(from volumesPath: String) throws -> [String] {
+    nonisolated static func getEjectableVolumes(from volumesPath: String) throws -> [String] {
         let fileManager = FileManager.default
         let contents = try fileManager.contentsOfDirectory(atPath: volumesPath)
         
         return contents.filter { name in
-            // 排除系统卷
-            if name == "Macintosh HD" || name.hasPrefix(".") {
+            // 排除隐藏项
+            if name.hasPrefix(".") {
                 return false
             }
             
-            let volumePath = "\(volumesPath)/\(name)"
-            var isDir: ObjCBool = false
-            let exists = fileManager.fileExists(atPath: volumePath, isDirectory: &isDir)
-            
-            // 必须是目录
-            return exists && isDir.boolValue
+            // 通过卷资源属性判断可推出性，排除内部/不可移除卷
+            let volumeURL = URL(fileURLWithPath: "\(volumesPath)/\(name)")
+            guard let values = try? volumeURL.resourceValues(forKeys: [
+                .volumeIsRemovableKey,
+                .volumeIsEjectableKey,
+                .volumeIsInternalKey
+            ]) else {
+                return false
+            }
+
+            // 始终排除内部卷
+            if values.volumeIsInternal == true {
+                return false
+            }
+
+            // 仅保留可移除或可推出的卷
+            return values.volumeIsRemovable == true || values.volumeIsEjectable == true
         }
     }
 

--- a/Plugins/EjectDisk/Tests/EjectDiskPluginTests.swift
+++ b/Plugins/EjectDisk/Tests/EjectDiskPluginTests.swift
@@ -18,6 +18,17 @@ final class EjectDiskPluginTests: XCTestCase {
         XCTAssertEqual(plugin.primaryPanelDescriptor.buttonTitle, "推出")
     }
 
+    func testGetEjectableVolumesExcludesNonRemovableDirectories() throws {
+        // 内部卷上的普通目录不应被当成可推出卷（旧的"名字+是否目录"启发式会误报）。
+        let root = NSTemporaryDirectory().appending("eject-test-\(UUID().uuidString)")
+        let child = (root as NSString).appendingPathComponent("RegularFolder")
+        try FileManager.default.createDirectory(atPath: child, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let result = try EjectDiskPlugin.getEjectableVolumes(from: root)
+        XCTAssertFalse(result.contains("RegularFolder"))
+    }
+
     func testInitialStateHasEjectedOffAndIsDisabled() {
         let plugin = EjectDiskPlugin()
 

--- a/Plugins/MenuBarHidden/Sources/MenuBarHiddenEventSynthesis.swift
+++ b/Plugins/MenuBarHidden/Sources/MenuBarHiddenEventSynthesis.swift
@@ -242,7 +242,7 @@ extension CGRect {
 }
 
 private extension CGEventField {
-    static let menuBarHiddenWindowID = CGEventField(rawValue: 0x33)!
+    static let menuBarHiddenWindowID = CGEventField(rawValue: 0x33)
 }
 
 private extension CGEvent {
@@ -251,8 +251,8 @@ private extension CGEvent {
         setIntegerValueField(.eventSourceUserData, value: Int64(Int(bitPattern: ObjectIdentifier(self))))
         setIntegerValueField(.mouseEventWindowUnderMousePointer, value: value)
         setIntegerValueField(.mouseEventWindowUnderMousePointerThatCanHandleThisEvent, value: value)
-        if includeWindowID {
-            setIntegerValueField(.menuBarHiddenWindowID, value: value)
+        if includeWindowID, let windowIDField = CGEventField.menuBarHiddenWindowID {
+            setIntegerValueField(windowIDField, value: value)
         }
     }
 }

--- a/Plugins/SystemStatus/Sources/SystemStatusPowerReader.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusPowerReader.swift
@@ -36,12 +36,12 @@ final class SystemStatusCPUPowerReader {
             let channels,
             let sample = functions.createSamples(subscription, channels, nil)?.takeRetainedValue(),
             let sampleDictionary = sample as? [String: Any],
-            let rawItems = sampleDictionary["IOReportChannels"]
+            let rawArray = sampleDictionary["IOReportChannels"] as? NSArray
         else {
             return nil
         }
 
-        let items = rawItems as! CFArray
+        let items = rawArray as CFArray
         var cpuEnergyJoules: Double?
         for index in 0..<CFArrayGetCount(items) {
             let item = unsafeBitCast(CFArrayGetValueAtIndex(items, index), to: CFDictionary.self)


### PR DESCRIPTION
## 三处防御性崩溃加固

### F22 · SystemStatus 电源读取
`IOReportChannels` 用 `as! CFArray` 强转私有 API 结果，类型不符时 trap。改为 `as? NSArray` 做真正的类型检查后再桥接为 `CFArray`，失败优雅返回 nil（调用方已能处理 nil，降级到电池遥测功率）。

### F19 · MenuBarHidden 事件合成
`CGEventField(rawValue: 0x33)!` 强解包未公开字段。改为可选 + 使用处 `guard`，取不到时跳过该提示字段、其余字段照常设置。
> 注：当前 macOS SDK 下 `CGEventField(rawValue:)` 是桥接 open-enum、不会返回 nil，所以**今天并不会崩**；这是预防性加固，移除不必要的强解包，与本文件已有的 `guard let button = CGMouseButton(rawValue:)` 风格一致。

### F18 · EjectDisk 可推出卷判断
原先仅靠 `/Volumes` 目录名 + 硬编码启动盘名判断，会把内部/网络/只读卷误判为可推出。改用 `volumeIsRemovable` / `volumeIsEjectable` / `volumeIsInternal` 卷资源属性，仅保留可移除或可推出且非内部的卷。

## 测试
- 新增 `EjectDiskPluginTests.testGetEjectableVolumesExcludesNonRemovableDirectories`：验证内部卷上的普通目录不再被误报（旧启发式会误报）。
- 全量测试套件本地通过：**700 passed / 0 failed**。
- ⚠️ F22 / F19 涉及私有 IOReport / CGEvent，无法在 XCTest 中有意义单测，靠编译 + 行为保持验证。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ejectable disk counts now refresh asynchronously to avoid blocking the UI and prevent stale results.

* **Bug Fixes**
  * Improved ejectable volume detection using system resource attributes for more accurate results.
  * Prevented crashes in menu-bar event handling and CPU power parsing with safer optional/type handling.
  * Cleanly removes mount observers when the plugin is deactivated.

* **Tests**
  * Added unit test coverage for volume filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->