### PR TITLE
Perf: 启动项扫描用一次 launchctl list 替代逐项 print（#21 需求1）

### DIFF
--- a/Plugins/LaunchControl/Sources/LaunchControlScanner.swift
+++ b/Plugins/LaunchControl/Sources/LaunchControlScanner.swift
@@ -33,6 +33,14 @@ struct LaunchControlScanner: @unchecked Sendable {
         var warnings: [String] = []
         progress(.message("读取 launchctl 禁用状态"))
         let disabledLabelsByDomain = loadDisabledLabels(domains: Set(directories.map(\.domain)))
+        // Fetch the whole user GUI domain in ONE `launchctl list` instead of one
+        // `launchctl print gui/<uid>/<label>` per item — the Status column is the
+        // last exit status and the PID column the running pid, so the data is
+        // equivalent. System-domain daemons are unaffected (handled per item below).
+        progress(.message("读取 launchctl 运行状态"))
+        let userDomainStatuses = Self.parseLaunchctlList(
+            (try? runner.runLaunchctl(arguments: ["list"]))?.combinedOutput ?? ""
+        )
         var items: [LaunchControlItem] = []
 
         for directory in directories {
@@ -54,9 +62,16 @@ struct LaunchControlScanner: @unchecked Sendable {
                         ? plistURL.deletingPathExtension().lastPathComponent
                         : summary.label
                     let disabledLabels = disabledLabelsByDomain[directory.domain, default: []]
-                    let launchctlStatus = directory.scope == .system
-                        ? (exitCode: Int32(-2), pid: nil as Int?, lastExitStatus: nil as Int?)
-                        : loadLaunchctlStatus(domain: directory.domain, label: label)
+                    let launchctlStatus: (exitCode: Int32, pid: Int?, lastExitStatus: Int?)
+                    if directory.scope == .system {
+                        launchctlStatus = (exitCode: Int32(-2), pid: nil, lastExitStatus: nil)
+                    } else if directory.domain == userDomain {
+                        // User GUI domain: served by the single `launchctl list` above.
+                        launchctlStatus = Self.status(from: userDomainStatuses, label: label)
+                    } else {
+                        // System-domain daemons (e.g. /Library/LaunchDaemons): unchanged.
+                        launchctlStatus = loadLaunchctlStatus(domain: directory.domain, label: label)
+                    }
                     let isDisabled = disabledLabels.contains(label)
                     let state = Self.state(
                         isDisabled: isDisabled,
@@ -220,6 +235,36 @@ struct LaunchControlScanner: @unchecked Sendable {
             let result = try? runner.runLaunchctl(arguments: ["print-disabled", domain])
             return (domain, Self.parseDisabledLabels(result?.combinedOutput ?? ""))
         })
+    }
+
+    /// Parses `launchctl list` output (tab-separated `PID  Status  Label`, with a
+    /// header row) into a label → (pid, lastExitStatus) map. `-` becomes nil.
+    static func parseLaunchctlList(_ output: String) -> [String: (pid: Int?, lastExitStatus: Int?)] {
+        var result: [String: (pid: Int?, lastExitStatus: Int?)] = [:]
+        for line in output.split(separator: "\n") {
+            let columns = line.split(separator: "\t", maxSplits: 2, omittingEmptySubsequences: false)
+            guard columns.count == 3 else { continue }
+            let label = columns[2].trimmingCharacters(in: .whitespaces)
+            guard !label.isEmpty, label != "Label" else { continue } // skip header / blanks
+            result[label] = (
+                pid: Int(columns[0].trimmingCharacters(in: .whitespaces)),
+                lastExitStatus: Int(columns[1].trimmingCharacters(in: .whitespaces))
+            )
+        }
+        return result
+    }
+
+    /// Maps a `launchctl list` entry to the same status tuple shape the per-item
+    /// `launchctl print` path produces: present → loaded (exitCode 0); absent →
+    /// not loaded (exitCode 1), matching a non-zero `launchctl print`.
+    static func status(
+        from map: [String: (pid: Int?, lastExitStatus: Int?)],
+        label: String
+    ) -> (exitCode: Int32, pid: Int?, lastExitStatus: Int?) {
+        guard let entry = map[label] else {
+            return (exitCode: 1, pid: nil, lastExitStatus: nil)
+        }
+        return (exitCode: 0, pid: entry.pid, lastExitStatus: entry.lastExitStatus)
     }
 
     private func loadLaunchctlStatus(domain: String, label: String) -> (exitCode: Int32, pid: Int?, lastExitStatus: Int?) {

--- a/Plugins/LaunchControl/Tests/LaunchControlScanStatusTests.swift
+++ b/Plugins/LaunchControl/Tests/LaunchControlScanStatusTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import MacToolsPluginKit
+@testable import MacTools
+@testable import LaunchControlPlugin
+
+final class LaunchControlScanStatusTests: XCTestCase {
+    func testParseLaunchctlListMapsPIDAndStatus() throws {
+        let output = """
+        PID\tStatus\tLabel
+        1270\t0\tcom.apple.cloudphotod
+        -\t-9\tcom.apple.progressd
+        -\t0\tcom.apple.enhancedloggingd
+        """
+        let map = LaunchControlScanner.parseLaunchctlList(output)
+        XCTAssertEqual(map.count, 3)
+
+        let running = try XCTUnwrap(map["com.apple.cloudphotod"])
+        XCTAssertEqual(running.pid, 1270)
+        XCTAssertEqual(running.lastExitStatus, 0)
+
+        let failed = try XCTUnwrap(map["com.apple.progressd"])
+        XCTAssertNil(failed.pid)              // "-" → nil
+        XCTAssertEqual(failed.lastExitStatus, -9)
+
+        let idle = try XCTUnwrap(map["com.apple.enhancedloggingd"])
+        XCTAssertNil(idle.pid)
+        XCTAssertEqual(idle.lastExitStatus, 0)
+    }
+
+    func testParseLaunchctlListSkipsHeaderAndBlankLines() {
+        XCTAssertTrue(LaunchControlScanner.parseLaunchctlList("PID\tStatus\tLabel\n").isEmpty)
+        XCTAssertTrue(LaunchControlScanner.parseLaunchctlList("").isEmpty)
+    }
+
+    func testStatusFromListPresentIsLoaded() {
+        let map: [String: (pid: Int?, lastExitStatus: Int?)] = ["x": (pid: 42, lastExitStatus: 0)]
+        let status = LaunchControlScanner.status(from: map, label: "x")
+        XCTAssertEqual(status.exitCode, 0)   // present in list → loaded
+        XCTAssertEqual(status.pid, 42)
+        XCTAssertEqual(status.lastExitStatus, 0)
+    }
+
+    func testStatusFromListAbsentIsNotLoaded() {
+        let status = LaunchControlScanner.status(from: [:], label: "missing")
+        XCTAssertEqual(status.exitCode, 1)   // absent → not loaded (matches non-zero `launchctl print`)
+        XCTAssertNil(status.pid)
+        XCTAssertNil(status.lastExitStatus)
+    }
+
+    func testStatusFromListPreservesFailedJob() {
+        // pid "-" + non-zero status: equivalent to a job that exited with an error.
+        let map: [String: (pid: Int?, lastExitStatus: Int?)] = ["y": (pid: nil, lastExitStatus: -9)]
+        let status = LaunchControlScanner.status(from: map, label: "y")
+        XCTAssertEqual(status.exitCode, 0)
+        XCTAssertNil(status.pid)
+        XCTAssertEqual(status.lastExitStatus, -9)
+    }
+}


### PR DESCRIPTION
## 背景（issue #21 需求 1）
原本扫描时对**每个**用户域启动项各跑一次 `launchctl print gui/<uid>/<label>`——N 个 LaunchAgents 就是 N 次子进程。issue 建议改用一次 `launchctl list` 合并状态。

## 实现
- 扫描开始时跑**一次** `launchctl list`：其 `PID` 列即运行 pid、`Status` 列即 last-exit-status，按 `Label` 建表。与逐项 `launchctl print` 取到的数据**等价**（实测列含义一致：运行中→pid+0、异常退出→`-`+负码、未运行→`-`+0、未加载→不在表中）。
- 新增 `parseLaunchctlList`（解析三列、跳过表头、`-`→nil）与 `status(from:label:)`（命中=已加载 `exitCode 0`；未命中=未加载 `exitCode 1`，与原 print 返回非零等价）。
- **仅替换用户 GUI 域(`gui/<uid>`)** 的状态获取；**system 域**守护进程（`/Library/LaunchDaemons` 等，`launchctl list` 不覆盖）**保持原逐项 print 不变** → 对这部分零行为变化。
- 派生 `state`（running / loaded / failed / unloaded）逻辑完全没动。

## 影响与诚实说明
- 子进程数：用户域从 **O(N) 降为 O(1)**（system 域少量项仍逐项）。
- 收益**随 LaunchAgents 数量增长**：在我的测试机上只有 14 个用户 agent、单次 print 都是亚毫秒，绝对差异不明显；重度第三方装机（几十~上百个 agent）才会有可感知的扫描提速。所以这是**结构性优化**，不是戏剧性加速——如实告知。
- 这是纯性能/实现改动，**不改变 UI、不改变任何用户可见数据**，回归面很小。

## 测试
- 新增 5 个单元测试：`launchctl list` 解析（pid/status/`-`/表头）+ 命中/未命中/失败任务的状态映射。
- 全量套件本地通过：**704 passed / 0 failed**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized process status gathering for improved performance and accuracy when monitoring user GUI domain processes.

* **Tests**
  * Added comprehensive test coverage to ensure reliable process status detection and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->