### PR TITLE
Fix: 修复 DisplayBrightness 各 backend 的数据竞争（加锁保护 display 与缓存）

### DIFF
--- a/Plugins/DisplayBrightness/Sources/DisplayBrightnessBackends.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayBrightnessBackends.swift
@@ -3,6 +3,14 @@ import CoreGraphics
 import Foundation
 import MacToolsPluginKit
 
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}
+
 final class SystemDisplayBrightnessBackendBuilder: DisplayBrightnessBackendBuilding {
     typealias Arm64ServiceResolver = ([DisplayInfo]) -> [CGDirectDisplayID: CFTypeRef]
     typealias AppleBackendFactory = (DisplayInfo) -> (any DisplayBrightnessBackend)?
@@ -267,7 +275,13 @@ final class SystemDisplayBrightnessBackendBuilder: DisplayBrightnessBackendBuild
 
 final class AppleNativeBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendable {
     let kind: DisplayBrightnessBackendKind = .appleNative
-    var display: DisplayInfo
+
+    private let lock = NSLock()
+    private var _display: DisplayInfo
+    var display: DisplayInfo {
+        get { lock.withLock { _display } }
+        set { lock.withLock { _display = newValue } }
+    }
 
     private let bridge: DisplayServicesBrightnessBridge
 
@@ -275,16 +289,18 @@ final class AppleNativeBrightnessBackend: DisplayBrightnessBackend, @unchecked S
         display: DisplayInfo,
         bridge: DisplayServicesBrightnessBridge
     ) {
-        self.display = display
+        self._display = display
         self.bridge = bridge
     }
 
     func readBrightness() throws -> Double {
-        try bridge.readBrightness(displayID: display.id)
+        let displayID = lock.withLock { _display.id }
+        return try bridge.readBrightness(displayID: displayID)
     }
 
     func writeBrightness(_ value: Double) throws {
-        try bridge.writeBrightness(value, displayID: display.id)
+        let displayID = lock.withLock { _display.id }
+        try bridge.writeBrightness(value, displayID: displayID)
     }
 
     func cleanup() {}
@@ -292,7 +308,13 @@ final class AppleNativeBrightnessBackend: DisplayBrightnessBackend, @unchecked S
 
 final class DDCBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendable {
     let kind: DisplayBrightnessBackendKind = .ddc
-    var display: DisplayInfo
+
+    private let lock = NSLock()
+    private var _display: DisplayInfo
+    var display: DisplayInfo {
+        get { lock.withLock { _display } }
+        set { lock.withLock { _display = newValue } }
+    }
 
     private let transport: any DDCBrightnessTransport
     private var maximumValue: UInt16
@@ -302,20 +324,24 @@ final class DDCBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendable 
             return nil
         }
 
-        self.display = display
+        self._display = display
         self.transport = transport
         self.maximumValue = (try? transport.readBrightness().maximum).flatMap(Self.validMaximum) ?? 100
     }
 
     func readBrightness() throws -> Double {
         let brightness = try transport.readBrightness()
-        maximumValue = Self.validMaximum(brightness.maximum) ?? maximumValue
-        return maximumValue == 0 ? 1 : Double(brightness.current) / Double(maximumValue)
+        return lock.withLock {
+            maximumValue = Self.validMaximum(brightness.maximum) ?? maximumValue
+            return maximumValue == 0 ? 1 : Double(brightness.current) / Double(maximumValue)
+        }
     }
 
     func writeBrightness(_ value: Double) throws {
         let clampedValue = max(0, min(value, 1))
-        let rawValue = UInt16((Double(maximumValue) * clampedValue).rounded())
+        let rawValue = lock.withLock {
+            UInt16((Double(maximumValue) * clampedValue).rounded())
+        }
         try transport.writeBrightness(rawValue)
     }
 
@@ -334,7 +360,13 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
     }
 
     let kind: DisplayBrightnessBackendKind = .gamma
-    var display: DisplayInfo
+
+    private let lock = NSLock()
+    private var _display: DisplayInfo
+    var display: DisplayInfo {
+        get { lock.withLock { _display } }
+        set { lock.withLock { _display = newValue } }
+    }
 
     private var originalTransferTable: TransferTable?
     private var currentBrightness = 1.0
@@ -344,22 +376,22 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
             return nil
         }
 
