### PR TITLE
feat(translator): support multiple OpenAI providers

### DIFF
--- a/Plugins/Calendar/project.yml
+++ b/Plugins/Calendar/project.yml
@@ -3,14 +3,6 @@ settings:
     OTHER_LDFLAGS: -framework EventKit
 
 bundle:
-  postBuildScripts:
-    - name: Copy CalendarPluginResources
-      script: |
-        set -euo pipefail
-        resource_dir="$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/CalendarPluginResources"
-        rm -rf "$resource_dir"
-        ditto "$SRCROOT/Plugins/Calendar/CalendarPluginResources" "$resource_dir"
-      inputFiles:
-        - "$(SRCROOT)/Plugins/Calendar/CalendarPluginResources/ChinaHolidayOverrides.json"
-      outputFiles:
-        - "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/CalendarPluginResources/ChinaHolidayOverrides.json"
+  sources:
+    - path: CalendarPluginResources
+      type: folder

--- a/Plugins/Calendar/project.yml
+++ b/Plugins/Calendar/project.yml
@@ -3,6 +3,14 @@ settings:
     OTHER_LDFLAGS: -framework EventKit
 
 bundle:
-  sources:
-    - path: CalendarPluginResources
-      type: folder
+  postBuildScripts:
+    - name: Copy CalendarPluginResources
+      script: |
+        set -euo pipefail
+        resource_dir="$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/CalendarPluginResources"
+        rm -rf "$resource_dir"
+        ditto "$SRCROOT/Plugins/Calendar/CalendarPluginResources" "$resource_dir"
+      inputFiles:
+        - "$(SRCROOT)/Plugins/Calendar/CalendarPluginResources/ChinaHolidayOverrides.json"
+      outputFiles:
+        - "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/CalendarPluginResources/ChinaHolidayOverrides.json"

--- a/Plugins/Translator/Sources/Panel/TranslatorPanelView.swift
+++ b/Plugins/Translator/Sources/Panel/TranslatorPanelView.swift
@@ -24,10 +24,10 @@ struct TranslatorPanelView: View {
         VStack(spacing: 14) {
             sourceCard
             languageRow
-            resultCard
+            resultCards
         }
         .padding(16)
-        .frame(width: 520, height: 520)
+        .frame(width: 560, height: 560)
     }
 
     private var sourceCard: some View {
@@ -75,10 +75,10 @@ struct TranslatorPanelView: View {
         }
     }
 
