### PR TITLE
Feat: 启动项支持本地备注（#21 需求3）

### DIFF
--- a/Plugins/LaunchControl/Sources/LaunchControlController.swift
+++ b/Plugins/LaunchControl/Sources/LaunchControlController.swift
@@ -11,16 +11,19 @@ final class LaunchControlController: ObservableObject {
     private let scanner: LaunchControlScanner
     private let runner: any LaunchControlCommandRunning
     private let favoritesStore: LaunchControlFavoritesStore
+    private let notesStore: LaunchControlNotesStore
     private var refreshTask: Task<Void, Never>?
 
     init(
         scanner: LaunchControlScanner? = nil,
         runner: any LaunchControlCommandRunning = ProcessLaunchControlCommandRunner(),
         favoritesStore: LaunchControlFavoritesStore? = nil,
+        notesStore: LaunchControlNotesStore? = nil,
         context: PluginRuntimeContext = PluginRuntimeContext(pluginID: "launch-control")
     ) {
         self.runner = runner
         self.favoritesStore = favoritesStore ?? LaunchControlFavoritesStore(context: context)
+        self.notesStore = notesStore ?? LaunchControlNotesStore(context: context)
         self.scanner = scanner ?? LaunchControlScanner(runner: runner)
     }
 
@@ -88,8 +91,16 @@ final class LaunchControlController: ObservableObject {
 
     func setFavorite(_ isFavorite: Bool, for item: LaunchControlItem) {
         favoritesStore.setFavorite(isFavorite, for: item.id)
-        replaceItem(item, isFavorite: isFavorite)
+        refreshPersistedState(for: item)
         snapshot.operationMessage = isFavorite ? "已关注 \(item.label)" : "已取消关注 \(item.label)"
+        onStateChange?()
+    }
+
+    func setNote(_ note: String, for item: LaunchControlItem) {
+        notesStore.setNote(note, for: item.id)
+        refreshPersistedState(for: item)
+        let isCleared = note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        snapshot.operationMessage = isCleared ? "已清除备注：\(item.label)" : "已保存备注：\(item.label)"
         onStateChange?()
     }
 
@@ -151,7 +162,7 @@ final class LaunchControlController: ObservableObject {
 
     private func apply(result: LaunchControlScanResult) {
         let selectedID = snapshot.selectedItemID
-        snapshot.items = sortedItems(result.items.map(applyingFavoriteState))
+        snapshot.items = sortedItems(result.items.map(applyingPersistedState))
         snapshot.selectedItemID = result.items.contains(where: { $0.id == selectedID })
             ? selectedID
             : result.items.first?.id
@@ -181,7 +192,7 @@ final class LaunchControlController: ObservableObject {
     }
 
     private func upsertScannedItem(_ item: LaunchControlItem) {
-        let item = applyingFavoriteState(item)
+        let item = applyingPersistedState(item)
 
         if let index = snapshot.items.firstIndex(where: { $0.id == item.id }) {
             snapshot.items[index] = item
@@ -194,56 +205,20 @@ final class LaunchControlController: ObservableObject {
         }
     }
 
-    private func replaceItem(_ item: LaunchControlItem, isFavorite: Bool) {
+    private func refreshPersistedState(for item: LaunchControlItem) {
         guard let index = snapshot.items.firstIndex(where: { $0.id == item.id }) else {
             return
         }
 
-        let updatedItem = LaunchControlItem(
-            id: item.id,
-            label: item.label,
-            plistURL: item.plistURL,
-            scope: item.scope,
-            origin: item.origin,
-            state: item.state,
-            pid: item.pid,
-            lastExitStatus: item.lastExitStatus,
-            programArguments: item.programArguments,
-            runAtLoad: item.runAtLoad,
-            keepAliveDescription: item.keepAliveDescription,
-            startInterval: item.startInterval,
-            startCalendarDescription: item.startCalendarDescription,
-            rawPlist: item.rawPlist,
-            launchctlDomain: item.launchctlDomain,
-            isDisabled: item.isDisabled,
-            isLoaded: item.isLoaded,
-            isFavorite: isFavorite
-        )
-        snapshot.items[index] = updatedItem
+        snapshot.items[index] = applyingPersistedState(snapshot.items[index])
         snapshot.items = sortedItems(snapshot.items)
     }
 
-    private func applyingFavoriteState(_ item: LaunchControlItem) -> LaunchControlItem {
-        LaunchControlItem(
-            id: item.id,
-            label: item.label,
-            plistURL: item.plistURL,
-            scope: item.scope,
-            origin: item.origin,
-            state: item.state,
-            pid: item.pid,
-            lastExitStatus: item.lastExitStatus,
-            programArguments: item.programArguments,
-            runAtLoad: item.runAtLoad,
-            keepAliveDescription: item.keepAliveDescription,
-            startInterval: item.startInterval,
-            startCalendarDescription: item.startCalendarDescription,
-            rawPlist: item.rawPlist,
-            launchctlDomain: item.launchctlDomain,
-            isDisabled: item.isDisabled,
-            isLoaded: item.isLoaded,
-            isFavorite: favoritesStore.isFavorite(item.id)
-        )
+    private func applyingPersistedState(_ item: LaunchControlItem) -> LaunchControlItem {
+        var updated = item
+        updated.isFavorite = favoritesStore.isFavorite(item.id)
+        updated.note = notesStore.note(for: item.id)
+        return updated
     }
 
     private func sortedItems(_ items: [LaunchControlItem]) -> [LaunchControlItem] {

--- a/Plugins/LaunchControl/Sources/LaunchControlManagerView.swift
+++ b/Plugins/LaunchControl/Sources/LaunchControlManagerView.swift
@@ -182,6 +182,8 @@ struct LaunchControlManagerView: View {
                     VStack(alignment: .leading, spacing: 18) {
                         detailHeader(item)
                         actionBar(item)
+                        LaunchControlNoteEditor(item: item, controller: controller)
+                            .id(item.id)
                         keyFields(item)
                         rawPlist(item)
                     }
@@ -267,7 +269,8 @@ struct LaunchControlManagerView: View {
                     item.commandText,
                     item.plistURL.path,
                     item.origin.title,
-                    item.triggerSummary
+                    item.triggerSummary,
+                    item.note
                 ].joined(separator: "\n")
                 searchMatches = haystack.localizedCaseInsensitiveContains(query)
             }
@@ -713,6 +716,57 @@ private enum LaunchControlPendingAction: Identifiable {
              .start,
              .restart:
             return nil
+        }
+    }
+}
+
+private struct LaunchControlNoteEditor: View {
+    let item: LaunchControlItem
+    let controller: LaunchControlController
+    @State private var draft: String
+
+    init(item: LaunchControlItem, controller: LaunchControlController) {
+        self.item = item
+        self.controller = controller
+        _draft = State(initialValue: item.note)
+    }
+
+    private var isDirty: Bool {
+        draft.trimmingCharacters(in: .whitespacesAndNewlines)
+            != item.note.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("备注")
+                    .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
+                Spacer()
+                if isDirty {
+                    Button("保存") {
+                        controller.setNote(draft, for: item)
+                    }
+                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+
+            TextEditor(text: $draft)
+                .font(.system(size: 12))
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 60, maxHeight: 120)
+                .padding(6)
+                .pluginSettingsCardBackground(.recessed)
+                .overlay(alignment: .topLeading) {
+                    if draft.isEmpty {
+                        Text("为这个启动项添加本地备注（仅保存在本机，不写入 plist）。")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.tertiary)
+                            .padding(.horizontal, 11)
+                            .padding(.top, 13)
+                            .allowsHitTesting(false)
+                    }
+                }
         }
     }
 }

--- a/Plugins/LaunchControl/Sources/LaunchControlModels.swift
+++ b/Plugins/LaunchControl/Sources/LaunchControlModels.swift
@@ -210,7 +210,9 @@ struct LaunchControlItem: Identifiable, Equatable, Sendable {
     let launchctlDomain: String
     let isDisabled: Bool
     let isLoaded: Bool
-    let isFavorite: Bool
+    var isFavorite: Bool
+    /// User-authored local note (persisted separately; never written to the plist).
+    var note: String = ""
 
     var commandText: String {
         if !programArguments.isEmpty {
@@ -305,6 +307,52 @@ final class LaunchControlFavoritesStore {
             favorites.remove(itemID)
         }
         storage.set(favorites.sorted(), forKey: StorageKey.storage)
+    }
+}
+
+/// Persists per-item user notes locally (keyed by item ID / plist path). Notes are
+/// never written back to the launchd plist — they live only in plugin storage.
+@MainActor
+final class LaunchControlNotesStore {
+    private enum StorageKey {
+        static let storage = "launch-control.item-notes"
+    }
+
+    private let storage: PluginStorage
+
+    init(
+        context: PluginRuntimeContext = PluginRuntimeContext(pluginID: "launch-control"),
+        userDefaults: UserDefaults? = nil
+    ) {
+        self.storage = userDefaults.map {
+            UserDefaultsPluginStorage(pluginID: context.pluginID, userDefaults: $0)
+        } ?? context.storage
+    }
+
+    func allNotes() -> [String: String] {
+        guard
+            let data = storage.data(forKey: StorageKey.storage),
+            let notes = try? JSONDecoder().decode([String: String].self, from: data)
+        else {
+            return [:]
+        }
+        return notes
+    }
+
+    func note(for itemID: String) -> String {
+        allNotes()[itemID] ?? ""
+    }
+
+    func setNote(_ note: String, for itemID: String) {
+        var notes = allNotes()
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            notes.removeValue(forKey: itemID)
+        } else {
+            notes[itemID] = trimmed
+        }
+        guard let data = try? JSONEncoder().encode(notes) else { return }
+        storage.set(data, forKey: StorageKey.storage)
     }
 }
 

--- a/Plugins/LaunchControl/Tests/LaunchControlNotesStoreTests.swift
+++ b/Plugins/LaunchControl/Tests/LaunchControlNotesStoreTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import MacToolsPluginKit
+@testable import MacTools
+@testable import LaunchControlPlugin
+
+@MainActor
+final class LaunchControlNotesStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "LaunchControlNotesStoreTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeStore() -> LaunchControlNotesStore {
+        LaunchControlNotesStore(userDefaults: defaults)
+    }
+
+    func testNoteIsEmptyByDefault() {
+        let store = makeStore()
+        XCTAssertEqual(store.note(for: "com.example.agent"), "")
+        XCTAssertTrue(store.allNotes().isEmpty)
+    }
+
+    func testSetAndGetNote() {
+        let store = makeStore()
+        store.setNote("夜间重建索引", for: "com.example.agent")
+        XCTAssertEqual(store.note(for: "com.example.agent"), "夜间重建索引")
+    }
+
+    func testNoteIsTrimmedOnSave() {
+        let store = makeStore()
+        store.setNote("  有空格  ", for: "x")
+        XCTAssertEqual(store.note(for: "x"), "有空格")
+    }
+
+    func testWhitespaceOnlyNoteClearsEntry() {
+        let store = makeStore()
+        store.setNote("保留", for: "x")
+        store.setNote("   \n  ", for: "x")
+        XCTAssertEqual(store.note(for: "x"), "")
+        XCTAssertNil(store.allNotes()["x"])
+    }
+
+    func testEmptyStringClearsNote() {
+        let store = makeStore()
+        store.setNote("note", for: "z")
+        store.setNote("", for: "z")
+        XCTAssertEqual(store.note(for: "z"), "")
+        XCTAssertTrue(store.allNotes().isEmpty)
+    }
+
+    func testNotesPersistAcrossInstances() {
+        makeStore().setNote("持久化", for: "y")
+        // A fresh store backed by the same defaults must read the saved note.
+        XCTAssertEqual(makeStore().note(for: "y"), "持久化")
+    }
+
+    func testMultipleNotesAreIndependent() {
+        let store = makeStore()
+        store.setNote("a-note", for: "a")
+        store.setNote("b-note", for: "b")
+        XCTAssertEqual(store.note(for: "a"), "a-note")
+        XCTAssertEqual(store.note(for: "b"), "b-note")
+        XCTAssertEqual(store.allNotes().count, 2)
+    }
+}


### PR DESCRIPTION
## 背景（issue #21 需求 3）
为启动项添加/编辑/删除**本地备注**，便于日常排查和长期管理。要求：备注本地持久化、**不修改原始 plist**、列表/详情/搜索可见。

## 实现
- 新增 `LaunchControlNotesStore`：`itemID → 备注` 字典以 JSON 持久化到插件存储（镜像现有 `LaunchControlFavoritesStore` 的模式与 ID 键）。保存时 trim；空白/空串自动删除该条。**绝不写回 launchd plist**。
- `LaunchControlItem` 新增 `note` 字段（默认 `""`，所以 scanner 等构造点无需改动）；`isFavorite` 由 `let` 改为 `var` 以便统一回填。
- 控制器新增 `setNote(_:for:)`；把原本逐字段重建的 `applyingFavoriteState`/`replaceItem` 统一为 `applyingPersistedState`/`refreshPersistedState`，一次性回填「关注 + 备注」两种持久化状态。
- 详情区新增「备注」编辑器（`TextEditor`，按 `item.id` 重置 draft，仅在有改动时显示「保存」按钮）；搜索 haystack 纳入 `item.note`，所以搜索能命中备注内容。

## 测试
- 新增 7 个 `LaunchControlNotesStore` 单元测试：默认空、读写、trim、空白清除、空串清除、跨实例持久化、多条独立。
- `LaunchControlPlugin` 编译通过。
- 全量套件本地通过：**706 passed / 0 failed**。

## 备注
- 备注 UI 视觉上沿用详情区现有卡片样式（`pluginSettingsCardBackground(.recessed)` + section 标题），未单独截图；需要的话可补。
- 控制器/视图集成是机械改动（编译验证），核心持久化逻辑由 NotesStore 单测覆盖。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can add, edit, and save personal notes for each item that persist locally
  * Inline note editor in the detail view for convenient editing
  * Search and filter functionality now includes note content
  * Notes automatically save for easy organization and reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->