### PR TITLE
Fix ActivityBar component card chrome

### DIFF
--- a/Plugins/ActivityBar/Sources/ActivityBarComponentView.swift
+++ b/Plugins/ActivityBar/Sources/ActivityBarComponentView.swift
@@ -3,16 +3,6 @@ import Charts
 import SwiftUI
 import MacToolsPluginKit
 
-private struct ActivityBarPanelShape: Shape {
-    func path(in rect: CGRect) -> Path {
-        Path(
-            roundedRect: rect,
-            cornerRadius: ActivityBarComponentLayout.cardCornerRadius,
-            style: .continuous
-        )
-    }
-}
-
 private enum ActivityBarComponentLayout {
     static let cardCornerRadius = PluginComponentPanelLayoutMetrics.cardCornerRadius
 }
@@ -193,12 +183,13 @@ struct ActivityBarComponentView: View {
             footerBar
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .background(.regularMaterial, in: ActivityBarPanelShape())
-        .overlay {
-            ActivityBarPanelShape()
-                .stroke(Color.black.opacity(0.5), lineWidth: 1)
-        }
-        .shadow(color: .black.opacity(0.2), radius: 10, y: 4)
+        .background(ActivityBarComponentBackground(cornerRadius: ActivityBarComponentLayout.cardCornerRadius))
+        .clipShape(
+            RoundedRectangle(
+                cornerRadius: ActivityBarComponentLayout.cardCornerRadius,
+                style: .continuous
+            )
+        )
         .animation(.easeInOut(duration: 0.2), value: statsExpanded)
         .animation(.easeInOut(duration: 0.2), value: chartRange)
         .animation(.easeInOut(duration: 0.2), value: trendMode)
@@ -1295,5 +1286,14 @@ struct ActivityBarComponentView: View {
         let tint: Color
         let systemImage: String
         let iconSize: CGFloat
+    }
+}
+
+private struct ActivityBarComponentBackground: View {
+    let cornerRadius: CGFloat
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(Color.primary.opacity(0.045))
     }
 }

--- a/Plugins/ActivityBar/plugin.json
+++ b/Plugins/ActivityBar/plugin.json
@@ -27,6 +27,5 @@
     "configuration": false
   },
   "permissions": [],
-  "category": "monitoring",
-  "releaseChannel": "beta"
+  "category": "monitoring"
 }


### PR DESCRIPTION
## Summary
- Replace ActivityBar's custom component-panel chrome with the same lightweight rounded card background used by other component plugins.
- Remove the ActivityBar-specific material, black stroke, and drop shadow that created a visible rectangular corner under the rounded component.
- Keep the existing ActivityBar panel content, layout, charts, and interactions unchanged.
- Remove ActivityBar's beta release channel from the plugin source manifest now that the UI issue is fixed.

## Root Cause
ActivityBar rendered its own full component container using `.regularMaterial`, a dark stroke, and shadow. Other component-panel plugins draw only a subtle rounded fill (`Color.primary.opacity(0.045)`) inside the host grid. The extra ActivityBar chrome conflicted with the host/component card shape and made the lower rectangular layer visible around the rounded corner.

## Release Channel Note
`docs/plugins/catalog.json` is a signed production catalog, so this PR intentionally does not hand-edit it. The local debug catalog and the next plugin release catalog are generated from `Plugins/ActivityBar/plugin.json`, where the beta channel has been removed.

## Before / After
| Before | After |
| --- | --- |
| ![ActivityBar before](https://raw.githubusercontent.com/char1eslu/MacTools/pr-assets-activitybar-ui-screenshots/docs/pr-assets/activitybar-component-card-chrome/before.png) | ![ActivityBar after](https://raw.githubusercontent.com/char1eslu/MacTools/pr-assets-activitybar-ui-screenshots/docs/pr-assets/activitybar-component-card-chrome/after.png) |

## Validation
- `swiftc -parse Plugins/ActivityBar/Sources/ActivityBarComponentView.swift`
- `python3 -m json.tool Plugins/ActivityBar/plugin.json`
- `git diff --check`
- GitHub Actions Build run on fork: https://github.com/char1eslu/MacTools/actions/runs/27529349905
