### PR TITLE
Fix brightness refresh for reconnected displays

### DIFF
--- a/Plugins/DisplayBrightness/Sources/DisplayBrightnessController.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayBrightnessController.swift
@@ -148,6 +148,10 @@ final class DisplayBrightnessController: DisplayBrightnessControlling {
         for displayID: CGDirectDisplayID,
         phase: PluginPanelAction.SliderPhase
     ) {
+        if managedDisplays[displayID] == nil {
+            refresh()
+        }
+
         guard var managedDisplay = managedDisplays[displayID] else {
             lastErrorMessage = DisplayBrightnessControllerError.displayUnavailable(
                 displayID: displayID

--- a/Plugins/DisplayBrightness/Tests/DisplayBrightnessControllerTests.swift
+++ b/Plugins/DisplayBrightness/Tests/DisplayBrightnessControllerTests.swift
@@ -62,6 +62,35 @@ final class DisplayBrightnessControllerTests: XCTestCase {
         XCTAssertEqual(backend.readCount, 1)
     }
 
+    func testSetBrightnessRefreshesTopologyBeforeFailingUnavailableDisplay() async {
+        let display = makeTestDisplay(id: 3, name: "LG UltraFine")
+        let provider = StubDisplayProvider(displays: [])
+        let backend = TestBrightnessBackend(kind: .ddc, display: display, brightness: 0.45)
+        let builder = StubBrightnessBackendBuilder { displays, _ in
+            displays.contains(where: { $0.id == display.id }) ? [display.id: backend] : [:]
+        }
+
+        let controller = DisplayBrightnessController(
+            displayProvider: provider,
+            backendBuilder: builder,
+            shortWriteDelay: 0.01,
+            minimumWriteInterval: 0
+        )
+        controller.refresh()
+
+        provider.displays = [display]
+        controller.setBrightness(0.7, for: display.id, phase: .ended)
+
+        await waitUntil {
+            backend.writeCount == 1
+        }
+
+        XCTAssertEqual(backend.recordedWrites, [0.7])
+        XCTAssertEqual(controller.snapshot().displays.map(\.id), [display.id])
+        XCTAssertNil(controller.snapshot().errorMessage)
+        XCTAssertEqual(builder.calls.map { $0.map(\.id) }, [[], [display.id]])
+    }
+
     func testEndedPhaseReadsBackHardwareBrightnessAndUpdatesSnapshot() async {
         let display = makeTestDisplay(id: 1, name: "LG UltraFine")
         let provider = StubDisplayProvider(displays: [display])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Lazy Display Refresh on Brightness Set

**Objective:** Enable brightness control for displays that reconnect after the plugin is initialized, addressing a scenario where users plug in an external display and immediately attempt to adjust its brightness.

### Changes
- **DisplayBrightnessController.swift** (`setBrightness(_:for:phase:)`): Added a lazy `refresh()` call when the target `displayID` is not found in `managedDisplays`. The method now re-enumerates available displays before falling back to the "display unavailable" error, allowing the controller to discover newly connected displays on-demand.
- **DisplayBrightnessControllerTests.swift**: Added test `testSetBrightnessRefreshesTopologyBeforeFailingUnavailableDisplay` to verify the refresh behavior: confirms the controller attempts topology enumeration, successfully discovers the reconnected display, writes the new brightness value, and clears error state.

### Assessment

**SECURITY** ✓ No concerns.
- No unsafe operations, force unwraps, or unauthorized system access.
- No clipboard, keychain, or sensitive directory scanning.

**STABILITY & ROBUSTNESS** ✓ Safe.
- Guard statement properly handles the case where `refresh()` still cannot locate the display.
- `@MainActor` annotation ensures thread safety.
- No force unwraps or array bounds violations.
- Maintains existing error handling path.

**PERFORMANCE** ✓ Acceptable.
- `refresh()` is only invoked once per `setBrightness()` call when display is missing, not in a polling loop.
- Main thread latency is acceptable for interactive slider operations and reconnect scenarios.
- Synchronous design matches existing usage patterns (`refreshDisplayTopology()` is also synchronous).

**CODE CONVENTIONS** ✓ Consistent.
- Follows existing guard statement patterns and error handling style.
- Test naming and structure align with existing test suite.
- Maintains separation of concerns.

### Summary
A minimal, well-tested fix that gracefully handles the reconnected display scenario without introducing performance overhead or stability risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->