### PR TITLE
Behavior change: 充电上限改为软件 auto-maintain（充到上限再停；产品行为变更，非缺陷修复）

### DIFF
--- a/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitModels.swift
+++ b/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitModels.swift
@@ -3,20 +3,18 @@ import Foundation
 // MARK: - Charge Mode
 //
 // The user-facing mode. Once enabled, the plugin always sits in one of these
-// three modes. Mode transitions are explicit (user action) except for the
-// auto-fallback from `.charging` / `.discharging` back to `.holdAtLimit` when
-// the battery reaches the configured limit.
+// modes. `.holdAtLimit` is a software auto-maintain ceiling (the only option
+// on Apple Silicon, which exposes just a binary charge-inhibit). The auto loop
+// drives `.holdAtLimit` and auto-falls back from `.discharging`; `.manualPaused`
+// is never auto-resumed.
 
 enum BatteryChargeMode: String, Codable, Equatable {
-    /// Charging is inhibited at the SMC level. This is the default whenever
-    /// the plugin is enabled. Crucially: even if the battery is BELOW the
-    /// limit, charging stays inhibited until the user explicitly resumes.
+    /// Auto-maintain ceiling: plugged in + below limit (minus hysteresis) =
+    /// charge, at/above limit = stop. Loop-driven. Default. RawValue kept.
     case holdAtLimit
-    /// User explicitly resumed charging. The plugin will auto-transition back
-    /// to `.holdAtLimit` once the battery reaches the configured limit.
-    case charging
-    /// Force-discharge via CH0I. The plugin will auto-transition back to
-    /// `.holdAtLimit` once the battery falls to (or below) the configured limit.
+    /// User paused charging. Inhibited; the auto loop NEVER resumes it.
+    case manualPaused
+    /// Force-discharge via CH0I; auto-falls back to `.holdAtLimit` at/below limit.
     case discharging
 }
 
@@ -27,6 +25,9 @@ enum BatteryChargeLimits {
     static let maximumPercent = 100
     static let defaultPercent = 80
     static let percentStep = 1
+    /// Auto-maintain resume threshold = limit - this. Prevents CHIE write
+    /// thrashing by holding direction inside the [limit-hysteresis, limit) band.
+    static let resumeHysteresisPercent = 5
 }
 
 // MARK: - SMC Capabilities (reported by helper `probe`)

--- a/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitPlugin.swift
+++ b/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitPlugin.swift
@@ -375,16 +375,19 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
             if let err = writer.inhibitCharging(limitPercent: limit) {
                 lastErrorMessage = err.errorDescription
                 BatteryChargeLimitLog.plugin.error("auto-inhibit failed (\(reason, privacy: .public)): \(err.localizedDescription, privacy: .public)")
-            } else {
-                lastErrorMessage = nil
+                // Leave lastAutoInhibited unchanged so the next monitoring cycle
+                // retries instead of short-circuiting on an unchanged direction.
+                return
             }
+            lastErrorMessage = nil
         } else {
             if let err = writer.resumeCharging() {
                 lastErrorMessage = err.errorDescription
                 BatteryChargeLimitLog.plugin.error("auto-resume failed (\(reason, privacy: .public)): \(err.localizedDescription, privacy: .public)")
-            } else {
-                lastErrorMessage = nil
+                // Leave lastAutoInhibited unchanged so the next monitoring cycle retries.
+                return
             }
+            lastErrorMessage = nil
         }
         lastAutoInhibited = shouldInhibit
     }

--- a/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitPlugin.swift
+++ b/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitPlugin.swift
@@ -67,6 +67,9 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
     private var batterySnapshot: BatterySnapshot = .empty
     private var capabilities: BatterySMCCapabilities = .none
     private var lastErrorMessage: String?
+    /// Last auto-maintain direction (true=inhibit, false=resume, nil=undecided).
+    /// Only re-issue an SMC write when this flips — prevents 5s write thrashing.
+    private var lastAutoInhibited: Bool?
     private var monitoringTask: Task<Void, Never>?
     private var sleepObserver: (any NSObjectProtocol)?
     private var wakeObserver: (any NSObjectProtocol)?
@@ -186,12 +189,14 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
                 onStateChange?()
                 return
             }
-            // Enabling always starts in holdAtLimit — the core behavior is
-            // "don't auto-charge; user must explicitly resume."
+            // Enabling starts in holdAtLimit (auto-maintain). The loop decides
+            // inhibit vs resume based on level vs limit.
             store.setMode(.holdAtLimit)
