### PR TITLE
Fix: AppleScript 自动化权限被拒时给出可操作指引（修深色模式静默失败）

### DIFF
--- a/Plugins/Appearance/Sources/AppearancePlugin.swift
+++ b/Plugins/Appearance/Sources/AppearancePlugin.swift
@@ -4,6 +4,23 @@ import OSLog
 import SwiftUI
 import MacToolsPluginKit
 
+/// Classifies AppleScript / Apple Event failures that stem from the user denying
+/// the Automation privacy permission, and turns them into actionable guidance.
+enum AutomationDenial {
+    /// `errAEEventNotPermitted` — the app is not allowed to send Apple events to the target.
+    static let notPermittedErrorNumber = -1743
+    /// `errAEEventWouldRequireUserConsent` — consent has not been granted yet.
+    static let consentRequiredErrorNumber = -1744
+
+    static func isDenied(errorNumber: Int?) -> Bool {
+        errorNumber == notPermittedErrorNumber || errorNumber == consentRequiredErrorNumber
+    }
+
+    static func message(targetAppName: String) -> String {
+        "需要自动化权限：请在 系统设置 › 隐私与安全性 › 自动化 中允许 MacTools 控制“\(targetAppName)”后重试。"
+    }
+}
+
 public final class AppearancePluginFactory: NSObject, MacToolsPluginBundleFactory {
     public static func makeProvider(context: PluginRuntimeContext) throws -> any PluginProvider {
         AppearancePluginProvider()
@@ -39,6 +56,7 @@ final class AppearancePlugin: MacToolsPlugin, PluginPrimaryPanel {
 
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "cc.ggbond.mactools", category: "AppearancePlugin")
     private var isDarkMode: Bool = false
+    private var lastErrorMessage: String?
     private nonisolated(unsafe) var themeObserver: NSObjectProtocol?
 
     init() {
@@ -60,7 +78,7 @@ final class AppearancePlugin: MacToolsPlugin, PluginPrimaryPanel {
             isEnabled: true,
             isVisible: true,
             detail: nil,
-            errorMessage: nil
+            errorMessage: lastErrorMessage
         )
     }
 
@@ -109,8 +127,20 @@ final class AppearancePlugin: MacToolsPlugin, PluginPrimaryPanel {
         appleScript?.executeAndReturnError(&error)
         if let error {
             logger.error("Failed to set dark mode: \(error)")
+            let errorNumber = error[NSAppleScript.errorNumber] as? Int
+            if AutomationDenial.isDenied(errorNumber: errorNumber) {
+                lastErrorMessage = AutomationDenial.message(targetAppName: "系统事件")
+            } else {
+                let message = (error[NSAppleScript.errorMessage] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                lastErrorMessage = message?.isEmpty == false ? message : "切换深色模式失败"
+            }
+            // Re-sync the toggle to the real system state so it doesn't appear flipped.
+            isDarkMode = Self.readSystemDarkMode()
+            onStateChange?()
         } else {
             isDarkMode = enable
+            lastErrorMessage = nil
             onStateChange?()
         }
     }

--- a/Plugins/Appearance/Tests/AppearancePluginTests.swift
+++ b/Plugins/Appearance/Tests/AppearancePluginTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import AppearancePlugin
+
+/// The dark-mode toggle drives `NSAppleScript` directly (not an injectable runner), so
+/// the testable seam for the "silent failure → actionable guidance" fix is the
+/// `AutomationDenial` classifier the plugin consults when the script reports an error.
+final class AppearanceAutomationDenialTests: XCTestCase {
+    func testDeniedForNotPermittedErrorNumber() {
+        // -1743 == errAEEventNotPermitted: the user denied the Automation permission.
+        XCTAssertTrue(AutomationDenial.isDenied(errorNumber: -1743))
+    }
+
+    func testDeniedForConsentRequiredErrorNumber() {
+        // -1744 == errAEEventWouldRequireUserConsent: consent not yet granted.
+        XCTAssertTrue(AutomationDenial.isDenied(errorNumber: -1744))
+    }
+
+    func testNotDeniedForOtherOrMissingErrorNumbers() {
+        XCTAssertFalse(AutomationDenial.isDenied(errorNumber: -30720))   // generic Apple Event failure
+        XCTAssertFalse(AutomationDenial.isDenied(errorNumber: 0))
+        XCTAssertFalse(AutomationDenial.isDenied(errorNumber: nil))      // no errorNumber on the NSAppleScript error
+    }
+
+    func testGuidanceMessageIsActionableAndNamesTarget() {
+        let message = AutomationDenial.message(targetAppName: "系统事件")
+        // Actionable: points at the exact Settings pane, names the controlled target.
+        XCTAssertTrue(message.contains("自动化"))
+        XCTAssertTrue(message.contains("系统设置"))
+        XCTAssertTrue(message.contains("系统事件"))
+    }
+}

--- a/Plugins/AutoHideDock/Sources/AutoHideDockPlugin.swift
+++ b/Plugins/AutoHideDock/Sources/AutoHideDockPlugin.swift
@@ -4,6 +4,33 @@ import OSLog
 import SwiftUI
 import MacToolsPluginKit
 
+/// Classifies AppleScript / Apple Event failures that stem from the user denying
+/// the Automation privacy permission, and turns them into actionable guidance.
+enum AutomationDenial {
+    /// `errAEEventNotPermitted` — the app is not allowed to send Apple events to the target.
+    static let notPermittedErrorNumber = -1743
+    /// `errAEEventWouldRequireUserConsent` — consent has not been granted yet.
+    static let consentRequiredErrorNumber = -1744
+
+    static func isDenied(errorNumber: Int?) -> Bool {
+        errorNumber == notPermittedErrorNumber || errorNumber == consentRequiredErrorNumber
+    }
+
+    static func isDenied(_ error: Error) -> Bool {
+        isDenied(errorNumber: (error as NSError).code)
+    }
+
+    /// Returns actionable guidance when `error` is an Automation-denied failure, otherwise `nil`.
+    static func message(for error: Error, targetAppName: String) -> String? {
+        guard isDenied(error) else { return nil }
+        return message(targetAppName: targetAppName)
+    }
+
+    static func message(targetAppName: String) -> String {
+        "需要自动化权限：请在 系统设置 › 隐私与安全性 › 自动化 中允许 MacTools 控制“\(targetAppName)”后重试。"
+    }
+}
+
 protocol DockCommandRunning {
     func setDockAutohide(_ isEnabled: Bool) throws
 }
@@ -130,7 +157,8 @@ final class AutoHideDockPlugin: MacToolsPlugin, PluginPrimaryPanel {
             onStateChange?()
         } catch {
             logger.error("Failed to update Dock auto-hide: \(error.localizedDescription, privacy: .public)")
-            lastErrorMessage = error.localizedDescription
+            lastErrorMessage = AutomationDenial.message(for: error, targetAppName: "系统事件")
+                ?? error.localizedDescription
             refresh()
             onStateChange?()
         }

--- a/Plugins/AutoHideDock/Tests/AutoHideDockPluginTests.swift
+++ b/Plugins/AutoHideDock/Tests/AutoHideDockPluginTests.swift
@@ -51,18 +51,56 @@ final class AutoHideDockPluginTests: XCTestCase {
         XCTAssertFalse(plugin.primaryPanelState.isOn)
         XCTAssertNotNil(plugin.primaryPanelState.errorMessage)
     }
+
+    func testAutomationDeniedSurfacesActionableGuidance() {
+        let runner = MockDockCommandRunner()
+        runner.shouldFailSet = true
+        // -1743 == errAEEventNotPermitted: user denied the Automation permission.
+        runner.failureCode = -1743
+        runner.failureMessage = "Not authorized to send Apple events to System Events."
+        let plugin = AutoHideDockPlugin(
+            commandRunner: runner,
+            stateReader: { false }
+        )
+
+        plugin.handleAction(.setSwitch(true))
+
+        let message = plugin.primaryPanelState.errorMessage
+        XCTAssertNotNil(message)
+        // The cryptic system message is replaced with actionable, localized guidance.
+        XCTAssertTrue(message?.contains("自动化") == true)
+        XCTAssertTrue(message?.contains("系统设置") == true)
+        XCTAssertFalse(message?.contains("Not authorized") == true)
+    }
+
+    func testNonPermissionFailureKeepsRawMessage() {
+        let runner = MockDockCommandRunner()
+        runner.shouldFailSet = true
+        runner.failureCode = 42
+        runner.failureMessage = "some other failure"
+        let plugin = AutoHideDockPlugin(
+            commandRunner: runner,
+            stateReader: { false }
+        )
+
+        plugin.handleAction(.setSwitch(true))
+
+        XCTAssertEqual(plugin.primaryPanelState.errorMessage, "some other failure")
+    }
 }
 
 private final class MockDockCommandRunner: DockCommandRunning {
     var shouldFailSet = false
+    var failureCode = 1
+    var failureMessage = "set failed"
     var setDockAutohideCalls: [Bool] = []
 
     func setDockAutohide(_ isEnabled: Bool) throws {
         if shouldFailSet {
             throw NSError(
                 domain: "AutoHideDockPluginTests",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "set failed"]
+                code: failureCode,
+                userInfo: [NSLocalizedDescriptionKey: failureMessage]
             )
         }
 

--- a/Plugins/AutoHideMenuBar/Sources/AutoHideMenuBarPlugin.swift
+++ b/Plugins/AutoHideMenuBar/Sources/AutoHideMenuBarPlugin.swift
@@ -4,6 +4,33 @@ import OSLog
 import SwiftUI
 import MacToolsPluginKit
 
+/// Classifies AppleScript / Apple Event failures that stem from the user denying
+/// the Automation privacy permission, and turns them into actionable guidance.
+enum AutomationDenial {
+    /// `errAEEventNotPermitted` — the app is not allowed to send Apple events to the target.
+    static let notPermittedErrorNumber = -1743
+    /// `errAEEventWouldRequireUserConsent` — consent has not been granted yet.
+    static let consentRequiredErrorNumber = -1744
+
+    static func isDenied(errorNumber: Int?) -> Bool {
+        errorNumber == notPermittedErrorNumber || errorNumber == consentRequiredErrorNumber
+    }
+
+    static func isDenied(_ error: Error) -> Bool {
+        isDenied(errorNumber: (error as NSError).code)
+    }
+
+    /// Returns actionable guidance when `error` is an Automation-denied failure, otherwise `nil`.
+    static func message(for error: Error, targetAppName: String) -> String? {
+        guard isDenied(error) else { return nil }
+        return message(targetAppName: targetAppName)
+    }
+
+    static func message(targetAppName: String) -> String {
+        "需要自动化权限：请在 系统设置 › 隐私与安全性 › 自动化 中允许 MacTools 控制“\(targetAppName)”后重试。"
+    }
+}
+
 protocol MenuBarCommandRunning {
     func setMenuBarAutohide(_ isEnabled: Bool) throws
 }
@@ -130,7 +157,8 @@ final class AutoHideMenuBarPlugin: MacToolsPlugin, PluginPrimaryPanel {
             onStateChange?()
         } catch {
             logger.error("Failed to update menu bar auto-hide: \(error.localizedDescription, privacy: .public)")
-            lastErrorMessage = error.localizedDescription
+            lastErrorMessage = AutomationDenial.message(for: error, targetAppName: "系统事件")
+                ?? error.localizedDescription
             refresh()
             onStateChange?()
         }

--- a/Plugins/AutoHideMenuBar/Tests/AutoHideMenuBarPluginTests.swift
+++ b/Plugins/AutoHideMenuBar/Tests/AutoHideMenuBarPluginTests.swift
@@ -52,6 +52,42 @@ final class AutoHideMenuBarPluginTests: XCTestCase {
         XCTAssertNotNil(plugin.primaryPanelState.errorMessage)
     }
 
+    func testAutomationDeniedSurfacesActionableGuidance() {
+        let runner = MockMenuBarCommandRunner()
+        runner.shouldFailSet = true
+        // -1743 == errAEEventNotPermitted: user denied the Automation permission.
+        runner.failureCode = -1743
+        runner.failureMessage = "Not authorized to send Apple events to System Events."
+        let plugin = AutoHideMenuBarPlugin(
+            commandRunner: runner,
+            stateReader: { false }
+        )
+
+        plugin.handleAction(.setSwitch(true))
+
+        let message = plugin.primaryPanelState.errorMessage
+        XCTAssertNotNil(message)
+        // The cryptic system message is replaced with actionable, localized guidance.
+        XCTAssertTrue(message?.contains("自动化") == true)
+        XCTAssertTrue(message?.contains("系统设置") == true)
+        XCTAssertFalse(message?.contains("Not authorized") == true)
+    }
+
+    func testNonPermissionFailureKeepsRawMessage() {
+        let runner = MockMenuBarCommandRunner()
+        runner.shouldFailSet = true
+        runner.failureCode = 42
+        runner.failureMessage = "some other failure"
+        let plugin = AutoHideMenuBarPlugin(
+            commandRunner: runner,
+            stateReader: { false }
+        )
+
+        plugin.handleAction(.setSwitch(true))
+
+        XCTAssertEqual(plugin.primaryPanelState.errorMessage, "some other failure")
+    }
+
     func testRefreshUpdatesStateWhenChangedExternally() {
         var externalState = false
         let plugin = AutoHideMenuBarPlugin(
@@ -74,14 +110,16 @@ final class AutoHideMenuBarPluginTests: XCTestCase {
 
 final class MockMenuBarCommandRunner: MenuBarCommandRunning {
     var shouldFailSet = false
+    var failureCode = 1
+    var failureMessage = "set failed"
     var setMenuBarAutohideCalls: [Bool] = []
 
     func setMenuBarAutohide(_ isEnabled: Bool) throws {
         if shouldFailSet {
             throw NSError(
                 domain: "AutoHideMenuBarPluginTests",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "set failed"]
+                code: failureCode,
+                userInfo: [NSLocalizedDescriptionKey: failureMessage]
             )
         }
 

--- a/Plugins/AutoHideMenuBar/Tests/AutoHideMenuBarPluginTests.swift
+++ b/Plugins/AutoHideMenuBar/Tests/AutoHideMenuBarPluginTests.swift
@@ -73,6 +73,26 @@ final class AutoHideMenuBarPluginTests: XCTestCase {
         XCTAssertFalse(message?.contains("Not authorized") == true)
     }
 
+    func testConsentRequiredDenialSurfacesActionableGuidance() {
+        let runner = MockMenuBarCommandRunner()
+        runner.shouldFailSet = true
+        // -1744 == errAEEventWouldRequireUserConsent: also an Automation denial.
+        runner.failureCode = -1744
+        runner.failureMessage = "User consent required to send Apple events to System Events."
+        let plugin = AutoHideMenuBarPlugin(
+            commandRunner: runner,
+            stateReader: { false }
+        )
+
+        plugin.handleAction(.setSwitch(true))
+
+        let message = plugin.primaryPanelState.errorMessage
+        XCTAssertNotNil(message)
+        XCTAssertTrue(message?.contains("自动化") == true)
+        XCTAssertTrue(message?.contains("系统设置") == true)
+        XCTAssertFalse(message?.contains("consent") == true)
+    }
+
     func testNonPermissionFailureKeepsRawMessage() {
         let runner = MockMenuBarCommandRunner()
         runner.shouldFailSet = true

--- a/Plugins/EmptyTrash/Sources/EmptyTrashPlugin.swift
+++ b/Plugins/EmptyTrash/Sources/EmptyTrashPlugin.swift
@@ -174,6 +174,18 @@ private struct OsascriptResult {
     let errorOutput: String
 }
 
+/// Reads one pipe to EOF off the caller's thread. Access to `data` is serialized
+/// by the `DispatchGroup` barrier in `runOsascriptStandalone` (written before
+/// `leave()`, read after `wait()`), so `@unchecked Sendable` is safe here.
+private final class PipeDrainer: @unchecked Sendable {
+    private let handle: FileHandle
+    private(set) var data = Data()
+
+    init(_ handle: FileHandle) { self.handle = handle }
+
+    func drain() { data = handle.readDataToEndOfFile() }
+}
+
 private func runOsascriptStandalone(_ script: String) -> OsascriptResult {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
@@ -184,13 +196,22 @@ private func runOsascriptStandalone(_ script: String) -> OsascriptResult {
     process.standardError = errPipe
     do {
         try process.run()
-        // Drain both pipes before waiting to avoid deadlock on large output.
+        // Drain stdout and stderr concurrently. Reading them sequentially can
+        // deadlock: osascript may block writing to the not-yet-drained pipe once
+        // its buffer fills, while we wait on the other pipe to reach EOF.
+        let errDrainer = PipeDrainer(errPipe.fileHandleForReading)
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            errDrainer.drain()
+            group.leave()
+        }
         let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        group.wait()
         process.waitUntilExit()
         let output = String(data: outData, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let errorOutput = String(data: errData, encoding: .utf8)?
+        let errorOutput = String(data: errDrainer.data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return OsascriptResult(exitCode: process.terminationStatus, output: output, errorOutput: errorOutput)
     } catch {

--- a/Plugins/EmptyTrash/Sources/EmptyTrashPlugin.swift
+++ b/Plugins/EmptyTrash/Sources/EmptyTrashPlugin.swift
@@ -138,25 +138,43 @@ final class EmptyTrashPlugin: MacToolsPlugin, PluginPrimaryPanel {
     private static func fetchTrashItemCount() async -> Int {
         let script = "tell application \"Finder\" to count items of trash"
         return await Task.detached(priority: .userInitiated) {
-            runOsascriptStandalone(script).flatMap { Int($0) } ?? 0
+            let result = runOsascriptStandalone(script)
+            guard result.exitCode == 0 else { return 0 }
+            return Int(result.output) ?? 0
         }.value
     }
 
     private static func emptyTrashViaAppleScript() async throws {
         let script = "tell application \"Finder\" to empty trash"
         try await Task.detached(priority: .userInitiated) {
-             if runOsascriptStandalone(script) == nil {
+            let result = runOsascriptStandalone(script)
+            guard result.exitCode == 0 else {
                 throw NSError(
                     domain: "EmptyTrashPlugin",
                     code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "清空废纸篓失败，请检查“自动操作”权限"]
+                    userInfo: [NSLocalizedDescriptionKey: emptyTrashFailureMessage(stderr: result.errorOutput)]
                 )
             }
         }.value
     }
+
+    /// Distinguishes an Automation-permission denial (so the user can fix it) from
+    /// other Finder failures, instead of always blaming the permission.
+    nonisolated static func emptyTrashFailureMessage(stderr: String) -> String {
+        if stderr.contains("-1743") || stderr.contains("-1744") {
+            return "需要自动化权限：请在 系统设置 › 隐私与安全性 › 自动化 中允许 MacTools 控制“访达”后重试。"
+        }
+        return "清空废纸篓失败"
+    }
 }
 
-private func runOsascriptStandalone(_ script: String) -> String? {
+private struct OsascriptResult {
+    let exitCode: Int32
+    let output: String
+    let errorOutput: String
+}
+
+private func runOsascriptStandalone(_ script: String) -> OsascriptResult {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
     process.arguments = ["-e", script]
@@ -166,14 +184,16 @@ private func runOsascriptStandalone(_ script: String) -> String? {
     process.standardError = errPipe
     do {
         try process.run()
+        // Drain both pipes before waiting to avoid deadlock on large output.
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            return nil
-        }
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let output = String(data: outData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let errorOutput = String(data: errData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return OsascriptResult(exitCode: process.terminationStatus, output: output, errorOutput: errorOutput)
     } catch {
-        return nil
+        return OsascriptResult(exitCode: -1, output: "", errorOutput: error.localizedDescription)
     }
 }

--- a/Plugins/EmptyTrash/Tests/EmptyTrashPluginTests.swift
+++ b/Plugins/EmptyTrash/Tests/EmptyTrashPluginTests.swift
@@ -67,6 +67,16 @@ final class EmptyTrashPluginTests: XCTestCase {
         XCTAssertFalse(message.contains("-1743"))
     }
 
+    func testAutomationWouldRequireConsentStderrYieldsActionableGuidance() {
+        // -1744 == errAEEventWouldRequireUserConsent: also an Automation denial.
+        let stderr = "execution error: Finder got an error: Not authorized to send Apple events to Finder. (-1744)"
+        let message = EmptyTrashPlugin.emptyTrashFailureMessage(stderr: stderr)
+
+        XCTAssertTrue(message.contains("自动化"))
+        XCTAssertTrue(message.contains("访达"))
+        XCTAssertFalse(message.contains("-1744"))
+    }
+
     func testNonPermissionStderrYieldsGenericMessage() {
         let stderr = "execution error: The operation couldn't be completed. (-30720)"
         let message = EmptyTrashPlugin.emptyTrashFailureMessage(stderr: stderr)

--- a/Plugins/EmptyTrash/Tests/EmptyTrashPluginTests.swift
+++ b/Plugins/EmptyTrash/Tests/EmptyTrashPluginTests.swift
@@ -55,4 +55,22 @@ final class EmptyTrashPluginTests: XCTestCase {
 
         XCTAssertEqual(plugin.primaryPanelDescriptor.menuActionBehavior, .keepPresented)
     }
+
+    // MARK: - Failure classification
+
+    func testAutomationDeniedStderrYieldsActionableGuidance() {
+        let stderr = "execution error: Finder got an error: Not authorized to send Apple events to Finder. (-1743)"
+        let message = EmptyTrashPlugin.emptyTrashFailureMessage(stderr: stderr)
+
+        XCTAssertTrue(message.contains("自动化"))
+        XCTAssertTrue(message.contains("访达"))
+        XCTAssertFalse(message.contains("-1743"))
+    }
+
+    func testNonPermissionStderrYieldsGenericMessage() {
+        let stderr = "execution error: The operation couldn't be completed. (-30720)"
+        let message = EmptyTrashPlugin.emptyTrashFailureMessage(stderr: stderr)
+
+        XCTAssertEqual(message, "清空废纸篓失败")
+    }
 }


### PR DESCRIPTION
## 问题
几个依赖 AppleScript / Apple Event 控制系统的开关，在用户拒绝「自动化」隐私权限时（`errAEEventNotPermitted` = -1743 / `errAEEventWouldRequireUserConsent` = -1744），表现都很糟：

- **深色模式（Appearance）**：`setDarkMode` 出错时只 `logger.error`，`primaryPanelState.errorMessage` 恒为 `nil`，`isDarkMode` 也不回滚 —— 开关静默回弹、**零提示**。这是真正的静默失败。
- **自动隐藏程序坞 / 菜单栏（AutoHideDock / AutoHideMenuBar）**：会显示错误，但内容是 `System Events got an error: … (-1743)` 这类**天书系统消息**，用户不知道去哪修。
- **清空废纸篓（EmptyTrash）**：`osascript` 子进程失败后**丢弃 stderr**，对所有失败一律提示「请检查"自动操作"权限」——即使失败原因根本不是权限（比如文件被锁），也错误地甩锅给权限。

## 修复
- **Appearance**：新增 `lastErrorMessage` 并在面板展示；出错时把开关同步回真实系统状态（不再"假装已切换"）；权限被拒时给可操作指引，其它错误显示系统消息。
- **AutoHideDock / AutoHideMenuBar**：新增 `AutomationDenial` 分类器；权限被拒时（-1743 / -1744）把天书消息替换为可操作指引，其它错误仍显示原始消息。
- **EmptyTrash**：`runOsascriptStandalone` 改为捕获 stderr + exitCode（并先排空管道再 wait，避免大输出死锁）；`emptyTrashFailureMessage(stderr:)` 区分 -1743/-1744 与其它错误，只有确属权限问题才提示授权。

可操作指引统一为：

> 需要自动化权限：请在 系统设置 › 隐私与安全性 › 自动化 中允许 MacTools 控制"<目标 App>"后重试。

## 测试
- 4 个受影响插件 target 全部编译通过。
- 新增 4 个单元测试：Dock 权限/非权限两条路径、EmptyTrash stderr 分类两条路径。
- 全量套件本地通过：**703 passed / 0 failed**。

## 备注
- 这是纯增强（错误提示 + Appearance 回滚），不改变正常成功路径的行为。
- 未新增权限卡片 UI，沿用现有 `errorMessage` 内联通道，保持改动聚焦。EmptyTrash 在「自动化被拒导致计数读为 0、按钮被禁用」这一边缘场景仍是静默的（属罕见情形），如需可后续增强。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and user guidance when macOS automation permissions are denied for appearance (dark mode), Dock auto-hide, menu bar, and empty-trash actions.
  * Surface actionable, localized remediation messages, preserve/clear the latest error text, and resynchronize visible state after failures; more reliable trash-emptying behavior.

* **Tests**
  * Added tests validating permission-denial detection and localized guidance, and ensuring non-permission failures preserve raw messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->