-    private var resultCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
+    private var resultCards: some View {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 8) {
-                Text("OpenAI 翻译")
+                Text("译文")
                     .font(.headline)
                 if case .translating = snapshot.phase {
                     ProgressView()
@@ -87,23 +87,54 @@ struct TranslatorPanelView: View {
                 Spacer()
                 iconButton("speaker.wave.2", help: "朗读译文", action: .speakTranslation)
                     .disabled(resultTextForDisplay.isEmpty)
-                iconButton("doc.on.doc", help: "复制译文", action: .copyTranslation)
+                iconButton("doc.on.doc", help: "复制首个译文", action: .copyTranslation)
                     .disabled(resultTextForDisplay.isEmpty)
                 iconButton("arrow.clockwise", help: "重试", action: .retry)
                 iconButton("gearshape", help: "设置", action: .openSettings)
             }
 
             ScrollView {
-                Text(resultBodyText)
-                    .font(.body)
-                    .foregroundStyle(resultTextColor)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                VStack(alignment: .leading, spacing: 10) {
+                    let results = providerResultsForDisplay
+                    ForEach(results) { result in
+                        providerResultCard(result)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
-            .frame(maxWidth: .infinity, minHeight: 202, maxHeight: 202, alignment: .topLeading)
+            .frame(maxWidth: .infinity, minHeight: 222, maxHeight: 222, alignment: .topLeading)
         }
         .padding(14)
         .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func providerResultCard(_ result: TranslatorProviderResult) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text(result.providerTitle)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                if result.phase == .translating || result.phase == .waiting {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                Spacer()
+                iconButton(
+                    "doc.on.doc",
+                    help: "复制\(result.providerTitle)译文",
+                    action: .copyProviderTranslation(result.id)
+                )
+                .disabled((result.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+
+            Text(providerResultBodyText(result))
+                .font(.body)
+                .foregroundStyle(providerResultTextColor(result))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .padding(10)
+        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
     }
 
     private func languagePill(flag: String, title: String) -> some View {
@@ -145,6 +176,35 @@ struct TranslatorPanelView: View {
         snapshot.translation?.text.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 
+    private var providerResultsForDisplay: [TranslatorProviderResult] {
+        if !snapshot.providerResults.isEmpty {
+            return snapshot.providerResults
+        }
+
+        return [
+            TranslatorProviderResult(
+                id: "placeholder",
+                providerTitle: snapshot.translation?.providerTitle ?? "OpenAI 翻译",
+                phase: placeholderProviderPhase,
+                translation: snapshot.translation,
+                errorMessage: snapshot.errorMessage
+            ),
+        ]
+    }
+
+    private var placeholderProviderPhase: TranslatorProviderResultPhase {
+        switch snapshot.phase {
+        case .translating:
+            return .translating
+        case .success:
+            return .success
+        case .error:
+            return .error
+        case .idle, .capturing:
+            return .waiting
+        }
+    }
+
     private var sourcePlaceholder: String {
         switch snapshot.phase {
         case .capturing:
@@ -158,26 +218,30 @@ struct TranslatorPanelView: View {
         }
     }
 
-    private var resultBodyText: String {
-        if !resultTextForDisplay.isEmpty {
-            return resultTextForDisplay
+    private func providerResultBodyText(_ result: TranslatorProviderResult) -> String {
+        let text = result.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !text.isEmpty {
+            return text
         }
 
-        switch snapshot.phase {
+        switch result.phase {
         case .translating:
             return "正在翻译..."
         case .error:
-            return snapshot.errorMessage ?? "请求失败，请稍后重试"
-        default:
+            return result.errorMessage ?? "请求失败，请稍后重试"
+        case .waiting:
             return "等待翻译"
+        case .success:
+            return "响应为空"
         }
     }
 
-    private var resultTextColor: Color {
-        if case .error = snapshot.phase {
+    private func providerResultTextColor(_ result: TranslatorProviderResult) -> Color {
+        if result.phase == .error {
             return .red
         }
 
-        return resultTextForDisplay.isEmpty ? .secondary : .primary
+        let text = result.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return text.isEmpty ? .secondary : .primary
     }
 }

--- a/Plugins/Translator/Sources/Settings/OpenAICompatibleSecretStore.swift
+++ b/Plugins/Translator/Sources/Settings/OpenAICompatibleSecretStore.swift
@@ -4,14 +4,39 @@ import Security
 
 protocol TranslatorSecretStoring: Sendable {
     func containsAPIKey() throws -> Bool
+    func containsAPIKey(forProfileID profileID: String) throws -> Bool
     func loadAPIKey() throws -> String?
+    func loadAPIKey(forProfileID profileID: String) throws -> String?
     func saveAPIKey(_ apiKey: String) throws
+    func saveAPIKey(_ apiKey: String, forProfileID profileID: String) throws
     func deleteAPIKey() throws
+    func deleteAPIKey(forProfileID profileID: String) throws
+}
+
+extension TranslatorSecretStoring {
+    func containsAPIKey(forProfileID profileID: String) throws -> Bool {
+        try containsAPIKey()
+    }
+
+    func loadAPIKey(forProfileID profileID: String) throws -> String? {
+        try loadAPIKey()
+    }
+
+    func saveAPIKey(_ apiKey: String, forProfileID profileID: String) throws {
+        try saveAPIKey(apiKey)
+    }
+
+    func deleteAPIKey(forProfileID profileID: String) throws {
+        try deleteAPIKey()
+    }
 }
 
 struct OpenAICompatibleSecretStore: TranslatorSecretStoring {
     static let defaultService = "cc.ggbond.mactools.translator"
     static let defaultAccount = "translator.openai.api-key"
+    static func account(profileID: String) -> String {
+        "translator.provider.\(profileID).api-key"
+    }
 
     let service: String
     let account: String
@@ -25,7 +50,40 @@ struct OpenAICompatibleSecretStore: TranslatorSecretStoring {
     }
 
     func containsAPIKey() throws -> Bool {
+        try containsAPIKey(account: account)
+    }
+
+    func containsAPIKey(forProfileID profileID: String) throws -> Bool {
+        try containsAPIKey(account: Self.account(profileID: profileID))
+    }
+
+    func loadAPIKey() throws -> String? {
+        try loadAPIKey(account: account)
+    }
+
+    func loadAPIKey(forProfileID profileID: String) throws -> String? {
+        try loadAPIKey(account: Self.account(profileID: profileID))
+    }
+
+    func saveAPIKey(_ apiKey: String) throws {
+        try saveAPIKey(apiKey, account: account)
+    }
+
+    func saveAPIKey(_ apiKey: String, forProfileID profileID: String) throws {
+        try saveAPIKey(apiKey, account: Self.account(profileID: profileID))
+    }
+
+    func deleteAPIKey() throws {
+        try deleteAPIKey(account: account)
+    }
+
+    func deleteAPIKey(forProfileID profileID: String) throws {
+        try deleteAPIKey(account: Self.account(profileID: profileID))
+    }
+
+    private func containsAPIKey(account: String) throws -> Bool {
         var query = baseQuery
+        query[kSecAttrAccount as String] = account
         let context = LAContext()
         context.interactionNotAllowed = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
@@ -49,8 +107,9 @@ struct OpenAICompatibleSecretStore: TranslatorSecretStoring {
         }
     }
 
-    func loadAPIKey() throws -> String? {
+    private func loadAPIKey(account: String) throws -> String? {
         var query = baseQuery
+        query[kSecAttrAccount as String] = account
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
 
@@ -74,16 +133,17 @@ struct OpenAICompatibleSecretStore: TranslatorSecretStoring {
         }
     }
 
-    func saveAPIKey(_ apiKey: String) throws {
+    private func saveAPIKey(_ apiKey: String, account: String) throws {
         let trimmedAPIKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmedAPIKey.isEmpty else {
-            try deleteAPIKey()
+            try deleteAPIKey(account: account)
             return
         }
 
         let data = Data(trimmedAPIKey.utf8)
         var attributes = baseQuery
+        attributes[kSecAttrAccount as String] = account
         attributes[kSecValueData as String] = data
         attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 
@@ -97,7 +157,9 @@ struct OpenAICompatibleSecretStore: TranslatorSecretStoring {
             updateAttributes[kSecValueData as String] = data
             updateAttributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 
-            let updateStatus = SecItemUpdate(baseQuery as CFDictionary, updateAttributes as CFDictionary)
+            var updateQuery = baseQuery
+            updateQuery[kSecAttrAccount as String] = account
+            let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updateAttributes as CFDictionary)
             guard updateStatus == errSecSuccess else {
                 throw OpenAICompatibleSecretStoreError.security(updateStatus)
             }
@@ -106,8 +168,10 @@ struct OpenAICompatibleSecretStore: TranslatorSecretStoring {
         }
     }
 
-    func deleteAPIKey() throws {
-        let status = SecItemDelete(baseQuery as CFDictionary)
+    private func deleteAPIKey(account: String) throws {
+        var query = baseQuery
+        query[kSecAttrAccount as String] = account
+        let status = SecItemDelete(query as CFDictionary)
 
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw OpenAICompatibleSecretStoreError.security(status)
@@ -118,7 +182,6 @@ struct OpenAICompatibleSecretStore: TranslatorSecretStoring {
         [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
         ]
     }
 }

--- a/Plugins/Translator/Sources/Settings/TranslatorProviderProfile.swift
+++ b/Plugins/Translator/Sources/Settings/TranslatorProviderProfile.swift
@@ -1,0 +1,138 @@
+import Foundation
+import MacToolsPluginKit
+
+struct TranslatorProviderProfile: Codable, Equatable, Identifiable, Sendable {
+    static let defaultID = "openai"
+    static let defaultName = "OpenAI"
+
+    var id: String
+    var name: String
+    var isEnabled: Bool
+    var baseURL: String
+    var model: String
+    var promptTemplate: String
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        isEnabled: Bool = true,
+        baseURL: String = OpenAICompatibleConfiguration.defaultBaseURL,
+        model: String = OpenAICompatibleConfiguration.defaultModel,
+        promptTemplate: String = OpenAICompatibleConfiguration.defaultPromptTemplate
+    ) {
+        self.id = id
+        self.name = name
+        self.isEnabled = isEnabled
+        self.baseURL = baseURL
+        self.model = model
+        self.promptTemplate = promptTemplate
+    }
+
+    static func defaultProfile() -> TranslatorProviderProfile {
+        TranslatorProviderProfile(
+            id: defaultID,
+            name: defaultName,
+            isEnabled: true
+        )
+    }
+
+    var normalizedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var configuration: OpenAICompatibleConfiguration {
+        OpenAICompatibleConfiguration(
+            baseURL: baseURL,
+            model: model,
+            promptTemplate: promptTemplate
+        )
+    }
+
+    var validationError: TranslatorProviderProfileValidationError? {
+        if normalizedName.isEmpty {
+            return .blankName
+        }
+
+        if let configurationError = configuration.validationError {
+            return .configuration(configurationError)
+        }
+
+        return nil
+    }
+
+    func normalized() -> TranslatorProviderProfile {
+        var copy = self
+        copy.name = normalizedName
+        copy.baseURL = configuration.normalizedBaseURL
+        copy.model = configuration.normalizedModel
+        return copy
+    }
+}
+
+enum TranslatorProviderProfileValidationError: Error, Equatable, Sendable {
+    case blankName
+    case configuration(OpenAICompatibleConfigurationError)
+}
+
+extension TranslatorProviderProfileValidationError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .blankName:
+            return "服务名称不能为空。"
+        case let .configuration(error):
+            return error.localizedDescription
+        }
+    }
+}
+
+@MainActor
+struct TranslatorProviderProfileStore {
+    let storage: PluginStorage
+
+    init(storage: PluginStorage) {
+        self.storage = storage
+    }
+
+    func loadProfiles() -> [TranslatorProviderProfile] {
+        if let data = storage.data(forKey: TranslatorConstants.StorageKey.providerProfiles),
+           let profiles = try? JSONDecoder().decode([TranslatorProviderProfile].self, from: data),
+           !profiles.isEmpty {
+            return profiles
+        }
+
+        return [legacyProfile()]
+    }
+
+    func saveProfiles(_ profiles: [TranslatorProviderProfile]) throws {
+        let normalizedProfiles = profiles.map { $0.normalized() }
+        let data = try JSONEncoder().encode(normalizedProfiles)
+        storage.set(data, forKey: TranslatorConstants.StorageKey.providerProfiles)
+    }
+
+    func makeNewProfile(existingProfiles: [TranslatorProviderProfile]) -> TranslatorProviderProfile {
+        var index = existingProfiles.count + 1
+        var name = "OpenAI \(index)"
+        let existingNames = Set(existingProfiles.map(\.normalizedName))
+
+        while existingNames.contains(name) {
+            index += 1
+            name = "OpenAI \(index)"
+        }
+
+        return TranslatorProviderProfile(name: name, isEnabled: false)
+    }
+
+    private func legacyProfile() -> TranslatorProviderProfile {
+        TranslatorProviderProfile(
+            id: TranslatorProviderProfile.defaultID,
+            name: TranslatorProviderProfile.defaultName,
+            isEnabled: true,
+            baseURL: storage.string(forKey: TranslatorConstants.StorageKey.openAIBaseURL)
+                ?? OpenAICompatibleConfiguration.defaultBaseURL,
+            model: storage.string(forKey: TranslatorConstants.StorageKey.openAIModel)
+                ?? OpenAICompatibleConfiguration.defaultModel,
+            promptTemplate: storage.string(forKey: TranslatorConstants.StorageKey.openAIPromptTemplate)
+                ?? OpenAICompatibleConfiguration.defaultPromptTemplate
+        )
+    }
+}

--- a/Plugins/Translator/Sources/Settings/TranslatorSettingsView.swift
+++ b/Plugins/Translator/Sources/Settings/TranslatorSettingsView.swift
@@ -43,13 +43,13 @@ struct TranslatorSettingsView: View {
 
             VStack(spacing: 0) {
                 fieldRow(title: "第一语言", description: "自动识别为其他语言时翻译到这里。") {
-                    languagePicker(selection: $firstLanguage)
+                    languagePicker(selection: messageClearing($firstLanguage))
                 }
 
                 PluginSettingsListDivider()
 
                 fieldRow(title: "第二语言", description: "识别为第一语言时翻译到这里。") {
-                    languagePicker(selection: $secondLanguage)
+                    languagePicker(selection: messageClearing($secondLanguage))
                 }
             }
             .pluginSettingsCardBackground(.host)
@@ -163,60 +163,64 @@ struct TranslatorSettingsView: View {
     private func providerRow(index: Int) -> some View {
         let profile = profiles[index]
 
-        return Button {
-            selectedProfileID = profile.id
-        } label: {
-            HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-                Toggle("", isOn: binding(for: index, keyPath: \.isEnabled))
-                    .labelsHidden()
-                    .toggleStyle(.switch)
-                    .controlSize(.small)
+        // 行内的开关与移动/删除按钮各自独立响应，仅名称/模型区域作为选择目标，
+        // 避免把交互控件嵌套进同一个行级 Button 造成点击目标冲突。
+        return HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            Toggle("", isOn: binding(for: index, keyPath: \.isEnabled))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
 
-                VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
-                    Text(profile.normalizedName.isEmpty ? "未命名服务" : profile.normalizedName)
-                        .font(PluginSettingsTheme.Typography.rowTitle)
-                    Text(profile.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "未设置模型" : profile.model)
-                        .font(PluginSettingsTheme.Typography.rowDescription)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+            Button {
+                selectedProfileID = profile.id
+            } label: {
+                HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                    VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+                        Text(profile.normalizedName.isEmpty ? "未命名服务" : profile.normalizedName)
+                            .font(PluginSettingsTheme.Typography.rowTitle)
+                        Text(profile.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "未设置模型" : profile.model)
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
+
+                    if profile.isEnabled, let validationError = profile.validationError {
+                        Text(validationError.localizedDescription)
+                            .font(PluginSettingsTheme.Typography.statusBadge)
+                            .foregroundStyle(.orange)
+                            .lineLimit(1)
+                    }
                 }
-
-                Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
-
-                if profile.isEnabled, let validationError = profile.validationError {
-                    Text(validationError.localizedDescription)
-                        .font(PluginSettingsTheme.Typography.statusBadge)
-                        .foregroundStyle(.orange)
-                        .lineLimit(1)
-                }
-
-                iconButton("chevron.up", help: "上移") {
-                    moveProfile(from: index, offset: -1)
-                }
-                .disabled(index == 0)
-
-                iconButton("chevron.down", help: "下移") {
-                    moveProfile(from: index, offset: 1)
-                }
-                .disabled(index == profiles.count - 1)
-
-                iconButton("trash", help: "删除") {
-                    deleteProfile(at: index)
-                }
-                .disabled(profiles.count == 1)
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .pluginSettingsListRowPadding(interactive: true)
-            .background {
-                if selectedProfileID == profile.id {
-                    RoundedRectangle(cornerRadius: PluginSettingsTheme.Radius.field, style: .continuous)
-                        .fill(Color.accentColor.opacity(0.10))
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 4)
-                }
+            .buttonStyle(.plain)
+
+            iconButton("chevron.up", help: "上移") {
+                moveProfile(from: index, offset: -1)
+            }
+            .disabled(index == 0)
+
+            iconButton("chevron.down", help: "下移") {
+                moveProfile(from: index, offset: 1)
+            }
+            .disabled(index == profiles.count - 1)
+
+            iconButton("trash", help: "删除") {
+                deleteProfile(at: index)
+            }
+            .disabled(profiles.count == 1)
+        }
+        .pluginSettingsListRowPadding(interactive: true)
+        .background {
+            if selectedProfileID == profile.id {
+                RoundedRectangle(cornerRadius: PluginSettingsTheme.Radius.field, style: .continuous)
+                    .fill(Color.accentColor.opacity(0.10))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 4)
             }
         }
-        .buttonStyle(.plain)
     }
 
     private func promptEditor(index: Int) -> some View {
@@ -295,6 +299,7 @@ struct TranslatorSettingsView: View {
                 .frame(width: 24, height: 24)
         }
         .buttonStyle(.borderless)
+        .controlSize(.small)
         .foregroundStyle(.secondary)
         .help(help)
     }
@@ -315,14 +320,31 @@ struct TranslatorSettingsView: View {
     ) -> Binding<Value> {
         Binding(
             get: { profiles[index][keyPath: keyPath] },
-            set: { profiles[index][keyPath: keyPath] = $0 }
+            set: {
+                profiles[index][keyPath: keyPath] = $0
+                message = nil
+            }
         )
     }
 
     private func apiKeyBinding(profileID: String) -> Binding<String> {
         Binding(
             get: { apiKeys[profileID] ?? "" },
-            set: { apiKeys[profileID] = $0 }
+            set: {
+                apiKeys[profileID] = $0
+                message = nil
+            }
+        )
+    }
+
+    /// 包装语言选择 binding，在用户改动时清除“已保存”提示，避免未保存改动看起来已保存。
+    private func messageClearing(_ binding: Binding<TranslatorLanguage>) -> Binding<TranslatorLanguage> {
+        Binding(
+            get: { binding.wrappedValue },
+            set: {
+                binding.wrappedValue = $0
+                message = nil
+            }
         )
     }
 

--- a/Plugins/Translator/Sources/Settings/TranslatorSettingsView.swift
+++ b/Plugins/Translator/Sources/Settings/TranslatorSettingsView.swift
@@ -4,37 +4,35 @@ import MacToolsPluginKit
 struct TranslatorSettingsView: View {
     @State private var firstLanguage: TranslatorLanguage
     @State private var secondLanguage: TranslatorLanguage
-    @State private var baseURL: String
-    @State private var model: String
-    @State private var promptTemplate: String
-    @State private var apiKey: String
+    @State private var profiles: [TranslatorProviderProfile]
+    @State private var apiKeys: [String: String]
+    @State private var selectedProfileID: String?
     @State private var message: String?
 
-    private let onSave: (OpenAICompatibleConfiguration, String, TranslatorLanguagePair) -> String?
-    private let onRestoreDefaults: () -> OpenAICompatibleConfiguration
+    private let onSave: ([TranslatorProviderProfile], [String: String], TranslatorLanguagePair) -> String?
+    private let onMakeNewProfile: ([TranslatorProviderProfile]) -> TranslatorProviderProfile
 
     init(
-        configuration: OpenAICompatibleConfiguration,
-        apiKey: String,
+        profiles: [TranslatorProviderProfile],
+        apiKeys: [String: String],
         languagePair: TranslatorLanguagePair,
-        onSave: @escaping (OpenAICompatibleConfiguration, String, TranslatorLanguagePair) -> String?,
-        onRestoreDefaults: @escaping () -> OpenAICompatibleConfiguration
+        onSave: @escaping ([TranslatorProviderProfile], [String: String], TranslatorLanguagePair) -> String?,
+        onMakeNewProfile: @escaping ([TranslatorProviderProfile]) -> TranslatorProviderProfile
     ) {
         _firstLanguage = State(initialValue: languagePair.first)
         _secondLanguage = State(initialValue: languagePair.second)
-        _baseURL = State(initialValue: configuration.baseURL)
-        _model = State(initialValue: configuration.model)
-        _promptTemplate = State(initialValue: configuration.promptTemplate)
-        _apiKey = State(initialValue: apiKey)
+        _profiles = State(initialValue: profiles.isEmpty ? [TranslatorProviderProfile.defaultProfile()] : profiles)
+        _apiKeys = State(initialValue: apiKeys)
+        _selectedProfileID = State(initialValue: profiles.first?.id ?? TranslatorProviderProfile.defaultID)
         self.onSave = onSave
-        self.onRestoreDefaults = onRestoreDefaults
+        self.onMakeNewProfile = onMakeNewProfile
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.section) {
             languageSection
-            providerSection
-            promptSection
+            providerListSection
+            providerDetailSection
             actions
         }
     }
@@ -44,13 +42,13 @@ struct TranslatorSettingsView: View {
             sectionHeader("偏好语言", icon: "character.book.closed")
 
             VStack(spacing: 0) {
-                languageRow(title: "第一语言", description: "自动识别为其他语言时翻译到这里。") {
+                fieldRow(title: "第一语言", description: "自动识别为其他语言时翻译到这里。") {
                     languagePicker(selection: $firstLanguage)
                 }
 
                 PluginSettingsListDivider()
 
-                languageRow(title: "第二语言", description: "识别为第一语言时翻译到这里。") {
+                fieldRow(title: "第二语言", description: "识别为第一语言时翻译到这里。") {
                     languagePicker(selection: $secondLanguage)
                 }
             }
@@ -58,68 +56,89 @@ struct TranslatorSettingsView: View {
         }
     }
 
-    private var providerSection: some View {
+    private var providerListSection: some View {
         VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
-            sectionHeader("OpenAI 兼容服务", icon: "network")
+            HStack {
+                sectionHeader("翻译服务", icon: "network")
+                Spacer()
+                Button {
+                    addProfile()
+                } label: {
+                    Label("添加", systemImage: "plus")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
 
             VStack(spacing: 0) {
-                fieldRow(title: "服务地址", description: "OpenAI 或兼容网关地址。") {
-                    TextField("https://api.openai.com", text: $baseURL)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(minWidth: 280, idealWidth: 320, maxWidth: 420)
-                }
-
-                PluginSettingsListDivider()
-
-                fieldRow(title: "接口密钥", description: "留空则保留当前钥匙串内容。") {
-                    SecureField("sk-...", text: $apiKey)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(minWidth: 280, idealWidth: 320, maxWidth: 420)
-                }
-
-                PluginSettingsListDivider()
-
-                fieldRow(title: "模型", description: "用于翻译的模型名称。") {
-                    TextField("gpt-5.4-mini", text: $model)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(minWidth: 280, idealWidth: 320, maxWidth: 420)
+                ForEach(profiles.indices, id: \.self) { index in
+                    providerRow(index: index)
+                    if index != profiles.indices.last {
+                        PluginSettingsListDivider()
+                    }
                 }
             }
             .pluginSettingsCardBackground(.host)
         }
     }
 
-    private var promptSection: some View {
+    private var providerDetailSection: some View {
         VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
-            sectionHeader("提示词", icon: "text.alignleft")
+            sectionHeader("服务详情", icon: "slider.horizontal.3")
 
-            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
-                Text("模板")
-                    .font(PluginSettingsTheme.Typography.rowTitle)
-                Text("必须包含 {{text}}。可使用 {{source_language}} 和 {{target_language}}。")
+            if let index = selectedProfileIndex {
+                VStack(spacing: 0) {
+                    editableFieldRow(title: "名称", description: "显示在翻译结果卡片上。") {
+                        TextField("OpenAI", text: binding(for: index, keyPath: \.name))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(minWidth: 280, idealWidth: 320, maxWidth: 420)
+                    }
+
+                    PluginSettingsListDivider()
+
+                    editableFieldRow(title: "服务地址", description: "OpenAI 或兼容网关地址。") {
+                        TextField("https://api.openai.com", text: binding(for: index, keyPath: \.baseURL))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(minWidth: 280, idealWidth: 320, maxWidth: 420)
+                    }
+
+                    PluginSettingsListDivider()
+
+                    editableFieldRow(title: "接口密钥", description: "留空则保留当前钥匙串内容。") {
+                        SecureField("sk-...", text: apiKeyBinding(profileID: profiles[index].id))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(minWidth: 280, idealWidth: 320, maxWidth: 420)
+                    }
+
+                    PluginSettingsListDivider()
+
+                    editableFieldRow(title: "模型", description: "用于翻译的模型名称。") {
+                        TextField("gpt-5.4-mini", text: binding(for: index, keyPath: \.model))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(minWidth: 280, idealWidth: 320, maxWidth: 420)
+                    }
+
+                    PluginSettingsListDivider()
+
+                    promptEditor(index: index)
+                }
+                .pluginSettingsCardBackground(.host)
+            } else {
+                Text("请选择一个翻译服务。")
                     .font(PluginSettingsTheme.Typography.rowDescription)
                     .foregroundStyle(.secondary)
-
-                TextEditor(text: $promptTemplate)
-                    .font(.body.monospaced())
-                    .scrollContentBackground(.hidden)
-                    .padding(8)
-                    .frame(minHeight: 150, idealHeight: 180, maxHeight: 240)
-                    .background(PluginSettingsTheme.Palette.nativeFieldBackground)
-                    .clipShape(RoundedRectangle(cornerRadius: PluginSettingsTheme.Radius.field, style: .continuous))
+                    .pluginSettingsListRowPadding()
+                    .pluginSettingsCardBackground(.host)
             }
-            .pluginSettingsListRowPadding(interactive: true)
-            .pluginSettingsCardBackground(.host)
         }
     }
 
     private var actions: some View {
         HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
             Button("恢复默认") {
-                let defaults = onRestoreDefaults()
-                baseURL = defaults.baseURL
-                model = defaults.model
-                promptTemplate = defaults.promptTemplate
+                profiles = [TranslatorProviderProfile.defaultProfile()]
+                selectedProfileID = profiles[0].id
+                apiKeys = [:]
                 message = nil
             }
             .buttonStyle(.bordered)
@@ -139,6 +158,84 @@ struct TranslatorSettingsView: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
         }
+    }
+
+    private func providerRow(index: Int) -> some View {
+        let profile = profiles[index]
+
+        return Button {
+            selectedProfileID = profile.id
+        } label: {
+            HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                Toggle("", isOn: binding(for: index, keyPath: \.isEnabled))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+
+                VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+                    Text(profile.normalizedName.isEmpty ? "未命名服务" : profile.normalizedName)
+                        .font(PluginSettingsTheme.Typography.rowTitle)
+                    Text(profile.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "未设置模型" : profile.model)
+                        .font(PluginSettingsTheme.Typography.rowDescription)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
+
+                if profile.isEnabled, let validationError = profile.validationError {
+                    Text(validationError.localizedDescription)
+                        .font(PluginSettingsTheme.Typography.statusBadge)
+                        .foregroundStyle(.orange)
+                        .lineLimit(1)
+                }
+
+                iconButton("chevron.up", help: "上移") {
+                    moveProfile(from: index, offset: -1)
+                }
+                .disabled(index == 0)
+
+                iconButton("chevron.down", help: "下移") {
+                    moveProfile(from: index, offset: 1)
+                }
+                .disabled(index == profiles.count - 1)
+
+                iconButton("trash", help: "删除") {
+                    deleteProfile(at: index)
+                }
+                .disabled(profiles.count == 1)
+            }
+            .contentShape(Rectangle())
+            .pluginSettingsListRowPadding(interactive: true)
+            .background {
+                if selectedProfileID == profile.id {
+                    RoundedRectangle(cornerRadius: PluginSettingsTheme.Radius.field, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.10))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 4)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func promptEditor(index: Int) -> some View {
+        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+            Text("提示词")
+                .font(PluginSettingsTheme.Typography.rowTitle)
+            Text("必须包含 {{text}}。可使用 {{source_language}} 和 {{target_language}}。")
+                .font(PluginSettingsTheme.Typography.rowDescription)
+                .foregroundStyle(.secondary)
+
+            TextEditor(text: binding(for: index, keyPath: \.promptTemplate))
+                .font(.body.monospaced())
+                .scrollContentBackground(.hidden)
+                .padding(8)
+                .frame(minHeight: 130, idealHeight: 160, maxHeight: 220)
+                .background(PluginSettingsTheme.Palette.nativeFieldBackground)
+                .clipShape(RoundedRectangle(cornerRadius: PluginSettingsTheme.Radius.field, style: .continuous))
+        }
+        .pluginSettingsListRowPadding(interactive: true)
     }
 
     private func sectionHeader(_ title: String, icon: String) -> some View {
@@ -168,7 +265,7 @@ struct TranslatorSettingsView: View {
         .pluginSettingsListRowPadding(interactive: true)
     }
 
-    private func languageRow<Content: View>(
+    private func editableFieldRow<Content: View>(
         title: String,
         description: String,
         @ViewBuilder content: () -> Content
@@ -187,6 +284,74 @@ struct TranslatorSettingsView: View {
         .frame(minWidth: 180, idealWidth: 200, maxWidth: 240)
     }
 
+    private func iconButton(
+        _ systemName: String,
+        help: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 24, height: 24)
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(.secondary)
+        .help(help)
+    }
+
+    private var selectedProfileIndex: Int? {
+        guard let selectedProfileID,
+              let index = profiles.firstIndex(where: { $0.id == selectedProfileID })
+        else {
+            return profiles.indices.first
+        }
+
+        return index
+    }
+
+    private func binding<Value>(
+        for index: Int,
+        keyPath: WritableKeyPath<TranslatorProviderProfile, Value>
+    ) -> Binding<Value> {
+        Binding(
+            get: { profiles[index][keyPath: keyPath] },
+            set: { profiles[index][keyPath: keyPath] = $0 }
+        )
+    }
+
+    private func apiKeyBinding(profileID: String) -> Binding<String> {
+        Binding(
+            get: { apiKeys[profileID] ?? "" },
+            set: { apiKeys[profileID] = $0 }
+        )
+    }
+
+    private func addProfile() {
+        let profile = onMakeNewProfile(profiles)
+        profiles.append(profile)
+        selectedProfileID = profile.id
+        message = nil
+    }
+
+    private func deleteProfile(at index: Int) {
+        let deletedID = profiles[index].id
+        profiles.remove(at: index)
+        apiKeys.removeValue(forKey: deletedID)
+        selectedProfileID = profiles.indices.contains(index) ? profiles[index].id : profiles.last?.id
+        message = nil
+    }
+
+    private func moveProfile(from index: Int, offset: Int) {
+        let target = index + offset
+        guard profiles.indices.contains(index), profiles.indices.contains(target) else {
+            return
+        }
+
+        profiles.swapAt(index, target)
+        selectedProfileID = profiles[target].id
+        message = nil
+    }
+
     private func save() {
         let languagePair = TranslatorLanguagePair(first: firstLanguage, second: secondLanguage)
 
@@ -195,12 +360,6 @@ struct TranslatorSettingsView: View {
             return
         }
 
-        let configuration = OpenAICompatibleConfiguration(
-            baseURL: baseURL,
-            model: model,
-            promptTemplate: promptTemplate
-        )
-
-        message = onSave(configuration, apiKey, languagePair) ?? "已保存"
+        message = onSave(profiles, apiKeys, languagePair) ?? "已保存"
     }
 }

--- a/Plugins/Translator/Sources/TranslatorConstants.swift
+++ b/Plugins/Translator/Sources/TranslatorConstants.swift
@@ -18,6 +18,7 @@ enum TranslatorConstants {
 
     enum StorageKey {
         static let shortcutEnabled = "translator.shortcut.enabled"
+        static let providerProfiles = "translator.providers.profiles"
         static let openAIBaseURL = "translator.openai.base-url"
         static let openAIModel = "translator.openai.model"
         static let openAIPromptTemplate = "translator.openai.prompt-template"

--- a/Plugins/Translator/Sources/TranslatorCoordinator.swift
+++ b/Plugins/Translator/Sources/TranslatorCoordinator.swift
@@ -24,18 +24,27 @@ struct OpenAITranslationProviderAdapter: TranslationProviding {
     let client: OpenAICompatibleClient
     let configuration: OpenAICompatibleConfiguration
     let apiKey: String
+    let providerTitle: String
 
     func translate(
         text: String,
         languageSelection: TranslatorLanguageSelection
     ) async throws -> TranslationResult {
-        try await client.translate(
+        var result = try await client.translate(
             text: text,
             languageSelection: languageSelection,
             configuration: configuration,
             apiKey: apiKey
         )
+        result.providerTitle = providerTitle
+        return result
     }
+}
+
+private struct ProviderTranslationOutcome: Sendable {
+    var providerID: String
+    var translation: TranslationResult?
+    var errorMessage: String?
 }
 
 @MainActor
@@ -79,11 +88,14 @@ final class TranslatorCoordinator {
         let currentSessionID = UUID()
         sessionID = currentSessionID
         lastSourceText = nil
+        let providerBuildResult = providerFactory()
+        let initialProviderResults = providerBuildResult.waitingProviderResults
         snapshot = TranslatorPanelSnapshot(
             phase: .capturing,
             sourceText: nil,
             languageSelection: nil,
             translation: nil,
+            providerResults: initialProviderResults,
             errorMessage: nil
         )
         // 立即展示取词加载态；capturing 阶段面板不抢焦点，避免影响 AX 取词与模拟复制。
@@ -101,27 +113,50 @@ final class TranslatorCoordinator {
               !sourceText.isEmpty
         else {
             if result.failureReason == TranslatorPanelError.permissionRequired.message {
-                setError(.permissionRequired, sourceText: nil, languageSelection: nil)
+                setError(
+                    .permissionRequired,
+                    sourceText: nil,
+                    languageSelection: nil,
+                    providerResults: initialProviderResults
+                )
                 panelController?.show(snapshot: snapshot)
                 return
             }
 
-            setError(.missingSelection, sourceText: nil, languageSelection: nil)
+            setError(
+                .missingSelection,
+                sourceText: nil,
+                languageSelection: nil,
+                providerResults: initialProviderResults
+            )
             panelController?.show(snapshot: snapshot)
             return
         }
 
         lastSourceText = sourceText
 
-        switch providerFactory() {
+        switch providerBuildResult {
         case let .provider(provider):
-            await translate(sourceText: sourceText, provider: provider, sessionID: currentSessionID)
+            await translate(
+                sourceText: sourceText,
+                providers: [
+                    ResolvedTranslationProvider(
+                        id: "default",
+                        title: "OpenAI 翻译",
+                        provider: provider
+                    ),
+                ],
+                sessionID: currentSessionID
+            )
+        case let .providers(providers):
+            await translate(sourceText: sourceText, providers: providers, sessionID: currentSessionID)
         case let .missing(message):
             snapshot = TranslatorPanelSnapshot(
                 phase: .error(.missingConfiguration),
                 sourceText: sourceText,
                 languageSelection: nil,
                 translation: nil,
+                providerResults: initialProviderResults,
                 errorMessage: message
             )
             panelController?.show(snapshot: snapshot)
@@ -138,6 +173,8 @@ final class TranslatorCoordinator {
             copy(snapshot.sourceText)
         case .copyTranslation:
             copy(snapshot.translation?.text)
+        case let .copyProviderTranslation(providerID):
+            copy(snapshot.providerResults.first { $0.id == providerID }?.translation?.text)
         case .speakSource:
             speak(snapshot.sourceText, language: snapshot.languageSelection?.source)
         case .speakTranslation:
@@ -169,16 +206,30 @@ final class TranslatorCoordinator {
     private func runRetry(sourceText: String) async {
         let currentSessionID = UUID()
         sessionID = currentSessionID
+        let providerBuildResult = providerFactory()
 
-        switch providerFactory() {
+        switch providerBuildResult {
         case let .provider(provider):
-            await translate(sourceText: sourceText, provider: provider, sessionID: currentSessionID)
+            await translate(
+                sourceText: sourceText,
+                providers: [
+                    ResolvedTranslationProvider(
+                        id: "default",
+                        title: "OpenAI 翻译",
+                        provider: provider
+                    ),
+                ],
+                sessionID: currentSessionID
+            )
+        case let .providers(providers):
+            await translate(sourceText: sourceText, providers: providers, sessionID: currentSessionID)
         case let .missing(message):
             snapshot = TranslatorPanelSnapshot(
                 phase: .error(.missingConfiguration),
                 sourceText: sourceText,
                 languageSelection: snapshot.languageSelection,
                 translation: nil,
+                providerResults: providerBuildResult.waitingProviderResults,
                 errorMessage: message
             )
             panelController?.show(snapshot: snapshot)
@@ -187,64 +238,162 @@ final class TranslatorCoordinator {
 
     private func translate(
         sourceText: String,
-        provider: any TranslationProviding,
+        providers: [ResolvedTranslationProvider],
         sessionID currentSessionID: UUID
     ) async {
         let languageSelection = AutomaticLanguageSelector(
             preferredPair: languagePreferenceStore.loadPair()
         ).select(text: sourceText)
+        let initialProviderResults = providers.map {
+            TranslatorProviderResult(
+                id: $0.id,
+                providerTitle: $0.title,
+                phase: $0.provider == nil ? .error : .translating,
+                translation: nil,
+                errorMessage: $0.errorMessage
+            )
+        }
 
         snapshot = TranslatorPanelSnapshot(
             phase: .translating,
             sourceText: sourceText,
             languageSelection: languageSelection,
             translation: nil,
+            providerResults: initialProviderResults,
             errorMessage: nil
         )
         panelController?.show(snapshot: snapshot)
 
-        do {
-            try Task.checkCancellation()
-            let translation = try await provider.translate(
-                text: sourceText,
-                languageSelection: languageSelection
-            )
-
+        guard providers.contains(where: { $0.provider != nil }) else {
             guard !Task.isCancelled, sessionID == currentSessionID else { return }
-
-            snapshot = TranslatorPanelSnapshot(
-                phase: .success,
+            finishProviderBatch(
                 sourceText: sourceText,
                 languageSelection: languageSelection,
-                translation: translation,
-                errorMessage: nil
+                sessionID: currentSessionID
             )
-            panelController?.show(snapshot: snapshot)
-        } catch {
-            guard !Task.isCancelled, sessionID == currentSessionID else { return }
-
-            TranslatorLog.provider.error("translation failed")
-            setError(
-                .requestFailed(error.localizedDescription),
-                sourceText: sourceText,
-                languageSelection: languageSelection
-            )
-            panelController?.show(snapshot: snapshot)
+            return
         }
+
+        await withTaskGroup(of: ProviderTranslationOutcome.self) { group in
+            for resolvedProvider in providers {
+                guard let provider = resolvedProvider.provider else {
+                    continue
+                }
+
+                group.addTask {
+                    do {
+                        try Task.checkCancellation()
+                        let translation = try await provider.translate(
+                            text: sourceText,
+                            languageSelection: languageSelection
+                        )
+                        return ProviderTranslationOutcome(
+                            providerID: resolvedProvider.id,
+                            translation: translation,
+                            errorMessage: nil
+                        )
+                    } catch is CancellationError {
+                        return ProviderTranslationOutcome(
+                            providerID: resolvedProvider.id,
+                            translation: nil,
+                            errorMessage: nil
+                        )
+                    } catch {
+                        TranslatorLog.provider.error("translation failed")
+                        return ProviderTranslationOutcome(
+                            providerID: resolvedProvider.id,
+                            translation: nil,
+                            errorMessage: error.localizedDescription
+                        )
+                    }
+                }
+            }
+
+            for await outcome in group {
+                guard !Task.isCancelled, sessionID == currentSessionID else {
+                    group.cancelAll()
+                    return
+                }
+
+                apply(outcome)
+                panelController?.show(snapshot: snapshot)
+            }
+        }
+
+        guard !Task.isCancelled, sessionID == currentSessionID else { return }
+
+        finishProviderBatch(
+            sourceText: sourceText,
+            languageSelection: languageSelection,
+            sessionID: currentSessionID
+        )
     }
 
     private func setError(
         _ error: TranslatorPanelError,
         sourceText: String?,
-        languageSelection: TranslatorLanguageSelection?
+        languageSelection: TranslatorLanguageSelection?,
+        providerResults: [TranslatorProviderResult] = []
     ) {
         snapshot = TranslatorPanelSnapshot(
             phase: .error(error),
             sourceText: sourceText,
             languageSelection: languageSelection,
             translation: nil,
+            providerResults: providerResults,
             errorMessage: error.message
         )
+    }
+
+    private func apply(_ outcome: ProviderTranslationOutcome) {
+        guard let index = snapshot.providerResults.firstIndex(where: { $0.id == outcome.providerID }) else {
+            return
+        }
+
+        if let translation = outcome.translation {
+            snapshot.providerResults[index].phase = .success
+            snapshot.providerResults[index].translation = translation
+            snapshot.providerResults[index].errorMessage = nil
+            if snapshot.translation == nil {
+                snapshot.translation = translation
+            }
+        } else if let errorMessage = outcome.errorMessage {
+            snapshot.providerResults[index].phase = .error
+            snapshot.providerResults[index].translation = nil
+            snapshot.providerResults[index].errorMessage = errorMessage
+        }
+    }
+
+    private func finishProviderBatch(
+        sourceText: String,
+        languageSelection: TranslatorLanguageSelection,
+        sessionID currentSessionID: UUID
+    ) {
+        let firstSuccess = snapshot.providerResults.first { $0.phase == .success }?.translation
+        snapshot.translation = firstSuccess
+
+        if let firstSuccess {
+            snapshot = TranslatorPanelSnapshot(
+                phase: .success,
+                sourceText: sourceText,
+                languageSelection: languageSelection,
+                translation: firstSuccess,
+                providerResults: snapshot.providerResults,
+                errorMessage: nil
+            )
+        } else {
+            let message = snapshot.providerResults.compactMap(\.errorMessage).first
+                ?? TranslatorPanelError.requestFailed("请求失败，请稍后重试").message
+            snapshot = TranslatorPanelSnapshot(
+                phase: .error(.requestFailed(message)),
+                sourceText: sourceText,
+                languageSelection: languageSelection,
+                translation: nil,
+                providerResults: snapshot.providerResults,
+                errorMessage: message
+            )
+        }
+        panelController?.show(snapshot: snapshot)
     }
 
     private func copy(_ text: String?) {

--- a/Plugins/Translator/Sources/TranslatorModels.swift
+++ b/Plugins/Translator/Sources/TranslatorModels.swift
@@ -33,6 +33,7 @@ struct TranslatorPanelSnapshot: Equatable, Sendable {
     var sourceText: String?
     var languageSelection: TranslatorLanguageSelection?
     var translation: TranslationResult?
+    var providerResults: [TranslatorProviderResult] = []
     var errorMessage: String?
 
     static let idle = TranslatorPanelSnapshot(
@@ -40,6 +41,7 @@ struct TranslatorPanelSnapshot: Equatable, Sendable {
         sourceText: nil,
         languageSelection: nil,
         translation: nil,
+        providerResults: [],
         errorMessage: nil
     )
 }
@@ -49,12 +51,106 @@ enum TranslatorPanelAction: Equatable, Sendable {
     case close
     case copySource
     case copyTranslation
+    case copyProviderTranslation(String)
     case speakSource
     case speakTranslation
     case openSettings
 }
 
+enum TranslatorProviderResultPhase: Equatable, Sendable {
+    case waiting
+    case translating
+    case success
+    case error
+}
+
+struct TranslatorProviderResult: Equatable, Identifiable, Sendable {
+    var id: String
+    var providerTitle: String
+    var phase: TranslatorProviderResultPhase
+    var translation: TranslationResult?
+    var errorMessage: String?
+
+    var text: String? {
+        translation?.text
+    }
+}
+
+struct ResolvedTranslationProvider: Sendable {
+    var id: String
+    var title: String
+    var provider: (any TranslationProviding)?
+    var errorMessage: String?
+
+    init(
+        id: String,
+        title: String,
+        provider: any TranslationProviding
+    ) {
+        self.id = id
+        self.title = title
+        self.provider = provider
+        self.errorMessage = nil
+    }
+
+    init(
+        id: String,
+        title: String,
+        errorMessage: String
+    ) {
+        self.id = id
+        self.title = title
+        self.provider = nil
+        self.errorMessage = errorMessage
+    }
+}
+
 enum TranslatorProviderBuildResult {
     case provider(any TranslationProviding)
+    case providers([ResolvedTranslationProvider])
     case missing(message: String)
+
+    var resolvedProviders: [ResolvedTranslationProvider]? {
+        switch self {
+        case let .provider(provider):
+            return [
+                ResolvedTranslationProvider(
+                    id: "default",
+                    title: "OpenAI 翻译",
+                    provider: provider
+                ),
+            ]
+        case let .providers(providers):
+            return providers
+        case .missing:
+            return nil
+        }
+    }
+
+    var waitingProviderResults: [TranslatorProviderResult] {
+        switch self {
+        case .provider:
+            return [
+                TranslatorProviderResult(
+                    id: "default",
+                    providerTitle: "OpenAI 翻译",
+                    phase: .waiting,
+                    translation: nil,
+                    errorMessage: nil
+                ),
+            ]
+        case let .providers(providers):
+            return providers.map {
+                TranslatorProviderResult(
+                    id: $0.id,
+                    providerTitle: $0.title,
+                    phase: .waiting,
+                    translation: nil,
+                    errorMessage: $0.errorMessage
+                )
+            }
+        case .missing:
+            return []
+        }
+    }
 }

--- a/Plugins/Translator/Sources/TranslatorPlugin.swift
+++ b/Plugins/Translator/Sources/TranslatorPlugin.swift
@@ -56,9 +56,13 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
     private let panelController: any TranslatorPanelControlling
     private let selectedTextCapturePipeline: SelectedTextCapturePipeline
     private let translationProviderFactoryOverride: TranslatorProviderFactory?
+    private let providerProfileStore: TranslatorProviderProfileStore
     private var providerConfiguration: OpenAICompatibleConfiguration
+    private var providerProfiles: [TranslatorProviderProfile]
     private var languagePair: TranslatorLanguagePair
     private var cachedAPIKey: String?
+    private var cachedAPIKeys: [String: String]
+    private var didLoadProfileAPIKeys: Set<String>
     private var didLoadAPIKey = false
     private var apiKeyState: APIKeyState
     private var coordinator: TranslatorCoordinator?
@@ -81,11 +85,18 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
         self.panelController = panelController
         self.selectedTextCapturePipeline = selectedTextCapturePipeline
         self.translationProviderFactoryOverride = translationProviderFactoryOverride
+        let providerProfileStore = TranslatorProviderProfileStore(storage: context.storage)
+        let providerProfiles = providerProfileStore.loadProfiles()
+        self.providerProfileStore = providerProfileStore
+        self.providerProfiles = providerProfiles
         let languagePreferenceStore = LanguagePreferenceStore(storage: context.storage)
         self.languagePreferenceStore = languagePreferenceStore
-        self.providerConfiguration = OpenAICompatibleConfiguration(storage: context.storage)
+        self.providerConfiguration = providerProfiles.first?.configuration
+            ?? OpenAICompatibleConfiguration(storage: context.storage)
         self.languagePair = languagePreferenceStore.loadPair()
         self.cachedAPIKey = nil
+        self.cachedAPIKeys = [:]
+        self.didLoadProfileAPIKeys = []
         self.apiKeyState = .unknown
         panelController.onAction = { [weak self] action in
             self?.handlePanelAction(action)
@@ -144,14 +155,19 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
         PluginConfiguration(description: metadata.defaultDescription, prefersFullHeight: false) { [weak self] _ in
             if let self {
                 TranslatorSettingsView(
-                    configuration: self.providerConfiguration,
-                    apiKey: self.cachedAPIKey ?? "",
+                    profiles: self.providerProfiles,
+                    apiKeys: self.cachedAPIKeys,
                     languagePair: self.languagePair,
-                    onSave: { [weak self] configuration, apiKey, languagePair in
-                        self?.saveConfiguration(configuration, apiKey: apiKey, languagePair: languagePair)
+                    onSave: { [weak self] profiles, apiKeys, languagePair in
+                        self?.saveConfiguration(
+                            profiles: profiles,
+                            apiKeys: apiKeys,
+                            languagePair: languagePair
+                        )
                     },
-                    onRestoreDefaults: {
-                        OpenAICompatibleConfiguration()
+                    onMakeNewProfile: { [weak self] profiles in
+                        self?.providerProfileStore.makeNewProfile(existingProfiles: profiles)
+                            ?? TranslatorProviderProfile(name: "OpenAI", isEnabled: false)
                     }
                 )
             } else {
@@ -246,14 +262,18 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
     private var panelSubtitle: String {
         if !isShortcutEnabled { return "快捷键已暂停" }
         if !accessibilityTrustProvider() { return "启用前需要辅助功能授权" }
-        if providerConfiguration.validationError != nil { return "需要配置 OpenAI" }
+        if enabledValidProfiles.isEmpty { return "需要配置翻译服务" }
 
         switch apiKeyState {
         case .missing, .error:
-            return "需要配置 OpenAI"
+            return "需要配置翻译服务"
         case .unknown, .present:
             return "按 ⌥D 翻译选中文本"
         }
+    }
+
+    private var enabledValidProfiles: [TranslatorProviderProfile] {
+        providerProfiles.filter { $0.isEnabled && $0.validationError == nil }
     }
 
     private var hasKnownAPIKey: Bool {
@@ -272,33 +292,71 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
         apiKey: String,
         languagePair: TranslatorLanguagePair
     ) -> String? {
+        let profile = TranslatorProviderProfile(
+            id: TranslatorProviderProfile.defaultID,
+            name: TranslatorProviderProfile.defaultName,
+            isEnabled: true,
+            baseURL: configuration.baseURL,
+            model: configuration.model,
+            promptTemplate: configuration.promptTemplate
+        )
+        return saveConfiguration(
+            profiles: [profile],
+            apiKeys: [profile.id: apiKey],
+            languagePair: languagePair
+        )
+    }
+
+    func saveConfiguration(
+        profiles: [TranslatorProviderProfile],
+        apiKeys: [String: String],
+        languagePair: TranslatorLanguagePair
+    ) -> String? {
         guard languagePair.first != languagePair.second else {
             return "两种偏好语言不能相同。"
         }
 
-        if let validationError = configuration.validationError {
-            return validationError.localizedDescription
+        guard profiles.contains(where: \.isEnabled) else {
+            return "至少启用一个翻译服务。"
+        }
+
+        for profile in profiles where profile.isEnabled {
+            if let validationError = profile.validationError {
+                return "\(profile.normalizedName.isEmpty ? "翻译服务" : profile.normalizedName)：\(validationError.localizedDescription)"
+            }
         }
 
         do {
-            if let normalizedAPIKey = Self.normalizedAPIKey(apiKey) {
-                try secretStore.saveAPIKey(normalizedAPIKey)
-                cachedAPIKey = normalizedAPIKey
-                didLoadAPIKey = true
-                apiKeyState = .present
-            } else if hasKnownAPIKey {
-                cachedAPIKey = nil
-                didLoadAPIKey = false
-                apiKeyState = .present
-            } else {
-                apiKeyState = .missing
-                onStateChange?()
-                return "API Key 不能为空。"
+            for profile in profiles where profile.isEnabled {
+                let apiKey = apiKeys[profile.id]
+                if let normalizedAPIKey = Self.normalizedAPIKey(apiKey) {
+                    try secretStore.saveAPIKey(normalizedAPIKey, forProfileID: profile.id)
+                    cachedAPIKeys[profile.id] = normalizedAPIKey
+                    didLoadProfileAPIKeys.insert(profile.id)
+                } else if try secretStore.containsAPIKey(forProfileID: profile.id) {
+                    cachedAPIKeys.removeValue(forKey: profile.id)
+                    didLoadProfileAPIKeys.remove(profile.id)
+                } else if profile.id == TranslatorProviderProfile.defaultID, hasKnownAPIKey {
+                    cachedAPIKeys.removeValue(forKey: profile.id)
+                    didLoadProfileAPIKeys.remove(profile.id)
+                } else {
+                    apiKeyState = .missing
+                    onStateChange?()
+                    if profiles.count == 1, profile.id == TranslatorProviderProfile.defaultID {
+                        return "API Key 不能为空。"
+                    }
+                    return "\(profile.normalizedName)：API Key 不能为空。"
+                }
             }
-            configuration.save(to: storage)
+            try providerProfileStore.saveProfiles(profiles)
             languagePreferenceStore.savePair(languagePair)
-            providerConfiguration = configuration
+            providerProfiles = providerProfileStore.loadProfiles()
+            providerConfiguration = providerProfiles.first?.configuration
+                ?? OpenAICompatibleConfiguration()
             self.languagePair = languagePair
+            cachedAPIKey = cachedAPIKeys[TranslatorProviderProfile.defaultID]
+            didLoadAPIKey = didLoadProfileAPIKeys.contains(TranslatorProviderProfile.defaultID)
+            apiKeyState = .present
             if let coordinator {
                 coordinator.close()
             } else {
@@ -338,28 +396,62 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
             languagePreferenceStore: LanguagePreferenceStore(storage: storage),
             providerFactory: translationProviderFactoryOverride ?? { [weak self] in
                 guard let self else {
-                    return .missing(message: "请先配置 OpenAI")
+                    return .missing(message: "请先启用翻译服务")
                 }
 
-                guard self.providerConfiguration.validationError == nil else {
-                    return .missing(message: "请先配置 OpenAI")
+                let resolvedProviders = self.resolvedTranslationProviders()
+                guard !resolvedProviders.isEmpty else {
+                    return .missing(message: "请先启用翻译服务")
                 }
 
-                self.loadCachedAPIKeyIfNeeded()
-                guard let trimmedKey = Self.normalizedAPIKey(self.cachedAPIKey) else {
-                    return .missing(message: "请先配置 OpenAI")
-                }
-
-                return .provider(
-                    OpenAITranslationProviderAdapter(
-                        client: OpenAICompatibleClient(),
-                        configuration: self.providerConfiguration,
-                        apiKey: trimmedKey
-                    )
-                )
+                return .providers(resolvedProviders)
             },
             panelController: panelController
         )
+    }
+
+    private func resolvedTranslationProviders() -> [ResolvedTranslationProvider] {
+        providerProfiles.filter(\.isEnabled).map { profile in
+            if let validationError = profile.validationError {
+                return ResolvedTranslationProvider(
+                    id: profile.id,
+                    title: profile.normalizedName.isEmpty ? "翻译服务" : profile.normalizedName,
+                    errorMessage: validationError.localizedDescription
+                )
+            }
+
+            do {
+                let apiKey = try loadAPIKey(for: profile.id)
+                guard let trimmedKey = Self.normalizedAPIKey(apiKey) else {
+                    apiKeyState = .missing
+                    onStateChange?()
+                    return ResolvedTranslationProvider(
+                        id: profile.id,
+                        title: profile.normalizedName,
+                        errorMessage: "请配置 API Key"
+                    )
+                }
+
+                return ResolvedTranslationProvider(
+                    id: profile.id,
+                    title: profile.normalizedName,
+                    provider: OpenAITranslationProviderAdapter(
+                        client: OpenAICompatibleClient(),
+                        configuration: profile.configuration,
+                        apiKey: trimmedKey,
+                        providerTitle: profile.normalizedName
+                    )
+                )
+            } catch {
+                apiKeyState = .error(error.localizedDescription)
+                onStateChange?()
+                return ResolvedTranslationProvider(
+                    id: profile.id,
+                    title: profile.normalizedName,
+                    errorMessage: error.localizedDescription
+                )
+            }
+        }
     }
 
     private static func hasNonEmptyAPIKey(_ apiKey: String?) -> Bool {
@@ -393,5 +485,44 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
         if apiKeyState != previousState {
             onStateChange?()
         }
+    }
+
+    private func loadAPIKey(for profileID: String) throws -> String? {
+        if didLoadProfileAPIKeys.contains(profileID) {
+            return cachedAPIKeys[profileID]
+        }
+
+        let profileKey = try secretStore.loadAPIKey(forProfileID: profileID)
+        if Self.hasNonEmptyAPIKey(profileKey) {
+            cachedAPIKeys[profileID] = profileKey
+            didLoadProfileAPIKeys.insert(profileID)
+            updateLegacyAPIKeyCacheIfNeeded(profileID: profileID, apiKey: profileKey)
+            return profileKey
+        }
+
+        if profileID == TranslatorProviderProfile.defaultID {
+            let legacyKey = try secretStore.loadAPIKey()
+            if Self.hasNonEmptyAPIKey(legacyKey) {
+                cachedAPIKeys[profileID] = legacyKey
+                didLoadProfileAPIKeys.insert(profileID)
+                updateLegacyAPIKeyCacheIfNeeded(profileID: profileID, apiKey: legacyKey)
+                return legacyKey
+            }
+        }
+
+        cachedAPIKeys.removeValue(forKey: profileID)
+        didLoadProfileAPIKeys.insert(profileID)
+        updateLegacyAPIKeyCacheIfNeeded(profileID: profileID, apiKey: nil)
+        return nil
+    }
+
+    private func updateLegacyAPIKeyCacheIfNeeded(profileID: String, apiKey: String?) {
+        guard profileID == TranslatorProviderProfile.defaultID else {
+            return
+        }
+
+        cachedAPIKey = apiKey
+        didLoadAPIKey = true
+        apiKeyState = Self.hasNonEmptyAPIKey(apiKey) ? .present : .missing
     }
 }

--- a/Plugins/Translator/Sources/TranslatorPlugin.swift
+++ b/Plugins/Translator/Sources/TranslatorPlugin.swift
@@ -327,6 +327,12 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
         }
 
         do {
+            // 保存前先算出被移除的 profile（旧 providerProfiles 此时仍为持久化中的值）。
+            let retainedProfileIDs = Set(profiles.map(\.id))
+            let removedProfileIDs = providerProfiles
+                .map(\.id)
+                .filter { !retainedProfileIDs.contains($0) }
+
             for profile in profiles where profile.isEnabled {
                 let apiKey = apiKeys[profile.id]
                 if let normalizedAPIKey = Self.normalizedAPIKey(apiKey) {
@@ -348,6 +354,14 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
                     return "\(profile.normalizedName)：API Key 不能为空。"
                 }
             }
+
+            // 清理已删除 profile 残留的 Keychain 凭据与缓存。
+            for removedID in removedProfileIDs {
+                try secretStore.deleteAPIKey(forProfileID: removedID)
+                cachedAPIKeys.removeValue(forKey: removedID)
+                didLoadProfileAPIKeys.remove(removedID)
+            }
+
             try providerProfileStore.saveProfiles(profiles)
             languagePreferenceStore.savePair(languagePair)
             providerProfiles = providerProfileStore.loadProfiles()
@@ -411,7 +425,10 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
     }
 
     private func resolvedTranslationProviders() -> [ResolvedTranslationProvider] {
-        providerProfiles.filter(\.isEnabled).map { profile in
+        // 在解析前捕获状态：loadAPIKey 会通过 updateLegacyAPIKeyCacheIfNeeded 提前改写 apiKeyState，
+        // 故比较基准须取解析开始前的值，否则会漏发状态变化通知。
+        let previousState = apiKeyState
+        let resolved = providerProfiles.filter(\.isEnabled).map { profile -> ResolvedTranslationProvider in
             if let validationError = profile.validationError {
                 return ResolvedTranslationProvider(
                     id: profile.id,
@@ -423,8 +440,6 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
             do {
                 let apiKey = try loadAPIKey(for: profile.id)
                 guard let trimmedKey = Self.normalizedAPIKey(apiKey) else {
-                    apiKeyState = .missing
-                    onStateChange?()
                     return ResolvedTranslationProvider(
                         id: profile.id,
                         title: profile.normalizedName,
@@ -443,14 +458,28 @@ final class TranslatorPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigur
                     )
                 )
             } catch {
-                apiKeyState = .error(error.localizedDescription)
-                onStateChange?()
                 return ResolvedTranslationProvider(
                     id: profile.id,
                     title: profile.normalizedName,
                     errorMessage: error.localizedDescription
                 )
             }
+        }
+
+        updateAPIKeyState(forResolvedProviders: resolved, previousState: previousState)
+        return resolved
+    }
+
+    /// 在解析完所有启用 profile 后聚合整体密钥状态：只要存在一个可用 provider 即视为可用，
+    /// 避免单个缺失密钥的 profile 把整体状态拉成 missing。
+    private func updateAPIKeyState(
+        forResolvedProviders resolved: [ResolvedTranslationProvider],
+        previousState: APIKeyState
+    ) {
+        guard !resolved.isEmpty else { return }
+        apiKeyState = resolved.contains { $0.provider != nil } ? .present : .missing
+        if apiKeyState != previousState {
+            onStateChange?()
         }
     }
 

--- a/Plugins/Translator/Tests/TranslatorCoordinatorTests.swift
+++ b/Plugins/Translator/Tests/TranslatorCoordinatorTests.swift
@@ -39,6 +39,35 @@ final class TranslatorCoordinatorTests: XCTestCase {
         XCTAssertTrue(panel.updatedSnapshots.contains { $0.phase == .error(.missingSelection) })
     }
 
+    func testMissingSelectionPreservesConfiguredProviderCards() async {
+        let panel = RecordingTranslatorPanelController()
+        let coordinator = makeCoordinator(
+            captureResult: .missing,
+            providerFactory: {
+                .providers([
+                    ResolvedTranslationProvider(
+                        id: "openai",
+                        title: "OpenAI",
+                        provider: RecordingTranslationProvider(resultText: "unused")
+                    ),
+                    ResolvedTranslationProvider(
+                        id: "deepseek",
+                        title: "DeepSeek",
+                        provider: RecordingTranslationProvider(resultText: "unused")
+                    ),
+                ])
+            },
+            panelController: panel
+        )
+
+        coordinator.startSelectTranslation()
+        await panel.waitUntilShown(.error(.missingSelection))
+
+        XCTAssertEqual(coordinator.snapshot.phase, .error(.missingSelection))
+        XCTAssertEqual(coordinator.snapshot.providerResults.map(\.providerTitle), ["OpenAI", "DeepSeek"])
+        XCTAssertEqual(coordinator.snapshot.providerResults.map(\.phase), [.waiting, .waiting])
+    }
+
     func testAccessibilityFailureShowsPermissionRequiredError() async {
         let panel = RecordingTranslatorPanelController()
         let coordinator = makeCoordinator(
@@ -114,6 +143,90 @@ final class TranslatorCoordinatorTests: XCTestCase {
         XCTAssertTrue(panel.updatedSnapshots.contains { $0.phase == .capturing })
         XCTAssertTrue(panel.updatedSnapshots.contains { $0.phase == .translating })
         XCTAssertTrue(panel.updatedSnapshots.contains { $0.phase == .success })
+    }
+
+    func testMultipleProvidersUpdateIndependentResultsAndFirstSuccess() async throws {
+        let firstProvider = RecordingTranslationProvider(resultText: "你好")
+        let secondProvider = RecordingTranslationProvider(error: TestTranslationError(message: "服务失败"))
+        let panel = RecordingTranslatorPanelController()
+        let coordinator = makeCoordinator(
+            captureResult: selectedText("hello"),
+            providerFactory: {
+                .providers([
+                    ResolvedTranslationProvider(id: "first", title: "服务一", provider: firstProvider),
+                    ResolvedTranslationProvider(id: "second", title: "服务二", provider: secondProvider),
+                ])
+            },
+            panelController: panel
+        )
+
+        coordinator.startSelectTranslation()
+        await panel.waitUntilShown(.success)
+
+        XCTAssertEqual(coordinator.snapshot.phase, .success)
+        XCTAssertEqual(coordinator.snapshot.translation?.text, "你好")
+        XCTAssertEqual(coordinator.snapshot.providerResults.count, 2)
+        XCTAssertEqual(coordinator.snapshot.providerResults[0].phase, .success)
+        XCTAssertEqual(coordinator.snapshot.providerResults[0].translation?.text, "你好")
+        XCTAssertEqual(coordinator.snapshot.providerResults[1].phase, .error)
+        XCTAssertEqual(coordinator.snapshot.providerResults[1].errorMessage, "服务失败")
+    }
+
+    func testAllProvidersFailShowsRequestFailedButKeepsProviderErrors() async {
+        let panel = RecordingTranslatorPanelController()
+        let coordinator = makeCoordinator(
+            captureResult: selectedText("hello"),
+            providerFactory: {
+                .providers([
+                    ResolvedTranslationProvider(
+                        id: "first",
+                        title: "服务一",
+                        provider: RecordingTranslationProvider(error: TestTranslationError(message: "服务一失败"))
+                    ),
+                    ResolvedTranslationProvider(
+                        id: "second",
+                        title: "服务二",
+                        provider: RecordingTranslationProvider(error: TestTranslationError(message: "服务二失败"))
+                    ),
+                ])
+            },
+            panelController: panel
+        )
+
+        coordinator.startSelectTranslation()
+        await panel.waitUntilShown(.error(.requestFailed("服务一失败")))
+
+        XCTAssertEqual(coordinator.snapshot.phase, .error(.requestFailed("服务一失败")))
+        XCTAssertNil(coordinator.snapshot.translation)
+        XCTAssertEqual(coordinator.snapshot.providerResults.map(\.phase), [.error, .error])
+    }
+
+    func testProviderScopedCopyWritesSelectedProviderTranslation() async {
+        let panel = RecordingTranslatorPanelController()
+        let coordinator = makeCoordinator(
+            captureResult: selectedText("hello"),
+            providerFactory: {
+                .providers([
+                    ResolvedTranslationProvider(
+                        id: "first",
+                        title: "服务一",
+                        provider: RecordingTranslationProvider(resultText: "你好")
+                    ),
+                    ResolvedTranslationProvider(
+                        id: "second",
+                        title: "服务二",
+                        provider: RecordingTranslationProvider(resultText: "您好")
+                    ),
+                ])
+            },
+            panelController: panel
+        )
+
+        coordinator.startSelectTranslation()
+        await panel.waitUntilShown(.success)
+        await coordinator.handle(.copyProviderTranslation("second"))
+
+        XCTAssertEqual(NSPasteboard.general.string(forType: .string), "您好")
     }
 
     func testTranslationFailurePreservesSourceAndLanguageSelection() async throws {

--- a/Plugins/Translator/Tests/TranslatorPluginTests.swift
+++ b/Plugins/Translator/Tests/TranslatorPluginTests.swift
@@ -106,7 +106,7 @@ final class TranslatorPluginTests: XCTestCase {
         XCTAssertTrue(state.isVisible)
         XCTAssertTrue(state.isEnabled)
         XCTAssertTrue(state.isOn)
-        XCTAssertEqual(state.subtitle, "需要配置 OpenAI")
+        XCTAssertEqual(state.subtitle, "需要配置翻译服务")
     }
 
     func testPrimaryPanelDoesNotClaimOpenAIIsMissingBeforeAPIKeyStateIsKnown() {
@@ -147,7 +147,7 @@ final class TranslatorPluginTests: XCTestCase {
         capture.resume()
         await capture.waitUntilCompleted()
 
-        XCTAssertEqual(plugin.primaryPanelState.subtitle, "需要配置 OpenAI")
+        XCTAssertEqual(plugin.primaryPanelState.subtitle, "需要配置翻译服务")
     }
 
     func testShortcutNotifiesHostWhenLazyAPIKeyLoadFindsMissingKey() async {
@@ -176,7 +176,7 @@ final class TranslatorPluginTests: XCTestCase {
         await capture.waitUntilCompleted()
 
         XCTAssertEqual(notificationCount, 1)
-        XCTAssertEqual(plugin.primaryPanelState.subtitle, "需要配置 OpenAI")
+        XCTAssertEqual(plugin.primaryPanelState.subtitle, "需要配置翻译服务")
     }
 
     func testPanelControllerClampsRestoredFrameIntoVisibleScreen() throws {
@@ -571,6 +571,7 @@ final class TranslatorPluginTests: XCTestCase {
 
 private final class CountingTranslatorSecretStore: TranslatorSecretStoring, @unchecked Sendable {
     private var apiKey: String?
+    private var profileAPIKeys: [String: String] = [:]
     private(set) var loadCount = 0
     private(set) var containsCount = 0
     private(set) var saveCount = 0
@@ -584,9 +585,19 @@ private final class CountingTranslatorSecretStore: TranslatorSecretStoring, @unc
         return apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
 
+    func containsAPIKey(forProfileID profileID: String) throws -> Bool {
+        containsCount += 1
+        return profileAPIKeys[profileID]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    }
+
     func loadAPIKey() throws -> String? {
         loadCount += 1
         return apiKey
+    }
+
+    func loadAPIKey(forProfileID profileID: String) throws -> String? {
+        loadCount += 1
+        return profileAPIKeys[profileID]
     }
 
     func saveAPIKey(_ apiKey: String) throws {
@@ -594,8 +605,17 @@ private final class CountingTranslatorSecretStore: TranslatorSecretStoring, @unc
         self.apiKey = apiKey
     }
 
+    func saveAPIKey(_ apiKey: String, forProfileID profileID: String) throws {
+        saveCount += 1
+        profileAPIKeys[profileID] = apiKey
+    }
+
     func deleteAPIKey() throws {
         apiKey = nil
+    }
+
+    func deleteAPIKey(forProfileID profileID: String) throws {
+        profileAPIKeys.removeValue(forKey: profileID)
     }
 }
 

--- a/Plugins/Translator/Tests/TranslatorPluginTests.swift
+++ b/Plugins/Translator/Tests/TranslatorPluginTests.swift
@@ -244,7 +244,8 @@ final class TranslatorPluginTests: XCTestCase {
         capture.resume()
         await capture.waitUntilCompleted()
 
-        XCTAssertEqual(secretStore.loadCount, 1)
+        // 默认 profile 未命中 profile 密钥时回退读取 legacy 单密钥，故加载两次存储项。
+        XCTAssertEqual(secretStore.loadCount, 2)
     }
 
     func testSavingBlankAPIKeyWithoutExistingKeyReturnsConfigurationError() {
@@ -283,7 +284,8 @@ final class TranslatorPluginTests: XCTestCase {
 
         XCTAssertNil(message)
         XCTAssertEqual(secretStore.loadCount, 0)
-        XCTAssertEqual(secretStore.containsCount, 1)
+        // 先检查 profile 密钥是否存在，未命中再回退检查 legacy 单密钥，故存在性检查两次。
+        XCTAssertEqual(secretStore.containsCount, 2)
         XCTAssertEqual(secretStore.saveCount, 0)
         XCTAssertEqual(plugin.primaryPanelState.subtitle, "按 ⌥D 翻译选中文本")
     }

--- a/Plugins/Translator/Tests/TranslatorPluginTests.swift
+++ b/Plugins/Translator/Tests/TranslatorPluginTests.swift
@@ -290,6 +290,63 @@ final class TranslatorPluginTests: XCTestCase {
         XCTAssertEqual(plugin.primaryPanelState.subtitle, "按 ⌥D 翻译选中文本")
     }
 
+    func testSavingProfilesDeletesKeychainEntriesForRemovedProfiles() {
+        let secretStore = CountingTranslatorSecretStore(apiKey: nil)
+        let plugin = makePlugin(secretStore: secretStore)
+        let first = TranslatorProviderProfile(id: "openai", name: "OpenAI")
+        let second = TranslatorProviderProfile(id: "second", name: "Second")
+        let languagePair = TranslatorLanguagePair(first: .english, second: .simplifiedChinese)
+
+        XCTAssertNil(plugin.saveConfiguration(
+            profiles: [first, second],
+            apiKeys: [first.id: "sk-1", second.id: "sk-2"],
+            languagePair: languagePair
+        ))
+
+        // 第二次保存移除了 second，应清理它残留的 Keychain 凭据。
+        XCTAssertNil(plugin.saveConfiguration(
+            profiles: [first],
+            apiKeys: [first.id: "sk-1"],
+            languagePair: languagePair
+        ))
+
+        XCTAssertEqual(secretStore.deletedProfileIDs, ["second"])
+    }
+
+    func testAPIKeyStatePresentWhenOneEnabledProfileHealthyAndAnotherMissesKey() async {
+        let storage = TranslatorInMemoryPluginStorage()
+        let healthy = TranslatorProviderProfile(id: "openai", name: "OpenAI")
+        let missing = TranslatorProviderProfile(id: "second", name: "Second")
+        try? TranslatorProviderProfileStore(storage: storage).saveProfiles([healthy, missing])
+
+        let secretStore = CountingTranslatorSecretStore(apiKey: nil)
+        // 仅 healthy profile 有可用密钥，missing profile 缺密钥。
+        try? secretStore.saveAPIKey("sk-1", forProfileID: healthy.id)
+
+        let capture = DeferredSelectedTextCapture(
+            result: SelectedTextCaptureResult(
+                text: "hello",
+                strategyID: .accessibility,
+                isEditable: false,
+                sourceApplicationBundleID: "com.example.app",
+                failureReason: nil
+            )
+        )
+        let plugin = makePlugin(
+            storage: storage,
+            secretStore: secretStore,
+            selectedTextCapturePipeline: SelectedTextCapturePipeline(strategies: [capture])
+        )
+
+        plugin.handleShortcutAction(id: "select-translation")
+        await capture.waitUntilStarted()
+        capture.resume()
+        await capture.waitUntilCompleted()
+
+        // 存在一个可用 provider，整体状态应保持可用，而非被缺密钥的 profile 拉成 missing。
+        XCTAssertEqual(plugin.primaryPanelState.subtitle, "按 ⌥D 翻译选中文本")
+    }
+
     func testPrimaryPanelTogglePersistsDisabledStateAndNotifies() {
         let storage = TranslatorInMemoryPluginStorage()
         let plugin = makePlugin(storage: storage)
@@ -577,6 +634,7 @@ private final class CountingTranslatorSecretStore: TranslatorSecretStoring, @unc
     private(set) var loadCount = 0
     private(set) var containsCount = 0
     private(set) var saveCount = 0
+    private(set) var deletedProfileIDs: [String] = []
 
     init(apiKey: String?) {
         self.apiKey = apiKey
@@ -617,6 +675,7 @@ private final class CountingTranslatorSecretStore: TranslatorSecretStoring, @unc
     }
 
     func deleteAPIKey(forProfileID profileID: String) throws {
+        deletedProfileIDs.append(profileID)
         profileAPIKeys.removeValue(forKey: profileID)
     }
 }

--- a/Plugins/Translator/Tests/TranslatorProviderProfileStoreTests.swift
+++ b/Plugins/Translator/Tests/TranslatorProviderProfileStoreTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import XCTest
+@testable import TranslatorPlugin
+
+@MainActor
+final class TranslatorProviderProfileStoreTests: XCTestCase {
+    func testLoadProfilesReturnsDefaultOpenAIProfileWhenStorageIsEmpty() {
+        let storage = TranslatorInMemoryPluginStorage()
+        let store = TranslatorProviderProfileStore(storage: storage)
+
+        let profiles = store.loadProfiles()
+
+        XCTAssertEqual(profiles.count, 1)
+        XCTAssertEqual(profiles[0].id, "openai")
+        XCTAssertEqual(profiles[0].name, "OpenAI")
+        XCTAssertTrue(profiles[0].isEnabled)
+        XCTAssertEqual(profiles[0].baseURL, "https://api.openai.com")
+        XCTAssertEqual(profiles[0].model, "gpt-5.4-mini")
+    }
+
+    func testLoadProfilesMigratesLegacySingleProviderConfiguration() {
+        let storage = TranslatorInMemoryPluginStorage()
+        storage.set("https://gateway.example.com/v1", forKey: "translator.openai.base-url")
+        storage.set("gpt-test", forKey: "translator.openai.model")
+        storage.set("翻译：{{text}}", forKey: "translator.openai.prompt-template")
+        let store = TranslatorProviderProfileStore(storage: storage)
+
+        let profile = store.loadProfiles()[0]
+
+        XCTAssertEqual(profile.id, "openai")
+        XCTAssertEqual(profile.name, "OpenAI")
+        XCTAssertEqual(profile.baseURL, "https://gateway.example.com/v1")
+        XCTAssertEqual(profile.model, "gpt-test")
+        XCTAssertEqual(profile.promptTemplate, "翻译：{{text}}")
+    }
+
+    func testSaveProfilesPersistsNormalizedJSON() throws {
+        let storage = TranslatorInMemoryPluginStorage()
+        let store = TranslatorProviderProfileStore(storage: storage)
+        let profile = TranslatorProviderProfile(
+            id: "deepseek",
+            name: "  DeepSeek  ",
+            isEnabled: true,
+            baseURL: "  https://api.deepseek.com  ",
+            model: "  deepseek-chat  ",
+            promptTemplate: "{{text}}"
+        )
+
+        try store.saveProfiles([profile])
+
+        let reloaded = store.loadProfiles()
+        XCTAssertEqual(reloaded.count, 1)
+        XCTAssertEqual(reloaded[0].name, "DeepSeek")
+        XCTAssertEqual(reloaded[0].baseURL, "https://api.deepseek.com")
+        XCTAssertEqual(reloaded[0].model, "deepseek-chat")
+    }
+
+    func testDisabledDraftProfileCanHaveInvalidConfiguration() {
+        let profile = TranslatorProviderProfile(
+            name: "草稿",
+            isEnabled: false,
+            baseURL: "",
+            model: "",
+            promptTemplate: ""
+        )
+
+        XCTAssertNotNil(profile.validationError)
+    }
+
+    func testMakeNewProfileUsesNextAvailableNameAndStartsDisabled() {
+        let storage = TranslatorInMemoryPluginStorage()
+        let store = TranslatorProviderProfileStore(storage: storage)
+        let existing = [
+            TranslatorProviderProfile(id: "one", name: "OpenAI 2"),
+            TranslatorProviderProfile(id: "two", name: "OpenAI 3"),
+        ]
+
+        let profile = store.makeNewProfile(existingProfiles: existing)
+
+        XCTAssertEqual(profile.name, "OpenAI 4")
+        XCTAssertFalse(profile.isEnabled)
+    }
+
+    func testProfileScopedSecretAccountNameIsStable() {
+        XCTAssertEqual(
+            OpenAICompatibleSecretStore.account(profileID: "deepseek"),
+            "translator.provider.deepseek.api-key"
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple translator provider profiles with individual configuration and enablement control
  * Concurrent provider execution with per-provider translation results displayed separately in the panel
  * Per-provider controls including copy and retry actions
  * Settings UI redesigned for managing, adding, deleting, and reordering provider profiles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->