### PR TITLE
Fix: 热键按签名派发 + 移除 AppHotkey 悬挂 Carbon handler（UAF）

### DIFF
--- a/Plugins/AppHotkey/Sources/AppHotkeyManager.swift
+++ b/Plugins/AppHotkey/Sources/AppHotkeyManager.swift
@@ -14,17 +14,26 @@ final class AppHotkeyManager {
     }
 
     // "AHKY" = 0x4148_4B59
-    private static let signature: OSType = 0x4148_4B59
+    private nonisolated static let signature: OSType = 0x4148_4B59
 
     var onTrigger: ((UUID) -> Void)?
 
-    private var handlerRef: EventHandlerRef?
+    nonisolated(unsafe) private var handlerRef: EventHandlerRef?
     private var registeredHotKeys: [UUID: RegisteredHotKey] = [:]
     private var idsByCarbon: [UInt32: UUID] = [:]
     private var nextCarbonID: UInt32 = 1
 
     init() {
         installHandler()
+    }
+
+    deinit {
+        // 进程级 Carbon handler 用 passUnretained(self) 安装，实例释放前必须移除，
+        // 否则悬挂 handler 仍会触发并解引用已释放的 self（use-after-free）。
+        // handlerRef 标 nonisolated(unsafe)：仅 init 写、deinit 读，无并发访问。
+        if let handlerRef {
+            RemoveEventHandler(handlerRef)
+        }
     }
 
     /// 根据当前 entries 重新同步热键注册（增量 diff）。
@@ -122,6 +131,12 @@ final class AppHotkeyManager {
             &hotKeyID
         )
         guard status == noErr else { return status }
+
+        // 只处理本管理器签名的热键；签名不符返回 eventNotHandledErr，
+        // 让 Carbon 继续把事件传给真正的拥有者（如宿主的 GlobalShortcutManager）。
+        guard hotKeyID.signature == AppHotkeyManager.signature else {
+            return OSStatus(eventNotHandledErr)
+        }
 
         let manager = Unmanaged<AppHotkeyManager>
             .fromOpaque(userData)

--- a/Plugins/AppHotkey/Sources/AppHotkeyManager.swift
+++ b/Plugins/AppHotkey/Sources/AppHotkeyManager.swift
@@ -13,8 +13,10 @@ final class AppHotkeyManager {
         let carbonID: UInt32
     }
 
-    // "AHKY" = 0x4148_4B59
-    private nonisolated static let signature: OSType = 0x4148_4B59
+    // "AHKY" = 0x4148_4B59. Internal (not private) so a test can assert it never
+    // collides with GlobalShortcutManager's signature — the precondition that lets the
+    // signature-filtered handler pass foreign hot keys through to the other manager.
+    nonisolated static let signature: OSType = 0x4148_4B59
 
     var onTrigger: ((UUID) -> Void)?
 

--- a/Plugins/AppHotkey/Tests/HotkeySignatureDispatchTests.swift
+++ b/Plugins/AppHotkey/Tests/HotkeySignatureDispatchTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import MacTools
+@testable import AppHotkeyPlugin
+
+/// The app-hotkey plugin and the host's global-shortcut manager both install Carbon
+/// hot-key handlers on the *same* process-wide event target. This PR makes each handler
+/// claim only its own signature and return `eventNotHandledErr` for foreign hot keys, so
+/// the other manager still receives them. That pass-through dispatch is only correct
+/// while the two signatures never collide — assert the invariant here, since the C event
+/// handler itself can't be exercised without a live Carbon event loop.
+final class HotkeySignatureDispatchTests: XCTestCase {
+    func testManagersUseDistinctSignatures() {
+        XCTAssertNotEqual(
+            AppHotkeyManager.signature,
+            GlobalShortcutManager.signature,
+            "Colliding signatures would make each handler swallow the other's hot keys."
+        )
+    }
+
+    func testSignaturesMatchDocumentedFourCC() {
+        // Document the bytes (the signature *is* the FourCC) rather than re-stating hex,
+        // so a transposed character is caught here.
+        XCTAssertEqual(AppHotkeyManager.signature, Self.fourCharCode("AHKY"))
+        XCTAssertEqual(GlobalShortcutManager.signature, Self.fourCharCode("MCTL"))
+    }
+
+    /// Packs a 4-char ASCII string into an `OSType` the way Carbon FourCC literals do.
+    private static func fourCharCode(_ string: String) -> OSType {
+        precondition(string.unicodeScalars.count == 4 && string.unicodeScalars.allSatisfy { $0.isASCII })
+        return string.unicodeScalars.reduce(0) { ($0 << 8) + OSType($1.value) }
+    }
+}

