### PR TITLE
Fix: 插件内存安全与并发修复（DeviceBattery / MiddleClick / DisplayBrightness）

### DIFF
--- a/Plugins/DeviceBattery/Sources/RapooBatteryMonitor.swift
+++ b/Plugins/DeviceBattery/Sources/RapooBatteryMonitor.swift
@@ -381,6 +381,12 @@ private final class RapooHIDDeviceSession {
     }
 
     deinit {
+        // Safety net for teardown paths that bypass the monitor's explicit
+        // teardownSession (e.g. the monitor deallocating without stop()): clear the
+        // input-report callback and unschedule before the buffer/context is freed,
+        // so a late HID report can never dereference this freed session.
+        IOHIDDeviceRegisterInputReportCallback(device, reportBuffer, RapooDeviceCatalog.reportLength, nil, nil)
+        IOHIDDeviceUnscheduleFromRunLoop(device, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
         reportBuffer.deinitialize(count: RapooDeviceCatalog.reportLength)
         reportBuffer.deallocate()
     }

--- a/Plugins/DeviceBattery/Sources/RapooBatteryMonitor.swift
+++ b/Plugins/DeviceBattery/Sources/RapooBatteryMonitor.swift
@@ -174,15 +174,19 @@ final class RapooHIDBatteryMonitor: RapooBatteryMonitoring {
     }
 
     func stop() {
+        let activeSessions = Array(sessions.values)
+        sessions.removeAll()
+        for session in activeSessions {
+            teardownSession(session)
+        }
+
         guard let manager else {
-            sessions.removeAll()
             return
         }
 
         IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
         IOHIDManagerClose(manager, IOOptionBits(kIOHIDOptionsTypeNone))
         self.manager = nil
-        sessions.removeAll()
     }
 
     func refresh() {
@@ -249,8 +253,28 @@ final class RapooHIDBatteryMonitor: RapooBatteryMonitoring {
             return
         }
 
-        sessions.removeValue(forKey: deviceInfo.stableKey)
+        if let session = sessions.removeValue(forKey: deviceInfo.stableKey) {
+            teardownSession(session)
+        }
         refresh()
+    }
+
+    // Clear the input-report callback and unschedule the device BEFORE its session
+    // (and reportBuffer) can be freed; otherwise a late HID report writes into freed
+    // memory and the callback dereferences a freed context (use-after-free).
+    private func teardownSession(_ session: RapooHIDDeviceSession) {
+        IOHIDDeviceRegisterInputReportCallback(
+            session.device,
+            session.reportBuffer,
+            RapooDeviceCatalog.reportLength,
+            nil,
+            nil
+        )
+        IOHIDDeviceUnscheduleFromRunLoop(
+            session.device,
+            CFRunLoopGetMain(),
+            CFRunLoopMode.defaultMode.rawValue
+        )
     }
 
     fileprivate func handleInputReport(

--- a/Plugins/DisplayBrightness/Sources/DisplayBrightnessDDC.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayBrightnessDDC.swift
@@ -112,19 +112,23 @@ final class IntelDDCTransport: DDCBrightnessTransport, @unchecked Sendable {
         request.sendAddress = UInt32(DDCBrightnessControl.displayAddress)
         request.sendTransactionType = IOOptionBits(kIOI2CSimpleTransactionType)
         request.sendBytes = UInt32(command.count)
-        request.sendBuffer = command.withUnsafeBufferPointer {
-            vm_address_t(bitPattern: $0.baseAddress)
-        }
         request.minReplyDelay = 10
         request.replyAddress = UInt32(DDCBrightnessControl.displayReplyAddress)
         request.replySubAddress = DDCBrightnessControl.hostAddress
         request.replyTransactionType = replyTransactionType
         request.replyBytes = UInt32(reply.count)
-        request.replyBuffer = reply.withUnsafeMutableBufferPointer {
-            vm_address_t(bitPattern: $0.baseAddress)
+
+        // Keep both buffers pinned for the whole IOI2CSendRequest call: letting a
+        // baseAddress escape withUnsafeBufferPointer and using it later is UB.
+        let succeeded = command.withUnsafeBufferPointer { commandBuffer in
+            reply.withUnsafeMutableBufferPointer { replyBuffer in
+                request.sendBuffer = vm_address_t(bitPattern: commandBuffer.baseAddress)
+                request.replyBuffer = vm_address_t(bitPattern: replyBuffer.baseAddress)
+                return Self.send(request: &request, to: framebuffer)
+            }
         }
 
-        guard Self.send(request: &request, to: framebuffer) else {
+        guard succeeded else {
             throw DisplayBrightnessControllerError.i2cUnavailable(displayName: display.name)
         }
 
@@ -147,13 +151,14 @@ final class IntelDDCTransport: DDCBrightnessTransport, @unchecked Sendable {
         request.sendAddress = UInt32(DDCBrightnessControl.displayAddress)
         request.sendTransactionType = IOOptionBits(kIOI2CSimpleTransactionType)
         request.sendBytes = UInt32(command.count)
-        request.sendBuffer = command.withUnsafeBufferPointer {
-            vm_address_t(bitPattern: $0.baseAddress)
-        }
         request.replyTransactionType = IOOptionBits(kIOI2CNoTransactionType)
         request.replyBytes = 0
 
-        return Self.send(request: &request, to: framebuffer)
+        // Keep the send buffer pinned for the whole IOI2CSendRequest call.
+        return command.withUnsafeBufferPointer { commandBuffer in
+            request.sendBuffer = vm_address_t(bitPattern: commandBuffer.baseAddress)
+            return Self.send(request: &request, to: framebuffer)
+        }
     }
 
     static func parseReply(

--- a/Plugins/MiddleClick/Sources/MiddleClickSession.swift
+++ b/Plugins/MiddleClick/Sources/MiddleClickSession.swift
@@ -44,7 +44,12 @@ final class MiddleClickSession: @unchecked Sendable {
 
     // MARK: - Config（由主线程设置，回调线程读取）
 
-    nonisolated(unsafe) var requiredFingerCount: Int = 3
+    /// 由不公平锁保护：主线程写、CGEvent/MT 回调线程读，避免数据竞争。
+    private let requiredFingerCountLock = OSAllocatedUnfairLock(initialState: 3)
+    var requiredFingerCount: Int {
+        get { requiredFingerCountLock.withLock { $0 } }
+        set { requiredFingerCountLock.withLock { $0 = newValue } }
+    }
 
     // MARK: - Infrastructure
 

--- a/Plugins/MiddleClick/Sources/MiddleClickSession.swift
+++ b/Plugins/MiddleClick/Sources/MiddleClickSession.swift
@@ -185,10 +185,17 @@ final class MiddleClickSession: @unchecked Sendable {
         devices.forEach { $0.register(contactFrameCallback: touchCallback); $0.start(runMode: 0) }
     }
 
-    private func stopTouchListeners() {
+    private func stopTouchListeners(resetConversionState: Bool = true) {
         devices.forEach { $0.unregister(contactFrameCallback: touchCallback); $0.stop(); $0.release() }
         devices.removeAll()
-        tapFlags.withLock { $0 = TapFlags() }
+        tapFlags.withLock { flags in
+            flags.threeDown = false
+            // 完全停止时清掉转换状态；重启监听（唤醒/显示器重配/触控板重新枚举）时保留，
+            // 否则会丢掉已转换中键 down 的配对 up，导致中键逻辑卡住。
+            if resetConversionState {
+                flags.wasThreeDown = false
+            }
+        }
     }
 
     // MARK: - Start / Stop
@@ -232,7 +239,7 @@ final class MiddleClickSession: @unchecked Sendable {
     private func restartListeners() {
         logger.info("重新建立多点触控与 CGEvent tap 监听")
         stopEventTap()
-        stopTouchListeners()
+        stopTouchListeners(resetConversionState: false)
         startTouchListeners()
         startEventTap()
         logger.info("监听重建完成，设备数：\(self.devices.count)")

--- a/Plugins/MiddleClick/Sources/MiddleClickSession.swift
+++ b/Plugins/MiddleClick/Sources/MiddleClickSession.swift
@@ -4,6 +4,7 @@ import CoreGraphics
 import Foundation
 import IOKit
 import MultitouchSupport
+import os
 import OSLog
 
 /// 管理触控板多点触控设备回调，检测到指定手指数后通过 CGEvent tap 把系统左键事件原地改为中键。
@@ -25,10 +26,21 @@ final class MiddleClickSession: @unchecked Sendable {
 
     // MARK: - CGEvent Tap State（CGEvent tap 与 C 回调线程均可读写）
 
-    /// 当前是否有所需手指数正在触碰（供 CGEvent tap 使用）
-    nonisolated(unsafe) var threeDown = false
-    /// CGEvent tap 已把一次 leftMouseDown 转换为 otherMouseDown，等待配对的 Up
-    nonisolated(unsafe) var wasThreeDown = false
+    /// CGEvent tap 与多点触控 C 回调线程共享的手指状态，用不公平锁保护避免数据竞争。
+    /// - threeDown: 当前是否有所需手指数正在触碰
+    /// - wasThreeDown: CGEvent tap 已把一次 leftMouseDown 转换为 otherMouseDown，等待配对的 Up
+    private struct TapFlags {
+        var threeDown = false
+        var wasThreeDown = false
+    }
+    private let tapFlags = OSAllocatedUnfairLock(initialState: TapFlags())
+
+    /// tap 回调在锁内决策，锁外再对 event 做 CGEvent C 调用。
+    private enum TapAction {
+        case passthrough
+        case convertToMiddleDown
+        case convertToMiddleUp
+    }
 
     // MARK: - Config（由主线程设置，回调线程读取）
 
@@ -70,7 +82,8 @@ final class MiddleClickSession: @unchecked Sendable {
 
     private let touchCallback: MTFrameCallbackFunction = { _, data, nFingers, _, _ in
         guard let session = MiddleClickSession.activeSession else { return }
-        session.threeDown = (nFingers == Int32(session.requiredFingerCount))
+        let isDown = (nFingers == Int32(session.requiredFingerCount))
+        session.tapFlags.withLock { $0.threeDown = isDown }
     }
 
     // MARK: - CGEvent Tap
@@ -89,15 +102,27 @@ final class MiddleClickSession: @unchecked Sendable {
             let kCenter = Int64(CGMouseButton.center.rawValue)
             let passthrough = Unmanaged.passUnretained(event)
 
-            if session.threeDown && (type == .leftMouseDown || type == .rightMouseDown) {
-                session.wasThreeDown = true
-                session.threeDown = false
+            let action: TapAction = session.tapFlags.withLock { flags in
+                if flags.threeDown && (type == .leftMouseDown || type == .rightMouseDown) {
+                    flags.wasThreeDown = true
+                    flags.threeDown = false
+                    return .convertToMiddleDown
+                } else if flags.wasThreeDown && (type == .leftMouseUp || type == .rightMouseUp) {
+                    flags.wasThreeDown = false
+                    return .convertToMiddleUp
+                }
+                return .passthrough
+            }
+
+            switch action {
+            case .convertToMiddleDown:
                 event.type = .otherMouseDown
                 event.setIntegerValueField(.mouseEventButtonNumber, value: kCenter)
-            } else if session.wasThreeDown && (type == .leftMouseUp || type == .rightMouseUp) {
-                session.wasThreeDown = false
+            case .convertToMiddleUp:
                 event.type = .otherMouseUp
                 event.setIntegerValueField(.mouseEventButtonNumber, value: kCenter)
+            case .passthrough:
+                break
             }
 
             return passthrough
@@ -158,8 +183,7 @@ final class MiddleClickSession: @unchecked Sendable {
     private func stopTouchListeners() {
         devices.forEach { $0.unregister(contactFrameCallback: touchCallback); $0.stop(); $0.release() }
         devices.removeAll()
-        threeDown = false
-        wasThreeDown = false
+        tapFlags.withLock { $0 = TapFlags() }
     }
 
     // MARK: - Start / Stop

--- a/Plugins/MiddleClick/Sources/MiddleClickSession.swift
+++ b/Plugins/MiddleClick/Sources/MiddleClickSession.swift
@@ -70,7 +70,10 @@ final class MiddleClickSession: @unchecked Sendable {
 
     // MARK: - 单例引用（供 C 回调访问）
 
-    nonisolated(unsafe) static weak var activeSession: MiddleClickSession?
+    /// 由不公平锁保护的强引用，替代原来 nonisolated(unsafe) 的 weak。
+    /// MT 驱动线程读、主线程写；Swift weak 读非原子会撕裂指针。锁内取强引用既原子又保活，
+    /// 取出后的强引用保证回调使用期间对象不被释放。
+    private static let activeSessionLock = OSAllocatedUnfairLock<MiddleClickSession?>(initialState: nil)
 
     // MARK: - MTDeviceCreateList（私有符号，通过 @_silgen_name 链接）
 
@@ -86,7 +89,7 @@ final class MiddleClickSession: @unchecked Sendable {
     // 只维护 threeDown 标志，不做手势识别。
 
     private let touchCallback: MTFrameCallbackFunction = { _, data, nFingers, _, _ in
-        guard let session = MiddleClickSession.activeSession else { return }
+        guard let session = MiddleClickSession.activeSessionLock.withLock({ $0 }) else { return }
         let isDown = (nFingers == Int32(session.requiredFingerCount))
         session.tapFlags.withLock { $0.threeDown = isDown }
     }
@@ -220,14 +223,14 @@ final class MiddleClickSession: @unchecked Sendable {
     }
 
     func activate() {
-        MiddleClickSession.activeSession?.stop()
-        MiddleClickSession.activeSession = self
+        MiddleClickSession.activeSessionLock.withLock { $0 }?.stop()
+        MiddleClickSession.activeSessionLock.withLock { $0 = self }
         start()
     }
 
     func deactivate() {
-        if MiddleClickSession.activeSession === self {
-            MiddleClickSession.activeSession = nil
+        MiddleClickSession.activeSessionLock.withLock { stored in
+            if stored === self { stored = nil }
         }
         stop()
     }


### PR DESCRIPTION
## 三处内存安全 / 并发修复

### F8 · DeviceBattery（Rapoo 监听）use-after-free
设备移除 / `stop()` 时只丢弃 session 引用，从未注销 `IOHIDDevice` 的 input-report 回调、也不 `unschedule`；HID 仍持有已释放的 `reportBuffer` 与 context，迟到的报告会写入已释放内存、回调对已释放对象做 `takeUnretainedValue`。新增 `teardownSession` 在释放前清回调 + unschedule；`stop()` 先 `Array(sessions.values)` 强引用住再清空，保证 buffer 在注销期间仍存活。

### F13 · MiddleClick 数据竞争
`threeDown` / `wasThreeDown` 被多点触控 C 回调线程与 CGEvent tap 线程无同步读写。改用 `OSAllocatedUnfairLock<TapFlags>` 保护；tap 回调**在锁内决策、锁外**再对 `event` 做 CGEvent C 调用，避免在实时 tap 中持锁。

### F1 · DisplayBrightness（DDC）指针逃逸 UB
`performRead` / `performWrite` 把数组 `baseAddress` 存进 `request` 后，在 `withUnsafeBufferPointer` 闭包返回**之后**才用于 `IOI2CSendRequest`——指针逃逸出有效作用域，属未定义行为。改为把 `send` 调用嵌进闭包内，发送期间 buffer 始终钉住。

## 测试
- 全量测试套件本地通过：**700 passed / 0 failed**（无回归）。
- ⚠️ 这三处涉及 IOKit HID / 实时 CGEvent tap / I2C，无法在 XCTest 中确定性单测。把关方式：对抗式设计复核 + Swift 6 严格并发编译（锁、IOKit 调用均通过）+ 指针/生命周期正确性推理。建议 maintainer 重点看 **F8 的 teardown 时序**与 **F13 的锁粒度**。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved battery monitor stability by ensuring all device sessions are removed and fully torn down during stop and device removal, preventing late callbacks into freed session state.
  * Fixed display-brightness communication to keep command/reply buffers valid for the entire hardware transaction, eliminating memory-safety issues.
  * Made middle-click handling thread-safe by protecting shared touch/mouse state and preserving conversion pairing across listener restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->