### PR TITLE
Feat: 支持互换菜单栏图标的左右键点击行为（#98）

### DIFF
--- a/Sources/App/MenuBarClickBehaviorPreference.swift
+++ b/Sources/App/MenuBarClickBehaviorPreference.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Whether the left/right click behaviors on the menu bar status item are swapped.
+///
+/// - `.standard`: primary click (left) opens the dashboard (component panel);
+///   secondary click (right or Control-click) opens the feature panel.
+/// - `.swapped`: primary click opens the feature panel; secondary click opens
+///   the dashboard.
+enum MenuBarClickBehaviorPreference: String, CaseIterable, Identifiable {
+    case standard
+    case swapped
+
+    static let userDefaultsKey = "menuBar.clickBehaviorPreference"
+
+    var id: String { rawValue }
+
+    var isSwapped: Bool { self == .swapped }
+
+    var title: String {
+        switch self {
+        case .standard:
+            return "默认"
+        case .swapped:
+            return "互换"
+        }
+    }
+
+    /// Reads the current preference from `UserDefaults` (defaults to `.standard`).
+    static func current(_ userDefaults: UserDefaults = .standard) -> MenuBarClickBehaviorPreference {
+        userDefaults.string(forKey: userDefaultsKey)
+            .flatMap(MenuBarClickBehaviorPreference.init(rawValue:))
+            ?? .standard
+    }
+}

--- a/Sources/App/MenuBarClickBehaviorPreference.swift
+++ b/Sources/App/MenuBarClickBehaviorPreference.swift
@@ -6,24 +6,13 @@ import Foundation
 ///   secondary click (right or Control-click) opens the feature panel.
 /// - `.swapped`: primary click opens the feature panel; secondary click opens
 ///   the dashboard.