--- a/Sources/Core/Shortcuts/GlobalShortcutManager.swift
+++ b/Sources/Core/Shortcuts/GlobalShortcutManager.swift
@@ -14,7 +14,9 @@ final class GlobalShortcutManager {
         let carbonID: UInt32
     }
 
-    private nonisolated static let signature: OSType = 0x4D43544C
+    // "MCTL" = 0x4D43544C. Internal (not private) for the cross-manager signature
+    // collision test; see AppHotkeyManager.signature.
+    nonisolated static let signature: OSType = 0x4D43544C
 
     var onShortcutTriggered: ((String) -> Void)?
 

--- a/Sources/Core/Shortcuts/GlobalShortcutManager.swift
+++ b/Sources/Core/Shortcuts/GlobalShortcutManager.swift
@@ -14,7 +14,7 @@ final class GlobalShortcutManager {
         let carbonID: UInt32
     }
 
-    private static let signature: OSType = 0x4D43544C
+    private nonisolated static let signature: OSType = 0x4D43544C
 
     var onShortcutTriggered: ((String) -> Void)?
 
@@ -141,6 +141,12 @@ final class GlobalShortcutManager {
 
         guard status == noErr else {
             return status
+        }
+
+        // 只处理本管理器签名的热键；签名不符返回 eventNotHandledErr，
+        // 让 Carbon 继续传递给真正的拥有者（如插件的 AppHotkeyManager）。
+        guard hotKeyID.signature == GlobalShortcutManager.signature else {
+            return OSStatus(eventNotHandledErr)
         }
 
         let manager = Unmanaged<GlobalShortcutManager>.fromOpaque(userData).takeUnretainedValue()


### PR DESCRIPTION
两个独立但同域的 Carbon 热键问题（来自一次全代码库对抗式审查）：

## 1. 热键派发不校验签名 → 跨触发 + 吞事件
`GlobalShortcutManager`（宿主全局快捷键）和 `AppHotkeyManager`（应用启动热键插件）都在 `GetApplicationEventTarget()` 上为 `kEventHotKeyPressed` 装 handler，且 `carbonID` 都从 1 自增。但两个 handler 派发时**都只读 `EventHotKeyID.id`、从不读 `signature`**——尽管 AppHotkeyManager 注释声称用 `'AHKY'` 签名"避免 Carbon ID 碰撞"（签名只在注册时设了、派发时没读）。

后果：用户同时设了一个全局快捷键和一个应用启动热键，两者 `carbonID` 都为 1 时，按其一会**触发另一个管理器的动作**，且 handler `return noErr` **吞掉事件**让正主收不到。

修复：两侧 handler 在读出 `hotKeyID` 后都加 `guard hotKeyID.signature == <Self>.signature else { return OSStatus(eventNotHandledErr) }`。返回 `eventNotHandledErr`（而非 `noErr`）让 Carbon 继续沿 handler 链传给真正的拥有者。

## 2. AppHotkey 悬挂 Carbon handler → use-after-free
`AppHotkeyManager.installHandler()` 用 `Unmanaged.passUnretained(self)` 装**进程级** handler（生命周期长于插件实例），却**从不 `RemoveEventHandler`**。插件热更新（`.updating`，旧实例释放后装新 handler）或卸载时，旧 handler 仍触发并 `fromOpaque(...).takeUnretainedValue()` 解引用已释放的 self → UAF。

修复：加 `deinit { RemoveEventHandler(handlerRef) }`；`handlerRef` 标 `nonisolated(unsafe)`（仅 `init` 写、`deinit` 读，无并发访问，可从 nonisolated deinit 合法访问）。（宿主的 GlobalShortcutManager 是 app 生命周期单例、不会提前释放，无此问题。）

## 测试
- 全量套件本地通过：**699 passed / 0 failed**。
- `MacTools` + `AppHotkeyPlugin` 均编译通过（Swift 6 严格并发）。
- ⚠️ 编译外未做真机验证（热键冲突需两个真实热键、Carbon 事件链实测）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented post-shutdown hotkey callbacks that could cause crashes by ensuring handlers are unregistered.
  * Strengthened isolation between global shortcuts and plugin hotkeys so they no longer interfere with each other.

* **Tests**
  * Added tests to verify hotkey identities are distinct and match documented values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->