### PR TITLE
Fix: AppHotkey 热键注册失败时向用户提示（不再静默吞掉）

### DIFF
--- a/Plugins/AppHotkey/Sources/AppHotkeyManager.swift
+++ b/Plugins/AppHotkey/Sources/AppHotkeyManager.swift
@@ -18,12 +18,31 @@ final class AppHotkeyManager {
 
     var onTrigger: ((UUID) -> Void)?
 
+    /// Performs the actual Carbon registration. Returns the hot-key reference on
+    /// success, or `nil` if registration failed (e.g. the combo is already taken
+    /// by another app — `eventHotKeyExistsErr`). Injectable for testing.
+    typealias Registrar = (_ keyCode: UInt32, _ modifiers: UInt32, _ hotKeyID: EventHotKeyID) -> EventHotKeyRef?
+
+    /// Entry IDs whose shortcut could not be registered on the last `sync`.
+    private(set) var failedEntryIDs: Set<UUID> = []
+
+    private let registrar: Registrar
     private var handlerRef: EventHandlerRef?
     private var registeredHotKeys: [UUID: RegisteredHotKey] = [:]
     private var idsByCarbon: [UInt32: UUID] = [:]
     private var nextCarbonID: UInt32 = 1
 
-    init() {
+    init(registrar: Registrar? = nil) {
+        self.registrar = registrar ?? { keyCode, modifiers, hotKeyID in
+            var ref: EventHotKeyRef?
+            // 与 installHandler 一致用事件分发目标：全局热键不会路由到
+            // GetApplicationEventTarget()，否则注册成功却从不触发（main 的路由修复）。
+            let status = RegisterEventHotKey(
+                keyCode, modifiers, hotKeyID, GetEventDispatcherTarget(), 0, &ref
+            )
+            guard status == noErr, let ref else { return nil }
+            return ref
+        }
         installHandler()
     }
 
@@ -42,15 +61,20 @@ final class AppHotkeyManager {
         }
 
         // 新增或更新
+        var failures: Set<UUID> = []
         for (id, binding) in desired {
             if let existing = registeredHotKeys[id], existing.binding == binding { continue }
             unregister(id: id)
-            register(id: id, binding: binding)
+            if !register(id: id, binding: binding) {
+                failures.insert(id)
+            }
         }
+        failedEntryIDs = failures
     }
 
     func unregisterAll() {
         for id in Array(registeredHotKeys.keys) { unregister(id: id) }
+        failedEntryIDs = []
     }
 
     /// 录制期间临时注销指定条目的热键，录制结束后由调用方调用 `sync` 恢复。
@@ -77,26 +101,26 @@ final class AppHotkeyManager {
         )
     }
 
