### PR TITLE
Fix: 电池上限重启探测能力 + 热更新无条件停止强制放电

### DIFF
--- a/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitPlugin.swift
+++ b/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitPlugin.swift
@@ -94,6 +94,10 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
         // reset by firmware across sleep/hibernation, so on launch we
         // re-apply whatever the user last had configured.
         if store.isEnabled {
+            // 重新探测能力：capabilities 之前只在 handleEnableToggle 里赋值，重启（持久化
+            // enabled）时不经过那条路径，会停在 .none，导致强制放电功能与设置项静默消失。
+            // probeCapabilities() 是带缓存的纯 SMC 读，无副作用。
+            capabilities = writer.probeCapabilities()
             applyCurrentMode(reason: "activate")
         }
     }
@@ -101,11 +105,15 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
     func deactivate(reason: PluginDeactivationReason) {
         unregisterSleepWakeObservers()
         stopMonitoring()
+        // 强制放电(CH0I)在没有监控任务时持续放电，任何停用场景下都不安全，必须无条件停止。
+        // 尤其热更新(.updating) requiresStateCleanup==false 且新版不在进程内重新激活，
+        // 否则会让电池在插电状态下被持续放空。充电上限(inhibit)则只在真正清理时解除——
+        // 热更新期间保留限制是期望行为。
+        _ = writer.setForceDischarge(false)
         if reason.requiresStateCleanup {
             // Restore unrestricted charging so the user isn't left with the
             // SMC stuck in inhibit after disabling/uninstalling the plugin.
             _ = writer.resumeCharging()
-            _ = writer.setForceDischarge(false)
             BatteryChargeLimitLog.plugin.info("Deactivated (\(String(describing: reason), privacy: .public)) — cleared SMC charge inhibit")
         }
     }

--- a/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitPlugin.swift
+++ b/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitPlugin.swift
@@ -109,12 +109,23 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
         // 尤其热更新(.updating) requiresStateCleanup==false 且新版不在进程内重新激活，
         // 否则会让电池在插电状态下被持续放空。充电上限(inhibit)则只在真正清理时解除——
         // 热更新期间保留限制是期望行为。
-        _ = writer.setForceDischarge(false)
+        // This is the safety-critical cleanup path: a dropped failure can leave the
+        // battery stuck in forced discharge with no visibility. Log if it fails.
+        if let err = writer.setForceDischarge(false) {
+            BatteryChargeLimitLog.plugin.error(
+                "Deactivation (\(String(describing: reason), privacy: .public)) failed to clear force-discharge: \(err.localizedDescription, privacy: .public)"
+            )
+        }
         if reason.requiresStateCleanup {
             // Restore unrestricted charging so the user isn't left with the
             // SMC stuck in inhibit after disabling/uninstalling the plugin.
-            _ = writer.resumeCharging()
-            BatteryChargeLimitLog.plugin.info("Deactivated (\(String(describing: reason), privacy: .public)) — cleared SMC charge inhibit")
+            if let err = writer.resumeCharging() {
+                BatteryChargeLimitLog.plugin.error(
+                    "Deactivation (\(String(describing: reason), privacy: .public)) failed to clear charge inhibit: \(err.localizedDescription, privacy: .public)"
+                )
+            } else {
+                BatteryChargeLimitLog.plugin.info("Deactivated (\(String(describing: reason), privacy: .public)) — cleared SMC charge inhibit")
+            }
         }
     }
 


### PR DESCRIPTION
两个独立的电池充电上限问题（来自全代码库对抗式审查）：

## 1. 重启后能力未探测 → 强制放电功能静默消失
`capabilities`（SMC 能力探测结果）的唯一赋值点在 `handleEnableToggle(true)` 里。但 `store.isEnabled` 是持久化的——重启/重登后宿主调用 `activate(context:)`，对已启用的插件**只走 `applyCurrentMode`、从不 `probeCapabilities()`**，于是 `capabilities` 停在初始 `.none`。

后果（核心限流仍工作，但）：`buildDetail` 的 `if capabilities.canForceDischarge` 失败 → **强制放电行不再构建**；设置页收到 `.none` → 显示"未检测到可用的 SMC 充电控制键"并隐藏放电/BCLM 行。一次静默功能回归。

修复：`activate(context:)` 中当 `store.isEnabled` 时先 `capabilities = writer.probeCapabilities()`（带缓存的纯 SMC 读、无副作用）再 `applyCurrentMode`。

## 2. 热更新时强制放电未清 → 电池被持续放空
`deactivate(reason:)` 只在 `reason.requiresStateCleanup == true` 时清强制放电。但 `.updating`（热更新）的 `requiresStateCleanup == false`，且热更新后插件进入 `restartRequired`、**不在进程内重新激活**。于是若在强制放电(CH0I)激活时热更新，CH0I 会被留在 asserted 状态且**没有监控任务** → 电池在插电状态下被持续放空。

修复：把 `setForceDischarge(false)` 移出 `requiresStateCleanup` 门控、**无条件执行**（无监控的持续放电任何场景都不安全）；充电上限(inhibit)的解除仍 gated——热更新期间保留限制是期望行为。

## 测试
- 全量套件本地通过：**700 passed / 0 failed**。
- `BatteryChargeLimitPlugin` 编译通过。
- ⚠️ 涉及真实 SMC 读写，未真机验证；建议补一个"持久化 isEnabled=true 时 activate 后 capabilities 非 .none"的回归测试（审查指出该路径当前无测试覆盖）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed battery capability detection so the app re-checks hardware support on startup when the feature is enabled, preventing a missing capability state across restarts.
  * Ensured force-discharge is always cleared during deactivation so normal charging is consistently resumed, regardless of the deactivation reason.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->