-enum MenuBarClickBehaviorPreference: String, CaseIterable, Identifiable {
+enum MenuBarClickBehaviorPreference: String {
     case standard
     case swapped
 
     static let userDefaultsKey = "menuBar.clickBehaviorPreference"
 
-    var id: String { rawValue }
-
     var isSwapped: Bool { self == .swapped }
-
-    var title: String {
-        switch self {
-        case .standard:
-            return "默认"
-        case .swapped:
-            return "互换"
-        }
-    }
 
     /// Reads the current preference from `UserDefaults` (defaults to `.standard`).
     static func current(_ userDefaults: UserDefaults = .standard) -> MenuBarClickBehaviorPreference {

--- a/Sources/App/MenuBarStatusItemController.swift
+++ b/Sources/App/MenuBarStatusItemController.swift
@@ -7,18 +7,22 @@ enum MenuBarStatusItemInvocation: Equatable {
     case featurePanel
     case componentPanel
 
-    static func invocation(for event: NSEvent?) -> MenuBarStatusItemInvocation {
-        guard let event else {
-            return .componentPanel
-        }
+    static func invocation(
+        for event: NSEvent?,
+        swapped: Bool = false
+    ) -> MenuBarStatusItemInvocation {
+        // A secondary click is a right-click or a Control-click; everything else
+        // (including a nil event for programmatic fallback) is a primary click.
+        let isSecondary: Bool = {
+            guard let event else { return false }
+            return event.type == .rightMouseDown
+                || event.type == .rightMouseUp
+                || event.modifierFlags.contains(.control)
+        }()
 
-        if event.type == .rightMouseDown
-            || event.type == .rightMouseUp
-            || event.modifierFlags.contains(.control) {
-            return .featurePanel
-        }
-
-        return .componentPanel
+        let primary: MenuBarStatusItemInvocation = swapped ? .featurePanel : .componentPanel
+        let secondary: MenuBarStatusItemInvocation = swapped ? .componentPanel : .featurePanel
+        return isSecondary ? secondary : primary
     }
 }
 
@@ -270,7 +274,10 @@ final class MenuBarStatusItemController: NSObject {
 
     @objc
     private func handleStatusItemAction(_ sender: NSStatusBarButton) {
-        switch MenuBarStatusItemInvocation.invocation(for: NSApp.currentEvent) {
+        // Read the preference live on each click so a settings change takes
+        // effect immediately without re-observing.
+        let swapped = MenuBarClickBehaviorPreference.current().isSwapped
+        switch MenuBarStatusItemInvocation.invocation(for: NSApp.currentEvent, swapped: swapped) {
         case .featurePanel:
             toggleFeaturePanel(relativeTo: sender)
         case .componentPanel:

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -145,6 +145,15 @@ struct GeneralSettingsView: View {
 
 private struct MenuBarClickBehaviorSettingsRow: View {
     @Binding var selection: MenuBarClickBehaviorPreference
+    @State private var toggleID = UUID()
+
+    private var isSwapped: Binding<Bool> {
+        Binding {
+            selection.isSwapped
+        } set: { enabled in
+            selection = enabled ? .swapped : .standard
+        }
+    }
 
     var body: some View {
         HStack(spacing: GeneralSettingsCardLayout.headerSpacing) {
@@ -159,10 +168,10 @@ private struct MenuBarClickBehaviorSettingsRow: View {
             .frame(width: GeneralSettingsCardLayout.iconSize, height: GeneralSettingsCardLayout.iconSize)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text("点击行为")
+                Text("交换左右键点击行为")
                     .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
 
-                Text("默认：左键仪表盘、右键功能面板；互换则反过来（Control+点击始终等同右键）。")
+                Text("关闭时左键打开仪表盘、右键打开功能面板；开启后左右键行为互换。")
                     .font(PluginSettingsTheme.Typography.rowDescription)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
@@ -170,20 +179,20 @@ private struct MenuBarClickBehaviorSettingsRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            Picker("点击行为", selection: $selection) {
-                ForEach(MenuBarClickBehaviorPreference.allCases) { preference in
-                    Text(preference.title)
-                        .tag(preference)
-                }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .fixedSize()
+            Toggle("交换左右键点击行为", isOn: isSwapped)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .id(toggleID)
         }
         .frame(maxWidth: .infinity, minHeight: GeneralSettingsCardLayout.minRowHeight, alignment: .leading)
         .padding(.horizontal, GeneralSettingsCardLayout.horizontalPadding)
         .padding(.vertical, GeneralSettingsCardLayout.verticalPadding)
-        .help("交换菜单栏图标的左右键点击行为")
+        .help("开启后左键打开功能面板，右键打开仪表盘")
+        .onAppear {
+            DispatchQueue.main.async {
+                toggleID = UUID()
+            }
+        }
     }
 }
 

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -96,6 +96,7 @@ struct GeneralSettingsView: View {
     @ObservedObject var menuBarIconGallery: MenuBarIconGalleryLibrary
     @ObservedObject var launchAtLoginController: LaunchAtLoginController
     @AppStorage(AppAppearancePreference.userDefaultsKey) private var appearancePreferenceRawValue = AppAppearancePreference.system.rawValue
+    @AppStorage(MenuBarClickBehaviorPreference.userDefaultsKey) private var clickBehaviorRawValue = MenuBarClickBehaviorPreference.standard.rawValue
 
     var body: some View {
         Form {
@@ -104,7 +105,7 @@ struct GeneralSettingsView: View {
             } header: {
                 Text("启动")
             }
-            
+
             Section {
                 AppearanceSettingsRow(selection: appearancePreferenceBinding)
             } header: {
@@ -116,6 +117,7 @@ struct GeneralSettingsView: View {
                     iconSettings: menuBarIconSettings,
                     gallery: menuBarIconGallery
                 )
+                MenuBarClickBehaviorSettingsRow(selection: clickBehaviorBinding)
             } header: {
                 Text("状态栏图标")
             }
@@ -130,6 +132,58 @@ struct GeneralSettingsView: View {
             appearancePreferenceRawValue = preference.rawValue
             preference.apply()
         }
+    }
+
+    private var clickBehaviorBinding: Binding<MenuBarClickBehaviorPreference> {
+        Binding {
+            MenuBarClickBehaviorPreference(rawValue: clickBehaviorRawValue) ?? .standard
+        } set: { preference in
+            clickBehaviorRawValue = preference.rawValue
+        }
+    }
+}
+
+private struct MenuBarClickBehaviorSettingsRow: View {
+    @Binding var selection: MenuBarClickBehaviorPreference
+
+    var body: some View {
+        HStack(spacing: GeneralSettingsCardLayout.headerSpacing) {
+            ZStack {
+                RoundedRectangle(cornerRadius: GeneralSettingsCardLayout.iconCornerRadius, style: .continuous)
+                    .fill(Color.accentColor.opacity(0.12))
+
+                Image(systemName: "cursorarrow.click.2")
+                    .font(PluginSettingsTheme.Typography.pageDescription.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .frame(width: GeneralSettingsCardLayout.iconSize, height: GeneralSettingsCardLayout.iconSize)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("点击行为")
+                    .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
+
+                Text("默认：左键仪表盘、右键功能面板；互换则反过来（Control+点击始终等同右键）。")
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Picker("点击行为", selection: $selection) {
+                ForEach(MenuBarClickBehaviorPreference.allCases) { preference in
+                    Text(preference.title)
+                        .tag(preference)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+        }
+        .frame(maxWidth: .infinity, minHeight: GeneralSettingsCardLayout.minRowHeight, alignment: .leading)
+        .padding(.horizontal, GeneralSettingsCardLayout.horizontalPadding)
+        .padding(.vertical, GeneralSettingsCardLayout.verticalPadding)
+        .help("交换菜单栏图标的左右键点击行为")
     }
 }
 

--- a/Tests/App/MenuBarStatusItemControllerTests.swift
+++ b/Tests/App/MenuBarStatusItemControllerTests.swift
@@ -86,4 +86,61 @@ final class MenuBarStatusItemControllerTests: XCTestCase {
 
         XCTAssertEqual(MenuBarStatusItemInvocation.invocation(for: event), .featurePanel)
     }
+
+    // MARK: - Swapped click behavior
+
+    private func mouseEvent(_ type: NSEvent.EventType, modifiers: NSEvent.ModifierFlags = []) -> NSEvent? {
+        NSEvent.mouseEvent(
+            with: type,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        )
+    }
+
+    func testSwappedLeftClickOpensFeaturePanel() {
+        XCTAssertEqual(
+            MenuBarStatusItemInvocation.invocation(for: mouseEvent(.leftMouseDown), swapped: true),
+            .featurePanel
+        )
+    }
+
+    func testSwappedRightClickOpensComponentPanel() {
+        XCTAssertEqual(
+            MenuBarStatusItemInvocation.invocation(for: mouseEvent(.rightMouseDown), swapped: true),
+            .componentPanel
+        )
+    }
+
+    func testSwappedControlClickFollowsSecondaryAndOpensComponentPanel() {
+        XCTAssertEqual(
+            MenuBarStatusItemInvocation.invocation(for: mouseEvent(.leftMouseUp, modifiers: [.control]), swapped: true),
+            .componentPanel
+        )
+    }
+
+    func testSwappedNilEventOpensFeaturePanel() {
+        XCTAssertEqual(
+            MenuBarStatusItemInvocation.invocation(for: nil, swapped: true),
+            .featurePanel
+        )
+    }
+
+    func testClickBehaviorPreferenceDefaultsToStandard() {
+        let suite = "MenuBarClickBehaviorPreferenceTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(MenuBarClickBehaviorPreference.current(defaults), .standard)
+        XCTAssertFalse(MenuBarClickBehaviorPreference.current(defaults).isSwapped)
+
+        defaults.set(MenuBarClickBehaviorPreference.swapped.rawValue, forKey: MenuBarClickBehaviorPreference.userDefaultsKey)
+        XCTAssertEqual(MenuBarClickBehaviorPreference.current(defaults), .swapped)
+        XCTAssertTrue(MenuBarClickBehaviorPreference.current(defaults).isSwapped)
+    }
 }


### PR DESCRIPTION
## 背景（issue #98）
当前菜单栏图标：左键打开仪表盘（component panel），右键/Control 打开功能面板（feature panel）。有用户希望能互换——常用功能面板时左键直达更顺手。

## 实现
- 新增 `MenuBarClickBehaviorPreference`（`standard` / `swapped`，存 `UserDefaults`，键 `menuBar.clickBehaviorPreference`）。
- 把点击判定抽象为「主点击（左键）/ 次点击（右键或 Control+点击）」，`MenuBarStatusItemInvocation.invocation(for:swapped:)` 按偏好映射：
  - 默认：主→仪表盘，次→功能面板
  - 互换：主→功能面板，次→仪表盘
  - **Control+点击始终归为"次点击"**，保留一个稳定的次要手势（这是 issue 里没指定的点，我选择了最可预测的语义）。
  - `swapped` 默认 false，旧行为完全不变。
- `handleStatusItemAction` 每次点击实时读偏好 → 改设置**即时生效**，无需重启或重新订阅。
- 设置页「状态栏图标」分组新增「点击行为」分段选择器，排版克隆现有「应用外观」行（同一套 `GeneralSettingsCardLayout` 常量与结构）。

## 测试
- 新增 5 个单元测试：互换后 左/右/Control/nil 四种点击的映射 + 偏好读取默认值与切换。
- 既有 `invocation(for:)` 测试靠默认参数 `swapped=false` 全部保持通过。
- 全量套件本地通过：**704 passed / 0 failed**。

## 备注
- 新设置行视觉上是现有 `AppearanceSettingsRow` 的忠实克隆（相同布局常量/结构/`.segmented` Picker），未单独截图验证；若希望我补一张设置页截图可以再加。
- Control+点击在互换后的语义（归为次点击 → 仪表盘）是一处产品判断，若 maintainer 偏好"Control 始终开功能面板"可轻松调整。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent menu bar icon click behavior setting letting users choose standard or swapped left/right click actions.
  * Setting appears in Settings as a segmented control with explanatory text and a help tooltip.
  * Preference persists across sessions.

* **Bug Fixes**
  * Swap setting is honored immediately on each click.

* **Tests**
  * Added tests for default behavior and swapped/un-swapped click mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->