-    private func register(id: UUID, binding: ShortcutBinding) {
-        var ref: EventHotKeyRef?
+    /// Returns `true` on success, `false` if the OS rejected the registration.
+    @discardableResult
+    private func register(id: UUID, binding: ShortcutBinding) -> Bool {
         let cid = nextCarbonID
         nextCarbonID += 1
 
         let hotKeyID = EventHotKeyID(signature: Self.signature, id: cid)
-        let status = RegisterEventHotKey(
+        guard let ref = registrar(
             UInt32(binding.keyCode),
             binding.modifiers.carbonFlags,
-            hotKeyID,
-            GetEventDispatcherTarget(),
-            0,
-            &ref
-        )
-        guard status == noErr, let ref else { return }
+            hotKeyID
+        ) else {
+            return false
+        }
 
         registeredHotKeys[id] = RegisteredHotKey(
             entryID: id, binding: binding, reference: ref, carbonID: cid
         )
         idsByCarbon[cid] = id
+        return true
     }
 
     private func unregister(id: UUID) {

--- a/Plugins/AppHotkey/Sources/AppHotkeyPlugin.swift
+++ b/Plugins/AppHotkey/Sources/AppHotkeyPlugin.swift
@@ -52,13 +52,17 @@ final class AppHotkeyPlugin: MacToolsPlugin, PluginPrimaryPanel {
     private let hotkeyManager: AppHotkeyManager
     private let storage: PluginStorage
     private var isEnabled: Bool
+    private var registrationErrorMessage: String?
 
     // MARK: Init
 
-    init(context: PluginRuntimeContext = PluginRuntimeContext(pluginID: "app-hotkey")) {
+    init(
+        context: PluginRuntimeContext = PluginRuntimeContext(pluginID: "app-hotkey"),
+        hotkeyManager: AppHotkeyManager = AppHotkeyManager()
+    ) {
         self.storage = context.storage
         self.store = AppHotkeyStore(storage: context.storage)
-        self.hotkeyManager = AppHotkeyManager()
+        self.hotkeyManager = hotkeyManager
         // 默认启用；仅当用户明确关闭后才存储 false
         self.isEnabled = context.storage.object(forKey: "isEnabled") == nil
             ? true
@@ -116,7 +120,7 @@ final class AppHotkeyPlugin: MacToolsPlugin, PluginPrimaryPanel {
             isEnabled: true,
             isVisible: true,
             detail: nil,
-            errorMessage: nil
+            errorMessage: registrationErrorMessage
         )
     }
 
@@ -142,6 +146,24 @@ final class AppHotkeyPlugin: MacToolsPlugin, PluginPrimaryPanel {
 
     private func syncHotkeys() {
         hotkeyManager.sync(entries: isEnabled ? store.entries : [])
+        updateRegistrationError()
+    }
+
+    /// Surface hot-keys that the OS refused to register (most often because the
+    /// combo is already claimed by another app) so the user isn't left wondering
+    /// why a shortcut silently does nothing.
+    private func updateRegistrationError() {
+        let failedIDs = hotkeyManager.failedEntryIDs
+        guard !failedIDs.isEmpty else {
+            registrationErrorMessage = nil
+            return
+        }
+
+        let names = store.entries
+            .filter { failedIDs.contains($0.id) }
+            .map(\.displayName)
+        let joined = names.isEmpty ? "" : "：\(names.joined(separator: "、"))"
+        registrationErrorMessage = "\(failedIDs.count) 个快捷键注册失败\(joined)，可能已被其它应用占用"
     }
 
     /// 按下快捷键时：若目标应用在前台则隐藏，否则打开/激活。

--- a/Plugins/AppHotkey/Tests/AppHotkeyStoreTests.swift
+++ b/Plugins/AppHotkey/Tests/AppHotkeyStoreTests.swift
@@ -430,3 +430,71 @@ fileprivate final class InMemoryPluginStorage: PluginStorage {
     func removeObject(forKey key: String) { store.removeValue(forKey: key) }
     func migrateValueIfNeeded(fromLegacyKey: String, to key: String) {}
 }
+
+// MARK: - Registration Failure Surfacing
+
+@MainActor
+final class AppHotkeyRegistrationFailureTests: XCTestCase {
+
+    private func entry(_ name: String) -> AppShortcutEntry {
+        AppShortcutEntry(
+            bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
+            displayName: name,
+            shortcut: ShortcutBinding(keyCode: 0, modifiers: [.command, .option])
+        )
+    }
+
+    func testManagerRecordsFailedRegistrations() {
+        // Registrar that always fails, simulating the OS rejecting the combo.
+        let manager = AppHotkeyManager(registrar: { _, _, _ in nil })
+        let e = entry("Safari")
+
+        manager.sync(entries: [e])
+
+        XCTAssertEqual(manager.failedEntryIDs, [e.id])
+    }
+
+    func testManagerClearsFailuresWhenEntriesRemoved() {
+        let manager = AppHotkeyManager(registrar: { _, _, _ in nil })
+        let e = entry("Safari")
+        manager.sync(entries: [e])
+        XCTAssertFalse(manager.failedEntryIDs.isEmpty)
+
+        manager.sync(entries: [])
+
+        XCTAssertTrue(manager.failedEntryIDs.isEmpty)
+    }
+
+    func testPluginSurfacesRegistrationFailureWithName() {
+        let storage = InMemoryPluginStorage()
+        // Seed the shared storage with an entry that has a shortcut.
+        AppHotkeyStore(storage: storage).addEntry(entry("Safari"))
+
+        let context = PluginRuntimeContext(pluginID: "app-hotkey", storage: storage)
+        let manager = AppHotkeyManager(registrar: { _, _, _ in nil })
+        let plugin = AppHotkeyPlugin(context: context, hotkeyManager: manager)
+
+        plugin.activate(context: context) // triggers syncHotkeys()
+
+        let message = plugin.primaryPanelState.errorMessage
+        XCTAssertNotNil(message)
+        XCTAssertTrue(message?.contains("Safari") == true)
+        XCTAssertTrue(message?.contains("注册失败") == true)
+    }
+
+    func testPluginHasNoErrorWhenRegistrationSucceeds() {
+        let storage = InMemoryPluginStorage()
+        AppHotkeyStore(storage: storage).addEntry(entry("Safari"))
+
+        let context = PluginRuntimeContext(pluginID: "app-hotkey", storage: storage)
+        // Registrar reports success by returning a non-nil reference.
+        let manager = AppHotkeyManager(registrar: { _, _, hotKeyID in
+            OpaquePointer(bitPattern: Int(hotKeyID.id) + 1)
+        })
+        let plugin = AppHotkeyPlugin(context: context, hotkeyManager: manager)
+
+        plugin.activate(context: context)
+
+        XCTAssertNil(plugin.primaryPanelState.errorMessage)
+    }
+}


### PR DESCRIPTION
## 问题
`AppHotkeyManager.register` 在 `RegisterEventHotKey` 失败时静默 `return`：

```swift
guard status == noErr, let ref else { return }
```

且 `AppHotkeyPlugin` 的面板 `errorMessage` 写死 `nil`。当用户设置的全局组合键已被其它应用（或系统）占用时，`RegisterEventHotKey` 返回 `eventHotKeyExistsErr`，热键**无声地不生效、零反馈**——用户只会困惑「我明明设了快捷键，怎么没反应」。

## 修复
- `register` 改为返回 `Bool`；`sync` 收集注册失败的 entry ID 到新的 `failedEntryIDs`。
- 把实际注册抽成可注入的 `Registrar` seam（默认包装 `RegisterEventHotKey`），便于单元测试失败路径（不需真实占用热键）。
- `AppHotkeyPlugin.syncHotkeys()` 后根据 `failedEntryIDs` 生成面板错误提示，并带上失败的应用名：

  > N 个快捷键注册失败：<应用名>，可能已被其它应用占用

- `unregisterAll` 一并清空 `failedEntryIDs`。

行为对成功路径不变，仅把原本被吞掉的失败暴露出来。

## 测试
- 新增 4 个测试：manager 记录失败 / 移除条目后清空 / plugin 上浮带名提示 / 成功时无错误。
- `AppHotkeyPlugin` target 编译通过。
- 全量套件本地通过：**703 passed / 0 failed**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error reporting for hotkey registration failures. Users now receive localized error messages when the OS refuses to register shortcuts, indicating they may be claimed by other applications.

* **Tests**
  * Added new test suite covering hotkey registration failure scenarios and error message display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->