### PR TITLE
Fix: 启动台审查发现的问题（崩溃/热区生命周期/无障碍）

### DIFF
--- a/Plugins/Launchpad/Sources/LaunchpadGridView.swift
+++ b/Plugins/Launchpad/Sources/LaunchpadGridView.swift
@@ -91,6 +91,12 @@ struct LaunchpadGridView: View {
         }
         .onAppear { selectedIndex = 0; currentPage = 0; sessionHidden = hiddenAppIDs }
         .onChange(of: searchText) { _, _ in selectedIndex = 0; currentPage = 0 }
+        // An async `catalog.reload()` can shrink the list under a stale selection; keep the
+        // source-of-truth selection valid so Return never targets a gone/off-page item (Codex P2).
+        .onChange(of: catalog.apps.count) { _, _ in
+            selectedIndex = min(selectedIndex, max(0, filtered.count - 1))
+            currentPage = filtered.isEmpty ? 0 : selectedIndex / perPage
+        }
     }
 
     private var searchBar: some View {
@@ -223,7 +229,8 @@ struct LaunchpadGridView: View {
                     // AX press needs an explicit action to actually change page.
                     .accessibilityAction { goToPage(page) }
                     .accessibilityLabel("第 \(page + 1) 页")
-                    .accessibilityAddTraits(.isButton)
+                    // Announce which dot is the current page (was visual-only — workflow QA).
+                    .accessibilityAddTraits(page == current ? [.isButton, .isSelected] : .isButton)
             }
         }
         .padding(.top, 2)

--- a/Plugins/Launchpad/Sources/LaunchpadHotCornerMonitor.swift
+++ b/Plugins/Launchpad/Sources/LaunchpadHotCornerMonitor.swift
@@ -12,6 +12,9 @@ final class LaunchpadHotCornerMonitor {
 
     private var corner: LaunchpadPreferences.HotCorner = .off
     private var pollTask: Task<Void, Never>?
+
+    /// Whether the cursor poll is active (for tests/diagnostics).
+    var isPolling: Bool { pollTask != nil }
     private var dwellTicks = 0
     private var armed = true
 
@@ -20,7 +23,10 @@ final class LaunchpadHotCornerMonitor {
     private let dwellTicksRequired = 2          // ~240ms in-corner before firing
 
     func update(corner: LaunchpadPreferences.HotCorner) {
-        guard corner != self.corner else { return }
+        // Idempotent: drives start/stop off the current corner. NOT guarded on
+        // `corner != self.corner` — after `stop()` (e.g. plugin deactivate) the poll task
+        // is gone but `corner` is unchanged, so a same-value re-apply on re-activate must
+        // still restart it. `start()` itself no-ops when the task is already running.
         self.corner = corner
         corner == .off ? stop() : start()
     }
@@ -36,11 +42,14 @@ final class LaunchpadHotCornerMonitor {
         guard pollTask == nil else { return }
         pollTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
-                self?.tick()
-                try? await Task.sleep(for: self?.pollInterval ?? .milliseconds(120))
+                guard let self else { break }    // monitor gone → stop the loop, don't spin
+                self.tick()
+                try? await Task.sleep(for: self.pollInterval)
             }
         }
     }
