### PR TITLE
Fix: 移除 AppHotkey 释放时悬挂的 Carbon handler（use-after-free）

### DIFF
--- a/Plugins/AppHotkey/Sources/AppHotkeyManager.swift
+++ b/Plugins/AppHotkey/Sources/AppHotkeyManager.swift
@@ -13,18 +13,32 @@ final class AppHotkeyManager {
         let carbonID: UInt32
     }
 
-    // "AHKY" = 0x4148_4B59
-    private static let signature: OSType = 0x4148_4B59
+    // "AHKY" = 0x4148_4B59. Internal (not private) so a test can assert it never
+    // collides with GlobalShortcutManager's signature — the precondition that lets the
+    // signature-filtered handler pass foreign hot keys through to the other manager.
+    nonisolated static let signature: OSType = 0x4148_4B59
 
     var onTrigger: ((UUID) -> Void)?
 
-    private var handlerRef: EventHandlerRef?
+    // `nonisolated(unsafe)`: written only in `init` (via `installHandler`), read only in
+    // `deinit` — no concurrent access — so `deinit` can remove the handler without tripping
+    // Swift 6's "non-Sendable access from a nonisolated deinit" rule.
+    nonisolated(unsafe) private var handlerRef: EventHandlerRef?
     private var registeredHotKeys: [UUID: RegisteredHotKey] = [:]
     private var idsByCarbon: [UInt32: UUID] = [:]
     private var nextCarbonID: UInt32 = 1
 
     init() {
         installHandler()
+    }
+
+    deinit {
+        // 进程级 Carbon handler 用 passUnretained(self) 安装，实例释放前必须移除，
+        // 否则悬挂 handler 仍会触发并解引用已释放的 self（use-after-free）。
+        // AppHotkeyManager 属于可动态卸载/重载的插件，释放是真实路径，不是理论问题。
+        if let handlerRef {
+            RemoveEventHandler(handlerRef)
+        }
     }
 
     /// 根据当前 entries 重新同步热键注册（增量 diff）。

--- a/Plugins/AppHotkey/Tests/HotkeySignatureDispatchTests.swift
+++ b/Plugins/AppHotkey/Tests/HotkeySignatureDispatchTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import MacTools
+@testable import AppHotkeyPlugin
+
+/// The app-hotkey plugin and the host's global-shortcut manager both install Carbon
+/// hot-key handlers on the *same* process-wide event target. Each handler claims only
+/// its own signature and returns `eventNotHandledErr` for foreign hot keys, so the other
+/// manager still receives them. That pass-through dispatch is only correct while the two
+/// signatures never collide — assert the invariant here, since the C event handler itself
+/// can't be exercised without a live Carbon event loop.
+final class HotkeySignatureDispatchTests: XCTestCase {
+    func testManagersUseDistinctSignatures() {
+        XCTAssertNotEqual(
+            AppHotkeyManager.signature,
+            GlobalShortcutManager.signature,
+            "Colliding signatures would make each handler swallow the other's hot keys."
+        )
+    }
+
+    func testSignaturesMatchDocumentedFourCC() {
+        // Document the bytes (the signature *is* the FourCC) rather than re-stating hex,
+        // so a transposed character is caught here.
+        XCTAssertEqual(AppHotkeyManager.signature, Self.fourCharCode("AHKY"))
+        XCTAssertEqual(GlobalShortcutManager.signature, Self.fourCharCode("MCTL"))
+    }
+
+    /// Packs a 4-char ASCII string into an `OSType` the way Carbon FourCC literals do.
+    private static func fourCharCode(_ string: String) -> OSType {
+        precondition(string.unicodeScalars.count == 4 && string.unicodeScalars.allSatisfy { $0.isASCII })
+        return string.unicodeScalars.reduce(0) { ($0 << 8) + OSType($1.value) }
+    }
+}

--- a/Sources/Core/Shortcuts/GlobalShortcutManager.swift
+++ b/Sources/Core/Shortcuts/GlobalShortcutManager.swift
@@ -15,7 +15,9 @@ final class GlobalShortcutManager {
         var shortcutIDs: [String]
     }
 
-    private static let signature: OSType = 0x4D43544C
+    // "MCTL" = 0x4D43544C. Internal + nonisolated (not private) for the cross-manager
+    // signature-collision test; see AppHotkeyManager.signature.
+    nonisolated static let signature: OSType = 0x4D43544C
 
     var onShortcutTriggered: ((String) -> Void)?
     var onShortcutReleased: ((String) -> Void)?


### PR DESCRIPTION
## 问题
`AppHotkeyManager` 用 `passUnretained(self)` 安装进程级 Carbon 热键 handler，但**没有在 `deinit` 移除**。实例释放后悬挂 handler 仍会在热键触发时解引用已释放的 `self` → **use-after-free**。AppHotkeyManager 属于可动态卸载/重载的插件，释放是真实路径。当前 main 上 `deinit` 缺失。

## 修复
- 补 `deinit` 调 `RemoveEventHandler(handlerRef)`。
- `handlerRef` 标 `nonisolated(unsafe)`（仅 init 写、deinit 读，无并发），让 deinit 在 Swift 6 下安全访问。

## 测试
新增 `HotkeySignatureDispatchTests`：断言两个 manager 签名互异（共用进程级事件目标，过滤放行他人事件的前提）并验证各自等于 FourCC（AHKY/MCTL）。为此把两个 signature 从 private 放宽为 internal（仅可见性）。本地 xcodebuild test 通过。

## 说明
基于当前 main 的最小修复。旧 PR #107 也含此 deinit，但落后 main 53 commit、签名过滤部分已被 main 覆盖（CONFLICTING）；本 PR 只取仍缺失的 UAF 修复，#107 可在此合并后关闭。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper cleanup of hotkey handlers when application instances are deallocated, preventing stale event processing.

* **Tests**
  * Added tests to validate hotkey signature uniqueness and correctness across managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->