### PR TITLE
Fix: ActivityBar 授予输入监控权限后无需重启即恢复统计

### DIFF
--- a/Plugins/ActivityBar/Sources/ActivityBarController.swift
+++ b/Plugins/ActivityBar/Sources/ActivityBarController.swift
@@ -131,6 +131,12 @@ final class ActivityBarController: ObservableObject {
     }
 
     func refresh() {
+        // Recover input monitoring if the user granted the permission after the
+        // tap was first denied — refresh() runs on panel appear, so the feature
+        // starts working without requiring a tracking toggle or app restart.
+        if isTrackingEnabled {
+            inputMonitor.retryEventTapIfDenied()
+        }
         codingStats.flushActiveDurations()
         notifyChange()
     }

--- a/Plugins/ActivityBar/Sources/ActivityBarInputMonitor.swift
+++ b/Plugins/ActivityBar/Sources/ActivityBarInputMonitor.swift
@@ -9,6 +9,9 @@ protocol ActivityBarInputMonitoring: AnyObject {
 
     func start()
     func stop()
+    /// Re-attempt only the event tap if a prior `start()` was denied Input
+    /// Monitoring permission. Safe to call repeatedly; no-op unless denied.
+    func retryEventTapIfDenied()
 }
 
 @MainActor
@@ -37,6 +40,16 @@ final class ActivityBarInputMonitor: ActivityBarInputMonitoring {
         }
 
         startScreenTimeTracking()
+        startEventTap()
+    }
+
+    /// Re-attempt only the event tap after an earlier denial. Screen-time
+    /// tracking already started during `start()`, so we must NOT re-run
+    /// `startScreenTimeTracking()` here — doing so would leak the existing
+    /// timer/workspace observer. Granting the permission then re-opening the
+    /// panel (which calls `refresh()`) now recovers without a restart.
+    func retryEventTapIfDenied() {
+        guard status == .inputMonitoringDenied else { return }
         startEventTap()
     }
 

--- a/Plugins/ActivityBar/Tests/ActivityBarPluginTests.swift
+++ b/Plugins/ActivityBar/Tests/ActivityBarPluginTests.swift
@@ -52,6 +52,32 @@ final class ActivityBarPluginTests: XCTestCase {
         XCTAssertEqual(harness.controller.todayInputStats.totalInputs, 0)
     }
 
+    func testRefreshRetriesEventTapAfterPermissionGranted() {
+        let harness = makeHarness()
+        harness.plugin.handleAction(.setSwitch(true)) // tracking on
+
+        // Simulate the tap having been denied Input Monitoring on first start,
+        // then the user granting the permission in System Settings.
+        harness.inputMonitor.status = .inputMonitoringDenied
+        harness.inputMonitor.statusAfterRetry = .running
+
+        // A panel appear / refresh must re-attempt the tap and recover.
+        harness.plugin.refresh()
+
+        XCTAssertGreaterThanOrEqual(harness.inputMonitor.retryCallCount, 1)
+        XCTAssertEqual(harness.controller.monitorStatus, .running)
+    }
+
+    func testRefreshDoesNotRetryWhenTrackingDisabled() {
+        let harness = makeHarness()
+        // Tracking is off by default; a denied tap should not be retried.
+        harness.inputMonitor.status = .inputMonitoringDenied
+
+        harness.plugin.refresh()
+
+        XCTAssertEqual(harness.inputMonitor.retryCallCount, 0)
+    }
+
     private func makeHarness() -> Harness {
         let storage = ActivityBarMemoryStorage()
         let inputMonitor = ActivityBarFakeInputMonitor()

--- a/Plugins/ActivityBar/Tests/ActivityBarTestSupport.swift
+++ b/Plugins/ActivityBar/Tests/ActivityBarTestSupport.swift
@@ -54,6 +54,10 @@ final class ActivityBarFakeInputMonitor: ActivityBarInputMonitoring {
     var onEvent: ((ActivityBarInputEvent) -> Void)?
     private(set) var startCallCount = 0
     private(set) var stopCallCount = 0
+    private(set) var retryCallCount = 0
+    /// When set, a retry while denied transitions the status to this value,
+    /// simulating the user granting the permission between attempts.
+    var statusAfterRetry: ActivityBarInputMonitorStatus?
 
     func start() {
         startCallCount += 1
@@ -63,6 +67,14 @@ final class ActivityBarFakeInputMonitor: ActivityBarInputMonitoring {
     func stop() {
         stopCallCount += 1
         status = .idle
+    }
+
+    func retryEventTapIfDenied() {
+        retryCallCount += 1
+        guard status == .inputMonitoringDenied else { return }
+        if let statusAfterRetry {
+            status = statusAfterRetry
+        }
     }
 
     func emit(_ event: ActivityBarInputEvent) {


### PR DESCRIPTION
## 问题
输入监控（Input Monitoring）权限在首次创建 `CGEvent` tap 时若被拒，`ActivityBarInputMonitor.startEventTap()` 会把 `status` 置为 `.inputMonitoringDenied` 后返回，键盘/鼠标/滚动统计失效（屏幕时间仍可记录）。

用户随后到 系统设置 › 隐私与安全性 › 输入监控 授予权限——但 `ActivityBarController.refresh()`（面板出现时 `onAppear` 调用）**并不会重建 tap**。统计会一直坏到用户手动关开 tracking 开关或重启 App。footnote 提示「请在系统设置中允许输入监控」却无法在授权后自动恢复，体验上像是 bug。

## 为什么不能直接在 refresh 里重调 start()
`start()` 会先跑 `startScreenTimeTracking()`（创建 `Timer` + workspace observer）再建 tap。denied 时屏幕时间追踪其实**已经在跑**，再调一次 `start()` 会覆盖并泄漏旧的 `Timer`/observer。

## 修复
- `ActivityBarInputMonitoring` 协议新增 `retryEventTapIfDenied()`。
- 实现：仅当 `status == .inputMonitoringDenied` 时重试 `startEventTap()`，**不**重跑屏幕时间追踪。
- `ActivityBarController.refresh()` 在 `isTrackingEnabled` 时调用它——面板出现即重试，授权后自动恢复，无需重启或关开。

## 测试
- 新增 `testRefreshRetriesEventTapAfterPermissionGranted`（模拟 denied→授权→refresh 后转 running）。
- 新增 `testRefreshDoesNotRetryWhenTrackingDisabled`（tracking 关闭时不重试）。
- 全量套件本地通过：**701 passed / 0 failed**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Input monitoring now automatically recovers when permission is granted after being previously denied, eliminating the need to manually toggle tracking or restart the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->