### PR TITLE
Fix: LaunchControl 在 macOS 14+ 上正确识别被禁用的启动项（解析 enabled/disabled）

### DIFF
--- a/Plugins/LaunchControl/Sources/LaunchControlScanner.swift
+++ b/Plugins/LaunchControl/Sources/LaunchControlScanner.swift
@@ -174,7 +174,11 @@ struct LaunchControlScanner: @unchecked Sendable {
             }
             _ = scanner.scanUpToString("=>")
             _ = scanner.scanString("=>")
-            if scanner.scanString("true") != nil {
+            // Modern macOS (14+) emits `=> disabled` / `=> enabled`; older output
+            // used `=> true` / `=> false`. Accept both so disabled items are
+            // detected on current systems (the previous code only matched "true",
+            // so on shipping macOS the disabled set was always empty).
+            if scanner.scanString("disabled") != nil || scanner.scanString("true") != nil {
                 labels.insert(label)
             } else {
                 _ = scanner.scanUpToCharacters(from: .newlines)

--- a/Plugins/LaunchControl/Tests/LaunchControlScannerTests.swift
+++ b/Plugins/LaunchControl/Tests/LaunchControlScannerTests.swift
@@ -60,7 +60,23 @@ final class LaunchControlScannerTests: XCTestCase {
         XCTAssertEqual(parsed.lastExitStatus, 1)
     }
 
-    func testParseDisabledLabelsOnlyReturnsDisabledServices() {
+    func testParseDisabledLabelsModernEnabledDisabledFormat() {
+        // The format emitted by `launchctl print-disabled` on macOS 14+.
+        let labels = LaunchControlScanner.parseDisabledLabels(
+            """
+            disabled services = {
+                "local.enabled" => enabled
+                "local.disabled" => disabled
+                "com.vendor.helper" => disabled
+            }
+            """
+        )
+
+        XCTAssertEqual(labels, ["local.disabled", "com.vendor.helper"])
+    }
+
+    func testParseDisabledLabelsLegacyTrueFalseFormat() {
+        // Older macOS used true/false; keep parsing it for backward compatibility.
         let labels = LaunchControlScanner.parseDisabledLabels(
             """
             disabled services = {


### PR DESCRIPTION
## 问题
`LaunchControlScanner.parseDisabledLabels` 只匹配 `=> true`：

```swift
if scanner.scanString("true") != nil { labels.insert(label) }
```

但现代 macOS（14+）的 `launchctl print-disabled gui/<uid>` 实际输出是 `=> enabled` / `=> disabled`，不是 `=> true` / `=> false`。

**本机实测（macOS 26.5.1, build 25F80）：**
```
"com.apple.ManagedClientAgent.enrollagent" => disabled
"com.docker.helper" => enabled
...
```
32 行全部是 `enabled`/`disabled`，**0 行** `true`/`false`，其中 4 个服务确实是 disabled。

**后果**：`disabled` 集合永远为空 → `isDisabled = disabledLabels.contains(label)` 永远 `false` → 启动项管理界面把**所有实际被禁用**的项目都显示成"已启用"，开关标签和状态门控全错。

原测试 `testParseDisabledLabelsOnlyReturnsDisabledServices` 恰好用了过时的 `true/false` fixture，所以测试通过、却掩盖了线上行为。

## 修复
- 解析器同时接受 `disabled`（现代）与 `true`（旧版，向后兼容）；`enabled`/`false` 视为未禁用。
- 测试拆成两个：现代 `enabled/disabled` 格式（新增，没有修复会失败）+ 旧版 `true/false` 格式（保留向后兼容验证）。

## 测试
- `LaunchControlPlugin` 编译通过。
- 全量套件本地通过：**700 passed / 0 failed**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced disabled service detection to support both modern macOS 14+ launchctl output format (`=> disabled`/`=> enabled`) and legacy format (`=> true`/`=> false`)

* **Tests**
  * Added comprehensive test coverage for modern launchctl output format detection
  * Refactored legacy format tests for improved verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->