### PR TITLE
Fix: resumePlugin 复用插件原始运行时上下文（修隐藏/显示后资源目录漂移）

### DIFF
--- a/Sources/Core/Plugins/Dynamic/DynamicPluginManager.swift
+++ b/Sources/Core/Plugins/Dynamic/DynamicPluginManager.swift
@@ -322,8 +322,16 @@ final class DynamicPluginManager: ObservableObject {
     /// Re-activate a previously paused plugin without reloading it.
     func resumePlugin(_ pluginID: String) {
         guard let plugins = loadedPluginsByID[pluginID] else { return }
+        // Re-activate with the SAME context the plugin was first loaded with
+        // (support/cache/temp directories, resource bundle, scoped storage). A bare
+        // `PluginRuntimeContext(pluginID:)` has nil directories and the .main bundle,
+        // so plugins that recompute paths in activate() — e.g. ActivityBar's hook
+        // script location — would silently switch on-disk locations after hide/show.
+        let context = packageStore.installedRecords().first { $0.id == pluginID }
+            .map { packageStore.runtimeContext(for: $0) }
+            ?? PluginRuntimeContext(pluginID: pluginID)
         for plugin in plugins {
-            plugin.activate(context: PluginRuntimeContext(pluginID: pluginID))
+            plugin.activate(context: context)
         }
     }
 

--- a/Tests/Core/Plugins/Dynamic/DynamicPluginManagerTests.swift
+++ b/Tests/Core/Plugins/Dynamic/DynamicPluginManagerTests.swift
@@ -248,6 +248,28 @@ final class DynamicPluginManagerTests: XCTestCase {
         )
     }
 
+    func testResumePluginReactivatesWithPackageScopedContext() throws {
+        let sourceURL = try makePackage(id: "com.example.demo")
+        let store = makeStore()
+        _ = try store.installPackage(from: sourceURL)
+        let plugin = MockDynamicPlugin(id: "com.example.demo")
+        let loader = StubDynamicPluginLoader { records in
+            records.map { DynamicPluginLoadResult(record: $0, plugins: [plugin], errorMessage: nil) }
+        }
+        let manager = DynamicPluginManager(packageStore: store, pluginLoader: loader)
+        _ = manager.loadInstalledPlugins()
+
+        manager.pausePlugin("com.example.demo")
+        manager.resumePlugin("com.example.demo")
+
+        // Resume must re-activate with the package-scoped context (support
+        // directory etc.), not a bare nil-directory PluginRuntimeContext(pluginID:).
+        let expected = store.runtimeContext(for: store.installedRecords().first!)
+        XCTAssertNotNil(expected.supportDirectory)
+        XCTAssertEqual(plugin.activationContexts.last?.supportDirectory, expected.supportDirectory)
+        XCTAssertEqual(plugin.deactivationReasons, [.disabled])
+    }
+
     private func makeStore() -> PluginPackageStore {
         PluginPackageStore(
             rootDirectory: temporaryRoot,
@@ -340,6 +362,7 @@ private final class MockDynamicPlugin: MacToolsPlugin {
     var requestPermissionGuidance: ((String) -> Void)?
     var shortcutBindingResolver: ((String) -> ShortcutBinding?)?
     private(set) var deactivationReasons: [PluginDeactivationReason] = []
+    private(set) var activationContexts: [PluginRuntimeContext] = []
 
     init(id: String) {
         self.metadata = PluginMetadata(
@@ -350,6 +373,10 @@ private final class MockDynamicPlugin: MacToolsPlugin {
             order: 1,
             defaultDescription: "Demo"
         )
+    }
+
+    func activate(context: PluginRuntimeContext) {
+        activationContexts.append(context)
     }
 
     func deactivate(reason: PluginDeactivationReason) {


### PR DESCRIPTION
## 问题
动态插件**初次加载**时用携带完整目录/资源的上下文激活（`DynamicPluginLoader` → `packageStore.runtimeContext(for: record)`，含 support/cache/temp 目录、插件资源 bundle、pluginID 作用域存储）。

但 `DynamicPluginManager.resumePlugin` 用的是裸上下文：

```swift
plugin.activate(context: PluginRuntimeContext(pluginID: pluginID))
```

该便捷 init 的 `supportDirectory`/`cacheDirectory`/`temporaryDirectory` 全为 `nil`，`resourceBundle` 退化为 `.main`。

**后果**：用户在设置里**隐藏再重新显示**一个动态插件（`SettingsView` → `pluginHost.setFeatureVisibility` → `resumePlugin`）后，凡是在 `activate()` 里根据 `supportDirectory` 重算路径的插件会**静默切到不同的磁盘位置**。

具体确认的受影响插件是 **ActivityBar**：`activate()` 每次都 `hookInstallerPaths = ActivityBarHookInstallerPaths.defaults(supportDirectory: context.supportDirectory, ...)`。`supportDirectory == nil` 时回退到 `~/.mactools/activity-bar/hooks` 而非 AppSupport 下的 `<root>/Data/activity-bar/hooks`；之后 `installHooks()` 把 hook 脚本写到新目录，并把 `~/.claude`、`~/.cursor`、`~/.codex` 的配置指过去，孤立掉之前安装的脚本。

## 修复
`resumePlugin` 改为按 `pluginID` 查回已安装 record，用 `packageStore.runtimeContext(for:)` 重建与**初次加载完全一致**的上下文；查不到 record 时回退裸上下文（保持原行为，无回归）。

```swift
let context = packageStore.installedRecords().first { $0.id == pluginID }
    .map { packageStore.runtimeContext(for: $0) }
    ?? PluginRuntimeContext(pluginID: pluginID)
```

## 测试
- 新增 `testResumePluginReactivatesWithPackageScopedContext`：pause→resume 后断言 activate 收到的上下文带有 package 作用域的 `supportDirectory`（没有修复时该值为 nil，测试失败）。
- 全量套件本地通过：**700 passed / 0 failed**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where paused plugins would lose their original runtime context when resumed, causing them to switch on-disk locations unexpectedly after hide/show operations. Plugins now maintain their configured paths and resource settings properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->