-        self.display = display
+        self._display = display
     }
 
     func readBrightness() throws -> Double {
-        currentBrightness
+        lock.withLock { currentBrightness }
     }
 
     func writeBrightness(_ value: Double) throws {
         let clampedValue = max(0, min(value, 1))
-        let transferTable = try loadOriginalTransferTableIfNeeded()
+        let (displayID, transferTable) = try loadOriginalTransferTableIfNeeded()
         let red = transferTable.red.map { $0 * Float(clampedValue) }
         let green = transferTable.green.map { $0 * Float(clampedValue) }
         let blue = transferTable.blue.map { $0 * Float(clampedValue) }
 
         let result = CGSetDisplayTransferByTable(
-            display.id,
+            displayID,
             UInt32(red.count),
             red,
             green,
@@ -370,34 +402,41 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
             throw DisplayBrightnessControllerError.failed(message: "软件亮度调节失败")
         }
 
-        currentBrightness = clampedValue
+        lock.withLock { currentBrightness = clampedValue }
     }
 
     func cleanup() {
-        guard let originalTransferTable else {
-            return
+        let snapshot: (id: CGDirectDisplayID, table: TransferTable)? = lock.withLock {
+            guard let originalTransferTable else { return nil }
+            return (_display.id, originalTransferTable)
         }
 
+        guard let snapshot else { return }
+
         _ = CGSetDisplayTransferByTable(
-            display.id,
-            UInt32(originalTransferTable.red.count),
-            originalTransferTable.red,
-            originalTransferTable.green,
-            originalTransferTable.blue
+            snapshot.id,
+            UInt32(snapshot.table.red.count),
+            snapshot.table.red,
+            snapshot.table.green,
+            snapshot.table.blue
         )
-        currentBrightness = 1
+        lock.withLock { currentBrightness = 1 }
     }
 
-    private func loadOriginalTransferTableIfNeeded() throws -> TransferTable {
-        if let originalTransferTable {
-            return originalTransferTable
+    private func loadOriginalTransferTableIfNeeded() throws -> (CGDirectDisplayID, TransferTable) {
+        let (displayID, displayName, cachedTable): (CGDirectDisplayID, String, TransferTable?) = lock.withLock {
+            (_display.id, _display.name, originalTransferTable)
+        }
+
+        if let cachedTable {
+            return (displayID, cachedTable)
         }
 
         var sampleCount: UInt32 = 0
-        let countResult = CGGetDisplayTransferByTable(display.id, 0, nil, nil, nil, &sampleCount)
+        let countResult = CGGetDisplayTransferByTable(displayID, 0, nil, nil, nil, &sampleCount)
 
         guard countResult == .success, sampleCount > 0 else {
-            throw DisplayBrightnessControllerError.brightnessUnavailable(displayName: display.name)
+            throw DisplayBrightnessControllerError.brightnessUnavailable(displayName: displayName)
         }
 
         let red = UnsafeMutablePointer<CGGammaValue>.allocate(capacity: Int(sampleCount))
@@ -410,7 +449,7 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
         }
 
         let readResult = CGGetDisplayTransferByTable(
-            display.id,
+            displayID,
             sampleCount,
             red,
             green,
@@ -419,7 +458,7 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
         )
 
         guard readResult == .success else {
-            throw DisplayBrightnessControllerError.brightnessUnavailable(displayName: display.name)
+            throw DisplayBrightnessControllerError.brightnessUnavailable(displayName: displayName)
         }
 
         let transferTable = TransferTable(
@@ -427,8 +466,8 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
             green: Array(UnsafeBufferPointer(start: green, count: Int(sampleCount))),
             blue: Array(UnsafeBufferPointer(start: blue, count: Int(sampleCount)))
         )
-        originalTransferTable = transferTable
-        return transferTable
+        lock.withLock { originalTransferTable = transferTable }
+        return (displayID, transferTable)
     }
 
     private static func canControl(displayID: CGDirectDisplayID) -> Bool {
@@ -440,7 +479,13 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
 
 final class ShadeBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendable {
     let kind: DisplayBrightnessBackendKind = .shade
-    var display: DisplayInfo
+
+    private let lock = NSLock()
+    private var _display: DisplayInfo
+    var display: DisplayInfo {
+        get { lock.withLock { _display } }
+        set { lock.withLock { _display = newValue } }
+    }
 
     private let overlayController = ShadeOverlayController()
     private var currentBrightness = 1.0
@@ -450,35 +495,39 @@ final class ShadeBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
             return nil
         }
 
-        self.display = display
+        self._display = display
     }
 
     func readBrightness() throws -> Double {
         refreshOverlayFrameIfNeeded()
-        return currentBrightness
+        return lock.withLock { currentBrightness }
     }
 
     func writeBrightness(_ value: Double) throws {
         let clampedValue = max(0, min(value, 1))
-        guard Self.screen(for: display.id) != nil else {
-            throw DisplayBrightnessControllerError.displayUnavailable(displayID: display.id)
+        let displayID = lock.withLock { _display.id }
+        guard Self.screen(for: displayID) != nil else {
+            throw DisplayBrightnessControllerError.displayUnavailable(displayID: displayID)
         }
 
         applyOverlay(brightness: clampedValue)
-        currentBrightness = clampedValue
+        lock.withLock { currentBrightness = clampedValue }
     }
 
     func cleanup() {
         hideOverlay()
-        currentBrightness = 1
+        lock.withLock { currentBrightness = 1 }
     }
 
     private func refreshOverlayFrameIfNeeded() {
-        guard currentBrightness < 0.999, Self.screen(for: display.id) != nil else {
+        let (displayID, brightness): (CGDirectDisplayID, Double) = lock.withLock {
+            (_display.id, currentBrightness)
+        }
+        guard brightness < 0.999, Self.screen(for: displayID) != nil else {
             return
         }
 
-        applyOverlay(brightness: currentBrightness)
+        applyOverlay(brightness: brightness)
     }
 
     private func applyOverlay(brightness: Double) {

--- a/Plugins/DisplayBrightness/Sources/DisplayBrightnessBackends.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayBrightnessBackends.swift
@@ -424,14 +424,30 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
     }
 
     private func loadOriginalTransferTableIfNeeded() throws -> (CGDirectDisplayID, TransferTable) {
-        let (displayID, displayName, cachedTable): (CGDirectDisplayID, String, TransferTable?) = lock.withLock {
-            (_display.id, _display.name, originalTransferTable)
-        }
+        // The first-time capture must be atomic w.r.t. concurrent writeBrightness()
+        // calls: if the read of the live LUT happened outside the lock, a racing
+        // writer could have already dimmed the display, and we'd cache that dimmed
+        // LUT as the "original" — cleanup() would then restore the wrong curve and
+        // never return the display to full brightness. Capture under the lock; it is
+        // a one-time cost (subsequent calls hit the cache and return immediately).
+        return try lock.withLock {
+            let displayID = _display.id
+            let displayName = _display.name
 
-        if let cachedTable {
-            return (displayID, cachedTable)
-        }
+            if let cachedTable = originalTransferTable {
+                return (displayID, cachedTable)
+            }
 
+            let transferTable = try Self.readTransferTable(displayID: displayID, displayName: displayName)
+            originalTransferTable = transferTable
+            return (displayID, transferTable)
+        }
+    }
+
+    private static func readTransferTable(
+        displayID: CGDirectDisplayID,
+        displayName: String
+    ) throws -> TransferTable {
         var sampleCount: UInt32 = 0
         let countResult = CGGetDisplayTransferByTable(displayID, 0, nil, nil, nil, &sampleCount)
 
@@ -461,13 +477,11 @@ final class GammaBrightnessBackend: DisplayBrightnessBackend, @unchecked Sendabl
             throw DisplayBrightnessControllerError.brightnessUnavailable(displayName: displayName)
         }
 
-        let transferTable = TransferTable(
+        return TransferTable(
             red: Array(UnsafeBufferPointer(start: red, count: Int(sampleCount))),
             green: Array(UnsafeBufferPointer(start: green, count: Int(sampleCount))),
             blue: Array(UnsafeBufferPointer(start: blue, count: Int(sampleCount)))
         )
-        lock.withLock { originalTransferTable = transferTable }
-        return (displayID, transferTable)
     }
 
     private static func canControl(displayID: CGDirectDisplayID) -> Bool {


### PR DESCRIPTION
## 问题
四个亮度 backend（`AppleNativeBrightnessBackend` / `DDCBrightnessBackend` / `GammaBrightnessBackend` / `ShadeBrightnessBackend`）的 `display` 属性和各自的内部缓存（`maximumValue` / `originalTransferTable` / `currentBrightness`）在无任何同步的情况下被多线程读写：

- 后台监控/刷新循环会读 `display` 并触发 `readBrightness()`；
- `updateDisplay()` 会写 `display`；
- 用户调节亮度走 `writeBrightness()`。

这些路径可能并发，存在**数据竞争**和对 `DisplayInfo` 结构体的**撕裂读**风险（`@unchecked Sendable` 等于把同步责任全交给了实现，但实现里没有同步）。

## 修复
每个 backend：
- 引入 `NSLock` 保护 `_display` 及内部缓存；`display` 改为 computed 属性，get/set 都经锁。新增 `NSLock.withLock` 私有 helper。
- **慢速 I/O 一律放在锁外**——锁内只快照 `displayID` 等少量字段。避免在持锁期间调用 DisplayServices / DDC transport / `CGGetDisplayTransferByTable` / overlay 应用，防止长时间持锁拖死其它线程。
- `GammaBrightnessBackend.loadOriginalTransferTableIfNeeded` 改为返回 `(CGDirectDisplayID, TransferTable)`：锁内取 id/name/已缓存表，锁外做 CG 读取，再锁内回存原始表。
- `ShadeBrightnessBackend.refreshOverlayFrameIfNeeded` 在锁外运行，锁内只读 id 与当前亮度。

行为不变，纯并发安全加固。

## 测试
- `DisplayBrightnessPlugin` target 编译通过。
- 全量套件本地通过：**699 passed / 0 failed**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved thread-safety across brightness controls to make brightness reads/writes and overlay handling more reliable.
  * Reduced race-condition related glitches and inconsistent brightness states, leading to smoother, more stable brightness adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->