### PR TITLE
Fix official Homebrew cask bump workflow

### DIFF
--- a/.github/workflows/homebrew-cask-update.yml
+++ b/.github/workflows/homebrew-cask-update.yml
@@ -69,7 +69,6 @@ jobs:
             echo "tag=$TAG"
             echo "version=$VERSION"
             echo "sha256=$SHA256"
-            echo "download_url=$DOWNLOAD_URL"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check official cask version
@@ -104,7 +103,6 @@ jobs:
 
           brew bump-cask-pr mactools \
             --version "${{ steps.release.outputs.version }}" \
-            --url "${{ steps.release.outputs.download_url }}" \
             --sha256 "${{ steps.release.outputs.sha256 }}" \
             --no-browse
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -257,7 +257,7 @@ changed: refine menu item icon names
 
 文件内容会被原样置顶到自动生成的 release notes 前。没有对应文件时，Release 工作流只使用自动生成内容。该文件也会同步进入 Sparkle 更新弹窗。
 
-稳定版发布成功创建 GitHub Release 后，`Homebrew Cask Update` 工作流会在配置了 `HOMEBREW_GITHUB_API_TOKEN` 时读取刚发布的 DMG URL 和 SHA-256，并通过 `brew bump-cask-pr mactools` 向官方 `Homebrew/homebrew-cask` 打开版本更新 PR。预发布版本不会成为默认稳定版；未配置该 secret 时可以手动运行 workflow 或手动提交 Homebrew PR。Homebrew PR 合并后，用户本地运行 `brew update` 后即可通过 `brew upgrade --cask --greedy mactools` 检测到新版本。
+稳定版发布成功创建 GitHub Release 后，`Homebrew Cask Update` 工作流会在配置了 `HOMEBREW_GITHUB_API_TOKEN` 时确认 `MacTools.dmg` 存在、读取 `MacTools.sha256`，并通过 `brew bump-cask-pr mactools --version ... --sha256 ...` 向官方 `Homebrew/homebrew-cask` 打开版本更新 PR。不要传入 GitHub release asset 的展开下载 URL；官方 cask 应保留 `v#{version}` URL 模板，否则 Homebrew audit 会把它当成未版本化 URL。预发布版本不会成为默认稳定版；未配置该 secret 时可以手动运行 workflow 或手动提交 Homebrew PR。Homebrew PR 合并后，用户本地运行 `brew update` 后即可通过 `brew upgrade --cask --greedy mactools` 检测到新版本。
 
 仓库设置中需要允许 workflow 写入：`Settings` → `Actions` → `General` → `Workflow permissions` 选择 `Read and write permissions`。
 


### PR DESCRIPTION
## Summary
- stop passing the GitHub release asset URL to `brew bump-cask-pr`
- keep validating that `MacTools.dmg` exists and continue passing the release SHA-256
- document why the official cask should preserve its `v#{version}` URL template

## Why
The v1.0.14 Homebrew cask update run failed because passing `--url` made Homebrew write a fixed release asset URL into the official cask. `brew audit` then treated it as an unversioned URL and required `sha256 :no_check`. Omitting `--url` lets `brew bump-cask-pr` update the existing official cask while preserving `v#{version}`.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/homebrew-cask-update.yml")'`\n- `git diff --check`\n- confirmed the official cask now resolves `mactools` 1.0.14 with `HOMEBREW_NO_INSTALL_FROM_API=1 brew info --cask mactools`\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Streamlined the Homebrew cask update workflow to simplify the bump PR process
* Updated documentation describing the Homebrew cask update behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->