### PR TITLE
[codex] Fix menu bar autohide state detection

### DIFF
--- a/Plugins/AutoHideMenuBar/Sources/AutoHideMenuBarPlugin.swift
+++ b/Plugins/AutoHideMenuBar/Sources/AutoHideMenuBarPlugin.swift
@@ -136,8 +136,36 @@ final class AutoHideMenuBarPlugin: MacToolsPlugin, PluginPrimaryPanel {
         }
     }
 
-    private nonisolated static func readMenuBarAutohideState() -> Bool {
-        let defaults = UserDefaults(suiteName: "com.apple.dock")
-        return defaults?.object(forKey: "autohide-menubar") as? Bool ?? false
+    nonisolated static func readMenuBarAutohideState(
+        globalDefaults: UserDefaults = .standard,
+        dockDefaults: UserDefaults? = UserDefaults(suiteName: "com.apple.dock")
+    ) -> Bool {
+        resolvedMenuBarAutohideState(
+            globalValue: globalDefaults.object(forKey: "_HIHideMenuBar"),
+            dockValue: dockDefaults?.object(forKey: "autohide-menubar")
+        )
+    }
+
+    nonisolated static func resolvedMenuBarAutohideState(globalValue: Any?, dockValue: Any?) -> Bool {
+        if let value = boolValue(from: globalValue) {
+            return value
+        }
+
+        if let value = boolValue(from: dockValue) {
+            return value
+        }
+
+        return false
+    }
+
+    private nonisolated static func boolValue(from value: Any?) -> Bool? {
+        switch value {
+        case let value as Bool:
+            value
+        case let value as NSNumber:
+            value.boolValue
+        default:
+            nil
+        }
     }
 }

--- a/Plugins/AutoHideMenuBar/Tests/AutoHideMenuBarPluginTests.swift
+++ b/Plugins/AutoHideMenuBar/Tests/AutoHideMenuBarPluginTests.swift
@@ -70,6 +70,24 @@ final class AutoHideMenuBarPluginTests: XCTestCase {
         XCTAssertTrue(plugin.primaryPanelState.isOn)
         XCTAssertEqual(stateChangeCount, 1)
     }
+
+    func testStateReaderUsesGlobalMenuBarAutohideKey() {
+        let isEnabled = AutoHideMenuBarPlugin.resolvedMenuBarAutohideState(
+            globalValue: true,
+            dockValue: false
+        )
+
+        XCTAssertTrue(isEnabled)
+    }
+
+    func testStateReaderFallsBackToLegacyDockKey() {
+        let isEnabled = AutoHideMenuBarPlugin.resolvedMenuBarAutohideState(
+            globalValue: nil,
+            dockValue: true
+        )
+
+        XCTAssertTrue(isEnabled)
+    }
 }
 
 final class MockMenuBarCommandRunner: MenuBarCommandRunning {


### PR DESCRIPTION
## Summary
- Read the menu bar auto-hide state from the current global `_HIHideMenuBar` preference key.
- Keep the legacy `com.apple.dock/autohide-menubar` key as a fallback.
- Add regression coverage for the new preference resolution path.

## Root Cause
On current macOS versions, System Events successfully toggles menu bar auto-hide through `dock preferences`, but the persisted state is reflected in `NSGlobalDomain/_HIHideMenuBar`. The plugin was reading only `com.apple.dock/autohide-menubar`, so its switch could show the wrong state and make the user unable to reliably turn menu bar auto-hide back off.

## Validation
- `xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug -derivedDataPath build/DerivedData -destination 'platform=macOS,arch=arm64' test -only-testing:MacToolsTests/AutoHideMenuBarPluginTests -quiet`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal implementation of menu bar auto-hide state detection.

* **Tests**
  * Added test coverage for menu bar auto-hide state resolution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->