### PR TITLE
Fix: IPOverview/DeviceBattery 异步竞争 + FixDamagedApp 选择器 .app 校验

### DIFF
--- a/Plugins/DeviceBattery/Sources/DeviceBatteryViewModel.swift
+++ b/Plugins/DeviceBattery/Sources/DeviceBatteryViewModel.swift
@@ -140,6 +140,9 @@ final class DeviceBatteryViewModel: ObservableObject {
 
         let referenceDate = Date()
         let collectedItems = await sampler.collectSystemDevices(referenceDate: referenceDate)
+        // collectSystemDevices 会跑 system_profiler 子进程（~1s+）。期间面板可能被关闭
+        // （onDisappear -> stop()）；普通 await 不会因取消提前返回，续体仍会写入陈旧快照。
+        guard !Task.isCancelled, isStarted else { return }
         systemItems = collectedItems
         lastSystemUpdate = referenceDate
         rebuildSnapshot()

--- a/Plugins/FixDamagedApp/Sources/FixDamagedAppPlugin.swift
+++ b/Plugins/FixDamagedApp/Sources/FixDamagedAppPlugin.swift
@@ -207,6 +207,14 @@ final class FixDamagedAppPlugin: MacToolsPlugin, PluginPrimaryPanel, DropZoneAnc
         panel.directoryURL = URL(fileURLWithPath: "/Applications")
         let response = panel.runModal()
         guard response == .OK, let url = panel.url else { return }
+        // canChooseDirectories 为 true 且 allowedContentTypes 无法阻止选中普通目录，
+        // 因此与拖拽路径一致，必须校验是 .app，避免对任意目录执行管理员权限的 xattr 删除。
+        guard url.pathExtension.lowercased() == "app" else {
+            selectedApp = url
+            fixState = .failure(message: "请选择 .app 应用")
+            onStateChange?()
+            return
+        }
         selectedApp = url
         fixState = .idle
         onStateChange?()

--- a/Plugins/IPOverview/Sources/IPOverviewViewModel.swift
+++ b/Plugins/IPOverview/Sources/IPOverviewViewModel.swift
@@ -168,18 +168,13 @@ final class IPOverviewViewModel: ObservableObject {
                 isCheckingConnectivity = false
             }
 
-            var nextResults: [IPOverviewConnectivityResult] = []
             for target in targets {
                 guard !Task.isCancelled else { return }
                 let result = await connectivityChecker.check(target: target)
-                nextResults.append(result)
-                connectivityResults = targets.map { candidate in
-                    nextResults.first(where: { $0.id == candidate.id })
-                        ?? IPOverviewConnectivityResult(
-                            id: candidate.id,
-                            target: candidate,
-                            status: .checking
-                        )
+                // 就地合并到当前发布数组，而不是从过期快照整体重建：
+                // 检测期间（最长十几秒）用户增删目标不会被覆盖——新增的不丢、删除的不复活。
+                if let index = connectivityResults.firstIndex(where: { $0.id == result.id }) {
+                    connectivityResults[index] = result
                 }
             }
         }


### PR DESCRIPTION
三个独立插件的竞争/校验修复（来自全代码库对抗式审查）。同源的 DisplayBrightness 后端并发问题（B7）因涉及 4 个后端类的并发重构、风险较高，单独提一个 PR。

## B3 · IPOverview 连通性检测覆盖用户编辑
`checkConnectivity()` 先快照 `targets`，然后在循环里每完成一个目标就**从这份过期快照整体重建** `connectivityResults`。检测最长十几秒（6 个目标 × 3s 超时），期间用户点增/删按钮（`@MainActor` 在 await 处interleave）会被下一次重建覆盖——新增的目标消失、删除的目标以 `.checking` 复活。

修复：改为**就地合并**——`connectivityResults.firstIndex(where: id)` 在当前发布数组上更新单个结果，不再从快照重建。

## B4 · DeviceBattery 关面板后写入陈旧快照
`collectOnce()` 在 `await sampler.collectSystemDevices`（内部跑 `system_profiler` 子进程，~1s+）后无条件写 `systemItems`/快照。普通 `await` 不因取消提前返回，所以关闭面板（`onDisappear -> stop()`）后续体仍把陈旧数据写回。

修复：await 后加 `guard !Task.isCancelled, isStarted else { return }`。

## B9 · FixDamagedApp 文件选择器缺 .app 校验
`chooseApp()` 的 `NSOpenPanel` 设了 `canChooseDirectories = true`（`allowedContentTypes` 挡不住普通目录），选中后直接 `performFix()` 对其执行**管理员权限的 `xattr -r -d com.apple.quarantine`**。拖拽路径校验了 `.app`、选择器路径没有。

修复：选中后与拖拽路径一致 `guard url.pathExtension.lowercased() == "app"`，否则报"请选择 .app 应用"。

## 测试
- 全量套件本地通过：**700 passed / 0 failed**。
- IpOverview / DeviceBattery / FixDamagedApp 三插件均编译通过。
- ⚠️ 编译+单测层面验证；竞争类（B3/B4）的时序、B9 的权限路径未真机验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device Battery: Fixed stale data display when view is dismissed during system profiling.
  * Damaged App: Added validation to ensure only .app files are selected with error messaging.
  * IP Overview: Fixed connectivity checks to preserve user-added or removed targets during in-flight operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->