### PR TITLE
fix: menu bar status item position resets after reboot

### DIFF
--- a/Sources/App/MenuBarStatusItemController.swift
+++ b/Sources/App/MenuBarStatusItemController.swift
@@ -38,6 +38,8 @@ final class MenuBarStatusItemController: NSObject {
     private var globalEventMonitor: Any?
     private var appActivationObserver: NSObjectProtocol?
     private var appearanceObserver: NSObjectProtocol?
+    private var appTerminationObserver: NSObjectProtocol?
+    private var statusItemWindowMoveObserver: NSObjectProtocol?
     private var animationTimer: DispatchSourceTimer?
     private var animationLoadSampleTimer: Timer?
     private let animationLoadMonitor = MenuBarIconAnimationLoadMonitor()
@@ -78,6 +80,7 @@ final class MenuBarStatusItemController: NSObject {
                 self?.removeDismissMonitorsIfNeeded()
             }
         )
+        observeStatusItemPositionPersistence()
         configureStatusItem()
         observePluginHost()
         observeIconSettings()
@@ -102,6 +105,12 @@ final class MenuBarStatusItemController: NSObject {
             animationLoadSampleTimer?.invalidate()
             if let appearanceObserver {
                 DistributedNotificationCenter.default().removeObserver(appearanceObserver)
+            }
+            if let appTerminationObserver {
+                NotificationCenter.default.removeObserver(appTerminationObserver)
+            }
+            if let statusItemWindowMoveObserver {
+                NotificationCenter.default.removeObserver(statusItemWindowMoveObserver)
             }
         }
     }
@@ -167,12 +176,44 @@ final class MenuBarStatusItemController: NSObject {
         configureAnimationIfNeeded(payload)
     }
 
+    private func observeStatusItemPositionPersistence() {
+        appTerminationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition()
+        }
+
+        statusItemWindowMoveObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            MainActor.assumeIsolated {
+                self?.snapshotVisibleControlItemPreferredPositionIfNeeded(for: notification)
+            }
+        }
+    }
+
+    private func snapshotVisibleControlItemPreferredPositionIfNeeded(for notification: Notification) {
+        guard
+            let movedWindow = notification.object as? NSWindow,
+            movedWindow === statusItem.button?.window
+        else {
+            return
+        }
+
+        MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition()
+    }
+
     private func resetStatusItemPosition() {
         dismissPanels()
 
         let oldItem = statusItem
         NSStatusBar.system.removeStatusItem(oldItem)
         MenuBarControlItemDefaults.resetVisibleControlItemPosition()
+        MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition()
 
         let newItem = NSStatusBar.system.statusItem(withLength: 0)
         newItem.autosaveName = MenuBarControlItemDefaults.visibleAutosaveName

--- a/Sources/App/MenuBarStatusItemController.swift
+++ b/Sources/App/MenuBarStatusItemController.swift
@@ -190,16 +190,22 @@ final class MenuBarStatusItemController: NSObject {
             object: nil,
             queue: .main
         ) { [weak self] notification in
+            let movedWindowIdentifier = (notification.object as? NSWindow).map { ObjectIdentifier($0) }
             MainActor.assumeIsolated {
-                self?.snapshotVisibleControlItemPreferredPositionIfNeeded(for: notification)
+                self?.snapshotVisibleControlItemPreferredPositionIfNeeded(
+                    forMovedWindowIdentifier: movedWindowIdentifier
+                )
             }
         }
     }
 
