### PR TITLE
Make Homebrew cask update workflow manual

### DIFF
--- a/.github/workflows/homebrew-cask-update.yml
+++ b/.github/workflows/homebrew-cask-update.yml
@@ -1,11 +1,6 @@
 name: Homebrew Cask Update
 
 on:
-  workflow_run:
-    workflows:
-      - Release
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary
- Remove the `workflow_run` trigger from the Homebrew cask update workflow
- Keep `workflow_dispatch` so the workflow can still be run manually when needed

## Rationale
Homebrew/homebrew-cask maintainers noted that their infrastructure already checks for new cask versions roughly every few hours and opens update PRs automatically. Keeping this workflow manual avoids duplicate update PRs while preserving an emergency fallback.

## Validation
- Parsed `.github/workflows/homebrew-cask-update.yml` with Ruby YAML loader
- Reviewed the diff to confirm only the automatic Release-triggered invocation was removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the homebrew cask update workflow trigger mechanism. The workflow can now be manually activated with an optional version parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->