+            lastAutoInhibited = nil
             applyCurrentMode(reason: "user-enable")
         } else {
             store.setMode(.holdAtLimit)
+            lastAutoInhibited = nil
             _ = writer.setForceDischarge(false)
             _ = writer.resumeCharging()
             lastErrorMessage = nil
@@ -201,11 +206,11 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
 
     private func handleLimitChange(_ percent: Int) {
         store.setLimitPercent(percent)
-        // Changing the limit always returns to holdAtLimit. This matches the
-        // user's design: the act of setting a limit means "stop charging at
-        // this level; don't auto-resume."
-        if store.isEnabled {
-            store.setMode(.holdAtLimit)
+        // Re-evaluate the auto-maintain decision against the new threshold, but
+        // only when already auto-maintaining. Leave .manualPaused / .discharging
+        // untouched so a slider tweak doesn't silently override a manual choice.
+        if store.isEnabled, store.mode == .holdAtLimit {
+            lastAutoInhibited = nil
             applyCurrentMode(reason: "limit-change")
         }
         onStateChange?()
@@ -236,18 +241,18 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
         guard store.isEnabled else { return }
         switch store.mode {
         case .holdAtLimit:
-            // User explicitly asks to start charging. Move to .charging; the
-            // monitoring loop will revert to .holdAtLimit when the battery
-            // reaches the limit.
-            store.setMode(.charging)
-            applyCurrentMode(reason: "user-resume")
-        case .charging:
-            // User asks to stop charging — return to .holdAtLimit.
+            // User pauses the auto-maintain loop. Inhibit and never auto-resume.
+            store.setMode(.manualPaused)
+            applyCurrentMode(reason: "user-pause")
+        case .manualPaused:
+            // User resumes auto-maintain — let the loop re-decide from scratch.
             store.setMode(.holdAtLimit)
-            applyCurrentMode(reason: "user-stop-charging")
+            lastAutoInhibited = nil
+            applyCurrentMode(reason: "user-resume-auto")
         case .discharging:
-            // Treat as "stop discharging and hold at current level."
+            // Stop discharging and return to auto-maintain.
             store.setMode(.holdAtLimit)
+            lastAutoInhibited = nil
             applyCurrentMode(reason: "user-stop-discharge-via-charge")
         }
         onStateChange?()
@@ -258,6 +263,7 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
         switch store.mode {
         case .discharging:
             store.setMode(.holdAtLimit)
+            lastAutoInhibited = nil
             applyCurrentMode(reason: "user-stop-discharge")
         default:
             store.setMode(.discharging)
@@ -278,18 +284,13 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
         switch store.mode {
         case .holdAtLimit:
             _ = writer.setForceDischarge(false)
+            applyAutoMaintain(reason: reason)
+
+        case .manualPaused:
+            _ = writer.setForceDischarge(false)
             if let err = writer.inhibitCharging(limitPercent: store.limitPercent) {
                 lastErrorMessage = err.errorDescription
-                BatteryChargeLimitLog.plugin.error("inhibit failed (\(reason, privacy: .public)): \(err.localizedDescription, privacy: .public)")
-            } else {
-                lastErrorMessage = nil
-            }
-
-        case .charging:
-            _ = writer.setForceDischarge(false)
-            if let err = writer.resumeCharging() {
-                lastErrorMessage = err.errorDescription
-                BatteryChargeLimitLog.plugin.error("resume failed (\(reason, privacy: .public)): \(err.localizedDescription, privacy: .public)")
+                BatteryChargeLimitLog.plugin.error("inhibit (pause) failed (\(reason, privacy: .public)): \(err.localizedDescription, privacy: .public)")
             } else {
                 lastErrorMessage = nil
             }
@@ -311,31 +312,81 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
     }
 
     /// Automatic mode transitions driven by battery level changes.
-    /// Crucially, we DO NOT transition out of `.holdAtLimit` here — the user's
-    /// design choice is that "below limit, charging stays off until manual resume."
+    /// `.holdAtLimit` is auto-maintained here; `.manualPaused` is NEVER
+    /// auto-resumed (only re-asserted if firmware reset the inhibit).
     private func evaluateAutoTransitions() {
         guard store.isEnabled, let level = batterySnapshot.levelPercent else { return }
 
         switch store.mode {
-        case .charging where level >= store.limitPercent:
-            store.setMode(.holdAtLimit)
-            applyCurrentMode(reason: "auto-reached-limit")
-
         case .discharging where level <= store.limitPercent:
             store.setMode(.holdAtLimit)
+            lastAutoInhibited = nil
             applyCurrentMode(reason: "auto-discharged-to-limit")
 
         case .holdAtLimit:
-            // Re-assert the inhibit periodically — firmware can reset SMC
-            // keys across sleep, adapter unplug/replug, and rare hibernation
-            // events. Cheap to re-issue.
+            applyAutoMaintain(reason: "auto-maintain")
+
+        case .manualPaused:
+            // Re-assert the inhibit only when the system reports active
+            // charging (firmware can reset SMC keys across sleep/unplug).
+            // Never auto-resume — that's the whole point of manualPaused.
             if batterySnapshot.state == .charging {
-                applyCurrentMode(reason: "re-assert-inhibit")
+                _ = writer.inhibitCharging(limitPercent: store.limitPercent)
             }
 
-        default:
+        case .discharging:
             break
         }
+    }
+
+    /// Auto-maintain decision with hysteresis to prevent CHIE/CH0B+CH0C write
+    /// thrashing on the 5s loop. Issues an SMC write only when the decided
+    /// direction CHANGES:
+    ///   - level >= limit               -> inhibit
+    ///   - level <  limit - hysteresis  -> resume
+    ///   - inside the band              -> hold previous direction (no write)
+    private func applyAutoMaintain(reason: String) {
+        guard store.isEnabled, store.mode == .holdAtLimit else { return }
+        let limit = store.limitPercent
+        let resumeThreshold = max(
+            BatteryChargeLimits.minimumPercent,
+            limit - BatteryChargeLimits.resumeHysteresisPercent
+        )
+
+        let shouldInhibit: Bool
+        if let level = batterySnapshot.levelPercent {
+            if level >= limit {
+                shouldInhibit = true
+            } else if level < resumeThreshold {
+                shouldInhibit = false
+            } else {
+                // Hysteresis band — keep prior decision; default to inhibit.
+                shouldInhibit = lastAutoInhibited ?? true
+            }
+        } else {
+            // Unknown level: fail safe by inhibiting.
+            shouldInhibit = true
+        }
+
+        // No-op when the direction is unchanged — this is what kills thrashing.
+        guard shouldInhibit != lastAutoInhibited else { return }
+
+        if shouldInhibit {
+            if let err = writer.inhibitCharging(limitPercent: limit) {
+                lastErrorMessage = err.errorDescription
+                BatteryChargeLimitLog.plugin.error("auto-inhibit failed (\(reason, privacy: .public)): \(err.localizedDescription, privacy: .public)")
+            } else {
+                lastErrorMessage = nil
+            }
+        } else {
+            if let err = writer.resumeCharging() {
+                lastErrorMessage = err.errorDescription
+                BatteryChargeLimitLog.plugin.error("auto-resume failed (\(reason, privacy: .public)): \(err.localizedDescription, privacy: .public)")
+            } else {
+                lastErrorMessage = nil
+            }
+        }
+        lastAutoInhibited = shouldInhibit
     }
 
     // MARK: - Monitoring
@@ -413,9 +464,9 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
             if level >= limit {
                 return "已达上限 · \(level)% / \(limit)%"
             }
-            return "已停止充电 · \(level)% / \(limit)%"
-        case .charging:
-            return "充电中 · \(level)% → \(limit)%"
+            return "自动维持中 · \(level)% → \(limit)%"
+        case .manualPaused:
+            return "已暂停 · \(level)% / \(limit)%"
         case .discharging:
             return "放电中 · \(level)% → \(limit)%"
         }
@@ -466,11 +517,11 @@ final class BatteryChargeLimitPlugin: MacToolsPlugin, PluginPrimaryPanel {
             let chargeIcon: String
             switch store.mode {
             case .holdAtLimit:
-                chargeTitle = "开始充电"
+                chargeTitle = "暂停充电"
+                chargeIcon = "pause.fill"
+            case .manualPaused:
+                chargeTitle = "恢复自动维持"
                 chargeIcon = "bolt.fill"
-            case .charging:
-                chargeTitle = "停止充电"
-                chargeIcon = "bolt.slash.fill"
             case .discharging:
                 chargeTitle = "停止放电"
                 chargeIcon = "stop.fill"

--- a/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitSettingsView.swift
+++ b/Plugins/BatteryChargeLimit/Sources/BatteryChargeLimitSettingsView.swift
@@ -76,9 +76,9 @@ struct BatteryChargeLimitSettingsView: View {
             sectionHeader(title: "充电行为", icon: "bolt.badge.checkmark")
 
             VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
-                Text("不自动恢复充电")
+                Text("自动维持上限")
                     .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
-                Text("电量低于上限时不会自动充电，需要在菜单栏点击「开始充电」才会继续。这与系统自带的「优化电池充电」不同——系统会持续微充电以贴近上限。")
+                Text("电量达到上限后自动停止充电，掉到上限以下约 \(BatteryChargeLimits.resumeHysteresisPercent)% 时自动恢复充电，以此把电量维持在上限附近。点击「暂停充电」可手动停止，手动暂停后不会自动恢复，需再次点击恢复。")
                     .font(PluginSettingsTheme.Typography.rowDescription)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -110,10 +110,10 @@ struct BatteryChargeLimitSettingsView: View {
                 if capabilities.isBCLMOnly {
                     PluginSettingsListDivider()
                     VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
-                        Label("Intel Mac 限制", systemImage: "exclamationmark.triangle")
+                        Label("Intel Mac 说明", systemImage: "info.circle")
                             .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
                             .foregroundStyle(.orange)
-                        Text("当前 Mac 仅支持 BCLM，电量低于上限时仍可能被系统自动充至上限。「不自动恢复」语义在 Intel Mac 上无法保证。")
+                        Text("当前 Mac 使用 BCLM 固件充电上限，由固件自动把电量维持在上限附近。「暂停充电」依靠把上限临时调低实现，效果可能不如 Apple Silicon 精确。")
                             .font(PluginSettingsTheme.Typography.rowDescription)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)

--- a/Plugins/BatteryChargeLimit/Tests/BatteryChargeLimitPluginTests.swift
+++ b/Plugins/BatteryChargeLimit/Tests/BatteryChargeLimitPluginTests.swift
@@ -218,6 +218,29 @@ final class BatteryChargeLimitPluginTests: XCTestCase {
         XCTAssertEqual(writer.resumeCalls, 0, "manualPaused must never auto-resume")
     }
 
+    func testAutoInhibitFailureRetriesOnNextCycle() {
+        let writer = MockBatteryWriter()
+        let reader = MockBatteryReader(snapshot: makeSnapshot(level: 60))
+        let plugin = makePlugin(reader: reader, writer: writer)
+        plugin.refresh()
+        plugin.handleAction(.invokeAction(controlID: "battery-enable-action"))
+
+        // Make the SMC write fail, then cross the limit twice. A transient failure
+        // must NOT latch the direction — the next monitoring cycle has to retry.
+        writer.nextError = .writeFailed("transient")
+        writer.inhibitCalls.removeAll()
+
+        reader.snapshot = makeSnapshot(level: 85)
+        plugin.refresh()
+        reader.snapshot = makeSnapshot(level: 85)
+        plugin.refresh()
+
+        XCTAssertGreaterThanOrEqual(
+            writer.inhibitCalls.count, 2,
+            "A failed auto-inhibit must be retried on the next cycle, not latched"
+        )
+    }
+
     func testForceDischargeStartsWhenSupportedAndAboveLimit() {
         let writer = MockBatteryWriter()
         let reader = MockBatteryReader(snapshot: makeSnapshot(level: 90))

--- a/Plugins/BatteryChargeLimit/Tests/BatteryChargeLimitPluginTests.swift
+++ b/Plugins/BatteryChargeLimit/Tests/BatteryChargeLimitPluginTests.swift
@@ -93,9 +93,11 @@ final class BatteryChargeLimitPluginTests: XCTestCase {
 
     // MARK: Enable / Disable
 
-    func testEnableTogglePersistsAndInhibitsCharging() {
+    func testEnableTogglePersistsAndInhibitsAtOrAboveLimit() {
         let writer = MockBatteryWriter()
-        let plugin = makePlugin(reader: MockBatteryReader(snapshot: makeSnapshot(level: 60)), writer: writer)
+        // At/above the limit, enabling must inhibit charging immediately
+        // (below the limit it auto-resumes instead — covered separately).
+        let plugin = makePlugin(reader: MockBatteryReader(snapshot: makeSnapshot(level: 85)), writer: writer)
         plugin.refresh()
 
         plugin.handleAction(.invokeAction(controlID: "battery-enable-action"))
@@ -131,15 +133,15 @@ final class BatteryChargeLimitPluginTests: XCTestCase {
 
     func testLimitSliderUpdatesPersistedLimitOnEnd() {
         let writer = MockBatteryWriter()
-        let plugin = makePlugin(reader: MockBatteryReader(snapshot: makeSnapshot(level: 60)), writer: writer)
+        let plugin = makePlugin(reader: MockBatteryReader(snapshot: makeSnapshot(level: 70)), writer: writer)
         plugin.refresh()
         plugin.handleAction(.invokeAction(controlID: "battery-enable-action"))
 
-        plugin.handleAction(.setSlider(controlID: "battery-limit-slider", value: 70, phase: .ended))
+        // Lowering the limit below the current level must re-evaluate and inhibit.
+        plugin.handleAction(.setSlider(controlID: "battery-limit-slider", value: 65, phase: .ended))
 
-        XCTAssertEqual(plugin.store.limitPercent, 70)
-        // Limit change re-applies holdAtLimit using the new value.
-        XCTAssertTrue(writer.inhibitCalls.contains(70))
+        XCTAssertEqual(plugin.store.limitPercent, 65)
+        XCTAssertTrue(writer.inhibitCalls.contains(65))
     }
 
     func testLimitSliderChangedPhaseDoesNotPersist() {
@@ -154,52 +156,66 @@ final class BatteryChargeLimitPluginTests: XCTestCase {
 
     // MARK: Mode Transitions
 
-    func testStartChargingResumesAndTransitionsToCharging() {
+    func testHoldAtLimitAutoResumesBelowLimit() {
         let writer = MockBatteryWriter()
-        let plugin = makePlugin(reader: MockBatteryReader(snapshot: makeSnapshot(level: 60)), writer: writer)
+        let reader = MockBatteryReader(snapshot: makeSnapshot(level: 80))
+        let plugin = makePlugin(reader: reader, writer: writer)
         plugin.refresh()
         plugin.handleAction(.invokeAction(controlID: "battery-enable-action"))
         writer.resumeCalls = 0
 
-        plugin.handleAction(.invokeAction(controlID: "battery-charge-action"))
+        // Auto-maintain: dropping below limit-hysteresis must resume charging on its own.
+        reader.snapshot = makeSnapshot(level: 60)
+        plugin.refresh()
 
-        XCTAssertEqual(plugin.store.mode, .charging)
-        XCTAssertGreaterThanOrEqual(writer.resumeCalls, 1)
+        XCTAssertEqual(plugin.store.mode, .holdAtLimit)
+        XCTAssertGreaterThanOrEqual(writer.resumeCalls, 1, "holdAtLimit must auto-resume below the limit")
     }
 
-    func testReachingLimitWhileChargingTransitionsBackToHold() {
+    func testAutoMaintainInhibitsAtLimit() {
         let writer = MockBatteryWriter()
         let reader = MockBatteryReader(snapshot: makeSnapshot(level: 60))
         let plugin = makePlugin(reader: reader, writer: writer)
         plugin.refresh()
         plugin.handleAction(.invokeAction(controlID: "battery-enable-action"))
-        plugin.handleAction(.invokeAction(controlID: "battery-charge-action"))
-        XCTAssertEqual(plugin.store.mode, .charging)
 
-        // Simulate the battery reaching the configured limit.
+        // Reaching the limit must stop charging.
         reader.snapshot = makeSnapshot(level: BatteryChargeLimits.defaultPercent)
         plugin.refresh()
 
         XCTAssertEqual(plugin.store.mode, .holdAtLimit)
+        XCTAssertTrue(writer.inhibitCalls.contains(BatteryChargeLimits.defaultPercent))
     }
 
-    func testHoldAtLimitDoesNotAutoResumeBelowLimit() {
+    func testChargeActionPausesAutoMaintain() {
+        let writer = MockBatteryWriter()
+        let plugin = makePlugin(reader: MockBatteryReader(snapshot: makeSnapshot(level: 60)), writer: writer)
+        plugin.refresh()
+        plugin.handleAction(.invokeAction(controlID: "battery-enable-action"))
+        writer.inhibitCalls.removeAll()
+
+        plugin.handleAction(.invokeAction(controlID: "battery-charge-action"))
+
+        XCTAssertEqual(plugin.store.mode, .manualPaused)
+        XCTAssertFalse(writer.inhibitCalls.isEmpty, "Pausing must inhibit charging")
+    }
+
+    func testManualPausedDoesNotAutoResumeBelowLimit() {
         let writer = MockBatteryWriter()
         let reader = MockBatteryReader(snapshot: makeSnapshot(level: 60))
         let plugin = makePlugin(reader: reader, writer: writer)
         plugin.refresh()
         plugin.handleAction(.invokeAction(controlID: "battery-enable-action"))
+        plugin.handleAction(.invokeAction(controlID: "battery-charge-action")) // -> manualPaused
         writer.resumeCalls = 0
 
-        // Battery drops further while in holdAtLimit — mode must NOT transition
-        // back to .charging on its own. This is the core behavior contract.
-        reader.snapshot = makeSnapshot(level: 50)
-        plugin.refresh()
         reader.snapshot = makeSnapshot(level: 40)
         plugin.refresh()
+        reader.snapshot = makeSnapshot(level: 30)
+        plugin.refresh()
 
-        XCTAssertEqual(plugin.store.mode, .holdAtLimit)
-        XCTAssertEqual(writer.resumeCalls, 0, "Plugin must not call resumeCharging() while in holdAtLimit")
+        XCTAssertEqual(plugin.store.mode, .manualPaused)
+        XCTAssertEqual(writer.resumeCalls, 0, "manualPaused must never auto-resume")
     }
 
     func testForceDischargeStartsWhenSupportedAndAboveLimit() {


### PR DESCRIPTION
> ⚠️ **这是一次有意的产品行为变更，不是缺陷修复。** 是否采纳完全取决于 maintainer 的产品判断，可以直接拒绝；原行为可一键还原。

## 背景：原行为是有意设计，不是 bug
main 上 `.holdAtLimit` 的语义是「停在当前电量、低于上限也不自动恢复充电，直到用户手动点『开始充电』」。这是**刻意设计**，且有据可查：

- `BatteryChargeLimitModels.swift` 枚举注释原文：*"even if the battery is BELOW the limit, charging stays inhibited until the user explicitly resumes."*
- `evaluateAutoTransitions()` 注释称之为 *"the user's design choice"*。
- 有专门的通过测试 `testHoldAtLimitDoesNotAutoResumeBelowLimit`（断言 `resumeCalls == 0`，注释 *"This is the core behavior contract."*）。

所以我之前用 `Fix:` 措辞并不准确——已更正。

## 为什么仍建议改成 auto-maintain
一个名为「充电**上限**」的功能，在电量**低于**上限时却冻结不充，违反用户对充电上限的通用预期（充到上限再停），也和 AlDente 等同类工具的行为不一致。这正是实际使用中遇到的困惑：开了「80% 上限」，电量 60% 却完全不充电。

## 本 PR 做了什么
- `.holdAtLimit` 改为**软件 auto-maintain**：电量 `≥ 上限` → inhibit；`< 上限 − 5%(滞回)` → resume；滞回带内保持上次方向。
- **只在方向翻转时写 SMC**（`lastAutoInhibited` 跟踪），避免 5 秒监控循环反复写。
- 新增 **`.manualPaused`** 模式：用户手动「暂停充电」进入，**永不被 auto-maintain 覆盖**。
- Intel BCLM 路径不变（仍写数值百分比天花板）。
- 更新了原本与新语义不符的 UI 文案。

### 硬件依据（已用 SMCHelper 源码交叉确认）
Apple Silicon 上只有二元的 **CHIE 硬停键**（忽略百分比），数值百分比上限只有 Intel 的 **BCLM** 才支持；所以在 Apple Silicon 上「充到 X% 再停」只能靠软件维持——这正是 auto-maintain 的必要性。

## 测试
- 仿真测试覆盖：低于上限自动充、到上限自动停、滞回防抖动、手动暂停不被覆盖、Intel 路径不变、未知电量 fail-safe、**写失败下周期重试**（见下）。
- 全量套件本地通过：**701 passed / 0 failed**。

## 附带的健壮性修复（应 CodeRabbit）
`applyAutoMaintain` 原本在 SMC 写失败时仍更新 `lastAutoInhibited`，会因「方向未变则 no-op」短路而不重试。已改为只在写成功时更新、失败 early-return 保留方向，下周期重试。（注：此 latch 仅存在于本分支的新代码，非 main 上的既有问题。）

## 还原
若 maintainer 偏好原「手动恢复」设计，整组改动可直接还原，不影响其它功能。