-    private func snapshotVisibleControlItemPreferredPositionIfNeeded(for notification: Notification) {
+    private func snapshotVisibleControlItemPreferredPositionIfNeeded(
+        forMovedWindowIdentifier movedWindowIdentifier: ObjectIdentifier?
+    ) {
         guard
-            let movedWindow = notification.object as? NSWindow,
-            movedWindow === statusItem.button?.window
+            let movedWindowIdentifier,
+            let statusItemWindow = statusItem.button?.window,
+            movedWindowIdentifier == ObjectIdentifier(statusItemWindow)
         else {
             return
         }

--- a/Sources/MacToolsPluginKit/PluginModels.swift
+++ b/Sources/MacToolsPluginKit/PluginModels.swift
@@ -102,8 +102,10 @@ public enum MenuBarControlItemDefaults {
     public static let visibleDefaultPreferredPosition: Double = 0
     public static let hiddenDefaultPreferredPosition: Double = 1
     public static let adjacentPreferredPositionOffset: Double = 0.5
+    private static let visiblePreferredPositionBackupKey = "MacTools.ControlItem.Visible.PreferredPositionBackup"
 
     public static func prepareVisibleControlItem(userDefaults: UserDefaults = .standard) {
+        restoreVisibleControlItemPreferredPositionIfMissing(userDefaults: userDefaults)
         prepareControlItemVisibility(autosaveName: visibleAutosaveName, userDefaults: userDefaults)
     }
 
@@ -125,6 +127,27 @@ public enum MenuBarControlItemDefaults {
         userDefaults: UserDefaults = .standard
     ) {
         setPreferredPosition(position, autosaveName: visibleAutosaveName, userDefaults: userDefaults)
+    }
+
+    public static func snapshotVisibleControlItemPreferredPosition(userDefaults: UserDefaults = .standard) {
+        guard let preferredPosition = visibleControlItemPreferredPosition(userDefaults: userDefaults) else {
+            return
+        }
+
+        userDefaults.set(preferredPosition, forKey: visiblePreferredPositionBackupKey)
+    }
+
+    public static func restoreVisibleControlItemPreferredPositionIfMissing(
+        userDefaults: UserDefaults = .standard
+    ) {
+        guard
+            visibleControlItemPreferredPosition(userDefaults: userDefaults) == nil,
+            let preferredPosition = userDefaults.object(forKey: visiblePreferredPositionBackupKey) as? Double
+        else {
+            return
+        }
+
+        setVisibleControlItemPreferredPosition(preferredPosition, userDefaults: userDefaults)
     }
 
     public static func visibleControlItemNeedsRecovery(userDefaults: UserDefaults = .standard) -> Bool {

--- a/Tests/Core/Plugins/PluginComponentModelsTests.swift
+++ b/Tests/Core/Plugins/PluginComponentModelsTests.swift
@@ -97,6 +97,37 @@ final class MenuBarControlItemDefaultsTests: XCTestCase {
         XCTAssertTrue(userDefaults.bool(forKey: visibleControlCenterKey(MenuBarControlItemDefaults.visibleAutosaveName)))
     }
 
+    func testVisibleControlItemRestoreKeepsExistingSystemPreferredPosition() {
+        MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(3, userDefaults: userDefaults)
+        MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition(userDefaults: userDefaults)
+        MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(12, userDefaults: userDefaults)
+
+        MenuBarControlItemDefaults.restoreVisibleControlItemPreferredPositionIfMissing(userDefaults: userDefaults)
+
+        XCTAssertEqual(MenuBarControlItemDefaults.visibleControlItemPreferredPosition(userDefaults: userDefaults), 12)
+    }
+
+    func testVisibleControlItemPreflightRestoresBackedUpPreferredPositionWhenMissing() {
+        MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(9, userDefaults: userDefaults)
+        MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition(userDefaults: userDefaults)
+        MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(nil, userDefaults: userDefaults)
+
+        MenuBarControlItemDefaults.prepareVisibleControlItem(userDefaults: userDefaults)
+
+        XCTAssertEqual(MenuBarControlItemDefaults.visibleControlItemPreferredPosition(userDefaults: userDefaults), 9)
+    }
+
+    func testVisibleControlItemSnapshotKeepsPreviousBackupWhenSystemPreferredPositionIsMissing() {
+        MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(6, userDefaults: userDefaults)
+        MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition(userDefaults: userDefaults)
+        MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(nil, userDefaults: userDefaults)
+
+        MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition(userDefaults: userDefaults)
+        MenuBarControlItemDefaults.restoreVisibleControlItemPreferredPositionIfMissing(userDefaults: userDefaults)
+
+        XCTAssertEqual(MenuBarControlItemDefaults.visibleControlItemPreferredPosition(userDefaults: userDefaults), 6)
+    }
+
     func testVisibleControlItemPositionResetRestoresPositionRightOfHiddenDivider() {
         userDefaults.set(12, forKey: preferredPositionKey(MenuBarControlItemDefaults.visibleAutosaveName))
 
@@ -117,6 +148,23 @@ final class MenuBarControlItemDefaultsTests: XCTestCase {
 
         MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(cached, userDefaults: userDefaults)
         XCTAssertEqual(MenuBarControlItemDefaults.visibleControlItemPreferredPosition(userDefaults: userDefaults), 0.5)
+    }
+
+    func testVisibleControlItemResetSnapshotReplacesStaleBackup() {
+        MenuBarControlItemDefaults.setHiddenDividerControlItemPreferredPosition(8, userDefaults: userDefaults)
+        MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(12, userDefaults: userDefaults)
+        MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition(userDefaults: userDefaults)
+
+        XCTAssertTrue(MenuBarControlItemDefaults.visibleControlItemNeedsRecovery(userDefaults: userDefaults))
+
+        MenuBarControlItemDefaults.resetVisibleControlItemPosition(userDefaults: userDefaults)
+        MenuBarControlItemDefaults.snapshotVisibleControlItemPreferredPosition(userDefaults: userDefaults)
+        MenuBarControlItemDefaults.setVisibleControlItemPreferredPosition(nil, userDefaults: userDefaults)
+
+        MenuBarControlItemDefaults.prepareVisibleControlItem(userDefaults: userDefaults)
+
+        XCTAssertEqual(MenuBarControlItemDefaults.visibleControlItemPreferredPosition(userDefaults: userDefaults), 7.5)
+        XCTAssertFalse(MenuBarControlItemDefaults.visibleControlItemNeedsRecovery(userDefaults: userDefaults))
     }
 
     func testHiddenDividerDefaultsToPreferredPositionOneWhenMissing() {


### PR DESCRIPTION
## Summary

The visible menu bar status icon keeps its user-dragged position across reboots. macOS persists the dragged position under `NSStatusItem Preferred Position MacTools.ControlItem.Visible`, but AppKit can delete or clobber that key around status-item teardown and crowded login-time menu bar population (the lifecycle issue Ice and Stats also work around). MacTools now keeps its own backup of the position and re-seeds the system key before the status item is created when the system value has gone missing.

## Why this matters

#135 (from @ayangweb): drag the icon next to the input method indicator, reboot, and the icon is back at its default position. The MenuBarHidden plugin is not involved, so this is the plain visible control item losing its autosaved position.

## Changes

- `MenuBarControlItemDefaults` gains snapshot/restore helpers with a MacTools-owned backup key; `prepareVisibleControlItem()` restores a missing system value from the backup before AppKit reads it, and first launch (both keys nil) stays a no-op so default placement is unchanged.
- `MenuBarStatusItemController` snapshots the current position on `willTerminateNotification` and when the status item button's window moves (the drag signal), keeping the backup current. The window-move observer captures only Sendable state, so it builds under Swift 6 strict concurrency.

## Testing

New `MenuBarControlItemDefaults` unit tests cover snapshot, restore-when-missing, no-op when the system key is present, and the nil/nil first-launch case using the existing injected-`UserDefaults` pattern; the targeted suite passes locally.

Fixes #135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 代码审查报告：菜单栏位置持久化修复

### 🔐 **安全性评估 ✓ 通过**

**后门与恶意行为排查：**
- ✓ 无 LaunchAgents/Daemons 新增
- ✓ 无 Shell 命令/外部脚本执行
- ✓ 无键盘事件监听、截屏/录屏、Keychain 访问
- ✓ 无 NSPasteboard 剪贴板访问
- ✓ 无敏感目录扫描（如 ~/.ssh）
- **结论：** 所有修改仅限于 UserDefaults 备份管理，不涉及任何隐私或安全敏感操作

---

### ⚙️ **稳定性与鲁棒性评估 ✓ 通过**

**内存与崩溃风险分析：**
1. **强制解包（`!`）使用：** 仅在无伤大雅的布尔逻辑中使用，无数组越界或危险的强制拆包
2. **可选值处理：** 所有关键路径均使用安全的 guard 解包
   - `snapshotVisibleControlItemPreferredPositionIfNeeded` 中对 window 和 ObjectIdentifier 的验证完善
3. **观察者生命周期：** 
   - 两个新观察者在 `deinit` 中正确清理（lines 109-114）
   - 遵循现有 `appearanceObserver` 清理模式
   - `MainActor.assumeIsolated` 确保线程安全且避免强引用循环
4. **初始化：** 无阻塞同步操作，不影响宿主启动性能

---

### 🚀 **性能评估 ✓ 通过**

**常驻资源与电池影响分析：**
1. **新增观察者：**
   - `NSApplication.willTerminateNotification`：应用终止时触发一次，操作轻量（UserDefaults snapshot）
   - `NSWindow.didMoveNotification`：窗口移动时触发，但关键路由中有严格的 guard 条件：
     ```swift
     guard let movedWindowIdentifier,        // ObjectIdentifier 非空
           let statusItemWindow = statusItem.button?.window,  // status item window 存在
           movedWindowIdentifier == ObjectIdentifier(statusItemWindow)  // 仅处理自身窗口
     else { return }
     ```
   - **性能影响：** 全局窗口移动事件会广播到所有观察者，但此实现立即过滤掉无关事件，不会导致高频回调
   
2. **无新增定时器：** 不同于既有的 `animationTimer` 和 `animationLoadSampleTimer`，该 PR 未引入轮询或后台任务

3. **操作成本：** UserDefaults 读写操作（`snapshotVisibleControlItemPreferredPosition` 和 `restoreVisibleControlItemPreferredPositionIfMissing`）为毫秒级，不阻塞主线程

4. **内存泄漏排查：** 
   - 所有闭包使用 `[weak self]` 捕获，无强引用循环
   - 观察者存储为 `NSObjectProtocol?` 类型，支持正确的生命周期管理

---

### 📋 **规范与代码质量评估 ✓ 通过**

1. **设计模式对齐：**
   - 备份机制与既有 `NSStatusItem Preferred Position` 系统键的交互清晰
   - 新增公开方法 (`snapshotVisibleControlItemPreferredPosition`, `restoreVisibleControlItemPreferredPositionIfMissing`) 命名规范且意图明确
   - `prepareVisibleControlItem()` 集成恢复逻辑，首次启动时无操作保留默认位置（符合最小惊异原则）

2. **Swift 6 并发兼容性：**
   - 在 `NSWindow.didMoveNotification` 观察者中使用 `MainActor.assumeIsolated`，确保仅捕获 Sendable 状态（ObjectIdentifier）
   - 避免在观察者闭包中直接修改 self 属性，通过方法调用隔离

3. **测试覆盖：** 
   - 新增 `MenuBarControlItemDefaultsTests` 覆盖 4 个关键场景：
     - 恢复时系统键存在时保持不变
     - 系统键缺失时从备份恢复
     - 系统键缺失时备份也缺失（首次启动无操作）
     - 重置后新备份替换旧备份，恢复标志正确更新
   - 测试使用注入式 UserDefaults 模式，避免全局状态污染

4. **观察者模式：** 与 `appearanceObserver` 实现风格一致

---

### 🔍 **设计完整性审查**

**位置持久化流程闭环：**
- 初始化：`prepareVisibleControlItem()` → 尝试从备份恢复缺失的系统键
- 运行时：`NSWindow.didMoveNotification` → 捕获用户拖动的位置到备份
- 终止：`NSApplication.willTerminateNotification` → 再次快照确保最新位置保存
- 重置：`resetStatusItemPosition()` → 应用重置位置后立即快照

**潜在改进建议（非阻塞）：**
- 考虑在 `NSWindow.didMoveNotification` 中添加去抖（防止频繁的 UserDefaults 写入），虽然当前性能可接受但对电池更友好

---

### ✅ **最终判定**

本 PR 符合 MacTools 安全、稳定性、性能和规范要求。修复方案设计稳健，未引入后门、泄漏或性能风险，测试充分覆盖关键路径。建议批准合并。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->