### PR TITLE
fix(l10n): remove unnecessary line break in about description

### DIFF
--- a/Sources/Resources/Localization/Settings.xcstrings
+++ b/Sources/Resources/Localization/Settings.xcstrings
@@ -7,13 +7,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A free, open-source collection of macOS menu bar tools.\\nBuilt with SwiftUI."
+            "value": "A free, open-source collection of macOS menu bar tools. Built with SwiftUI."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "一款免费、开源的 macOS 菜单栏工具集合。\\n使用 SwiftUI 构建。"
+            "value": "一款免费、开源的 macOS 菜单栏工具集合。使用 SwiftUI 构建。"
           }
         }
       }


### PR DESCRIPTION
<img width="1440" height="1064" alt="image" src="https://github.com/user-attachments/assets/e33dacb7-aa60-46d3-9aed-0fbe40d79279" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Chinese (Simplified) localization for the About description to correct newline encoding, ensuring line breaks display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->