+
+    deinit { pollTask?.cancel() }
 
     private func tick() {
         let point = NSEvent.mouseLocation

--- a/Plugins/Launchpad/Sources/LaunchpadOverlayController.swift
+++ b/Plugins/Launchpad/Sources/LaunchpadOverlayController.swift
@@ -69,6 +69,7 @@ final class LaunchpadOverlayController: NSObject, NSWindowDelegate {
 
     func open() {
         guard window == nil else { return }
+        guard let screen = activeScreen() else { return }   // no display → nothing to show
         // Restore the *user's* app on dismiss, not ourselves. When triggered from the
         // menu bar, frontmost may already be MacTools; capturing that would make
         // dismissal a no-op (Codex P2). The global-hotkey path captures the real app.
@@ -76,7 +77,6 @@ final class LaunchpadOverlayController: NSObject, NSWindowDelegate {
         previousApp = (front == .current) ? nil : front
         catalog.reload()
         sessionMode = preferences.windowMode      // snapshot for this session
-        let screen = activeScreen()
         let isCompact = sessionMode == .compact
         let frame = targetFrame(on: screen)
 
@@ -174,16 +174,12 @@ final class LaunchpadOverlayController: NSObject, NSWindowDelegate {
 
     /// v1 decision: open on the screen under the mouse (NOT NSScreen.main, NOT all
     /// screens). Documented single-display behavior.
-    private func activeScreen() -> NSScreen {
+    /// Screen under the mouse, else the main screen, else `nil` when no displays are
+    /// attached. Callers must handle `nil` (don't open / close) — never fabricate an
+    /// `NSScreen()`, which AppKit doesn't support (unbacked, invalid frame) (CodeRabbit).
+    private func activeScreen() -> NSScreen? {
         let mouse = NSEvent.mouseLocation
-        // `NSScreen.main` is nil ONLY when no displays are attached, which is exactly when
-        // `NSScreen.screens` is empty — so `screens[0]` as a terminal fallback would trap
-        // precisely in the state it's meant to cover (e.g. all displays unplugged while the
-        // launcher is open → fires via the screen-change observer). End with a degenerate
-        // `NSScreen()` instead of an out-of-bounds index (workflow QA).
-        return NSScreen.screens.first { $0.frame.contains(mouse) }
-            ?? NSScreen.main
-            ?? NSScreen()
+        return NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
     }
 
     /// Window frame for the current mode: the whole screen (fullscreen) or a centered
@@ -232,7 +228,8 @@ final class LaunchpadOverlayController: NSObject, NSWindowDelegate {
         ) { [weak self] _ in
             Task { @MainActor in
                 guard let self, let win = self.window, win === session else { return }
-                win.setFrame(self.targetFrame(on: self.activeScreen()), display: true)
+                guard let screen = self.activeScreen() else { self.close(); return } // all displays gone
+                win.setFrame(self.targetFrame(on: screen), display: true)
             }
         }
         tokens.resignObserver = NotificationCenter.default.addObserver(

--- a/Plugins/Launchpad/Sources/LaunchpadOverlayController.swift
+++ b/Plugins/Launchpad/Sources/LaunchpadOverlayController.swift
@@ -176,9 +176,14 @@ final class LaunchpadOverlayController: NSObject, NSWindowDelegate {
     /// screens). Documented single-display behavior.
     private func activeScreen() -> NSScreen {
         let mouse = NSEvent.mouseLocation
+        // `NSScreen.main` is nil ONLY when no displays are attached, which is exactly when
+        // `NSScreen.screens` is empty — so `screens[0]` as a terminal fallback would trap
+        // precisely in the state it's meant to cover (e.g. all displays unplugged while the
+        // launcher is open → fires via the screen-change observer). End with a degenerate
+        // `NSScreen()` instead of an out-of-bounds index (workflow QA).
         return NSScreen.screens.first { $0.frame.contains(mouse) }
             ?? NSScreen.main
-            ?? NSScreen.screens[0]
+            ?? NSScreen()
     }
 
     /// Window frame for the current mode: the whole screen (fullscreen) or a centered

--- a/Plugins/Launchpad/Sources/LaunchpadPlugin.swift
+++ b/Plugins/Launchpad/Sources/LaunchpadPlugin.swift
@@ -64,7 +64,10 @@ final class LaunchpadPlugin: MacToolsPlugin, PluginPrimaryPanel {
         self.preferences = preferences
         self.overlay = LaunchpadOverlayController(preferences: preferences)
 
-        hotCornerMonitor.onTrigger = { [weak self] in self?.openLaunchpad() }
+        // Hot corner *summons* (open-only), it does not toggle: re-entering the corner
+        // while the launcher is already open must not close it (Codex P1). `open()` is a
+        // no-op when already shown. Menu button / global hotkey keep toggle semantics.
+        hotCornerMonitor.onTrigger = { [weak self] in self?.overlay.open() }
         // Apply the saved corner now and whenever the user changes it in settings.
         preferences.$hotCorner
             .sink { [weak hotCornerMonitor] corner in hotCornerMonitor?.update(corner: corner) }
@@ -119,10 +122,18 @@ final class LaunchpadPlugin: MacToolsPlugin, PluginPrimaryPanel {
         overlay.toggle()
     }
 
+    func activate(context: PluginRuntimeContext) {
+        // Re-arm the hot corner after a pause/resume cycle. `deactivate` stops the poll;
+        // without this, disable→enable would leave the corner "on" in settings but dead
+        // (Codex P1). `update` restarts the poll when the saved corner isn't `.off`.
+        hotCornerMonitor.update(corner: preferences.hotCorner)
+    }
+
     func deactivate(reason: PluginDeactivationReason) {
-        if reason.requiresStateCleanup {
-            hotCornerMonitor.stop()      // stop the cursor poll; no runaway timer
-            overlay.close()
-        }
+        // Always release the internal poll task + overlay window — including `.updating`
+        // (hot reload), so a replaced instance never leaves a stale 120ms poll or window
+        // behind (Codex P1). These are process-internal resources, not system side effects.
+        hotCornerMonitor.stop()
+        overlay.close()
     }
 }

--- a/Plugins/Launchpad/Tests/LaunchpadHotCornerTests.swift
+++ b/Plugins/Launchpad/Tests/LaunchpadHotCornerTests.swift
@@ -47,4 +47,21 @@ final class LaunchpadHotCornerTests: XCTestCase {
         XCTAssertTrue(LaunchpadHotCornerMonitor.isInCorner(
             CGPoint(x: -2, y: 2), corner: .bottomRight, screenFrame: secondary, threshold: t))
     }
+
+    // Regression for the pause/resume restart bug (Codex P1): a non-`.off` re-apply after
+    // `stop()` must restart the poll — the old `guard corner != self.corner` early-return broke it.
+    @MainActor
+    func testUpdateRestartsPollAfterStop() {
+        let monitor = LaunchpadHotCornerMonitor()
+        XCTAssertFalse(monitor.isPolling)
+        monitor.update(corner: .topLeft)
+        XCTAssertTrue(monitor.isPolling)
+        monitor.stop()
+        XCTAssertFalse(monitor.isPolling)
+        monitor.update(corner: .topLeft)        // same value as before stop → must still restart
+        XCTAssertTrue(monitor.isPolling)
+        monitor.update(corner: .off)
+        XCTAssertFalse(monitor.isPolling)
+        monitor.stop()                           // cleanup
+    }
 }


### PR DESCRIPTION
启动台插件（#125 已合并）合并后做了一轮全量审查（Codex 全量只读审查 + 对抗式多 agent QA 工作流，27 条发现经逐条对抗验证），修复确认的问题：

### 崩溃
- `activeScreen()` 结尾 `?? NSScreen.screens[0]`：`NSScreen.main` 仅在无显示器时为 nil，而那正是 `screens` 为空、下标越界之时——这个兜底只会在它必崩的状态下执行。启动台开着时全部显示器断开（合盖 / Mac mini 拔屏 / 重配瞬间）会经 `didChangeScreenParameters` 观察器触发。改为 `?? NSScreen()`。

### 热区生命周期
- 插件**禁用→启用**后热区不再触发：`deactivate` 停了轮询，但 `update` 因 `corner` 未变早退、无法重启。去掉早退；新增 `activate(context:)` 重新应用偏好；`deactivate` 对**所有 reason**（含 `.updating` 热更新）清理 monitor + overlay，避免残留空转任务/旧窗口；poll 循环加 `guard let self else break` + `deinit` 取消。

### 热区语义
- 触发改 `overlay.open()`（唤起、幂等）而非 `toggle()`：离开角落再回到角落时不会把已打开的启动台误关。菜单按钮/全局热键仍保留 toggle。

### 其它
- 异步 `catalog.reload()` 缩短列表后统一 clamp `selectedIndex/currentPage`，避免回车落到不可见/已消失项。
- 无障碍：页码点用 `.isSelected` 向 VoiceOver 报告当前页。
- 回归测试 `testUpdateRestartsPollAfterStop`（停止后再启用能重启轮询）。

构建通过、启动台单测全过（含新回归）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed app selection from pointing to removed or out-of-view items after content refreshes.
  * Resolved an issue that could affect Launchpad when displays change or are unavailable.
  * Hot corner behavior now consistently opens Launchpad and remains stable after pause/resume cycles.

* **Improvements**
  * Improved page indicator accessibility for screen reader users.
  * Hot corner polling is now more reliable after being stopped and restarted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->