### PR TITLE
Fix: strip quarantine from local plugin installs after trust validation

### DIFF
--- a/Sources/Core/Diagnostics/AppLog.swift
+++ b/Sources/Core/Diagnostics/AppLog.swift
@@ -8,6 +8,7 @@ enum AppLog {
     static let displayConfigurationObserver = Logger(subsystem: subsystem, category: "DisplayConfigurationObserver")
     static let autoHideDockPlugin = Logger(subsystem: subsystem, category: "AutoHideDockPlugin")
     static let pluginHost = Logger(subsystem: subsystem, category: "PluginHost")
+    static let dynamicPlugins = Logger(subsystem: subsystem, category: "DynamicPlugins")
     static let launchAtLogin = Logger(subsystem: subsystem, category: "LaunchAtLogin")
 
     static var isVerboseLoggingEnabled: Bool {

--- a/Sources/Core/Plugins/Dynamic/DynamicPluginLoader.swift
+++ b/Sources/Core/Plugins/Dynamic/DynamicPluginLoader.swift
@@ -16,13 +16,16 @@ protocol DynamicPluginLoading {
 final class DynamicPluginLoader: DynamicPluginLoading {
     private let packageStore: PluginPackageStore
     private let trustValidator: PluginTrustValidating
+    private let quarantineInspector: PluginQuarantineInspecting
 
     init(
         packageStore: PluginPackageStore,
-        trustValidator: PluginTrustValidating = SameTeamPluginTrustValidator()
+        trustValidator: PluginTrustValidating = SameTeamPluginTrustValidator(),
+        quarantineInspector: PluginQuarantineInspecting = PluginQuarantineInspector()
     ) {
         self.packageStore = packageStore
         self.trustValidator = trustValidator
+        self.quarantineInspector = quarantineInspector
     }
 
     func loadInstalledPlugins(from records: [PluginPackageRecord]) -> [DynamicPluginLoadResult] {
@@ -66,6 +69,7 @@ final class DynamicPluginLoader: DynamicPluginLoading {
 
     private func loadProvider(for record: PluginPackageRecord) throws -> any PluginProvider {
         try trustValidator.validatePluginBundle(at: record.bundleURL)
+        stripLingeringQuarantine(from: record)
 
         guard let bundle = Bundle(url: record.bundleURL) else {
             throw DynamicPluginLoaderError.unreadableBundle(record.bundleURL)
@@ -87,6 +91,34 @@ final class DynamicPluginLoader: DynamicPluginLoading {
         }
 
         return try factoryClass.makeProvider(context: context)
+    }
+
+    // Packages installed before install-time quarantine stripping existed may still carry
+    // the attribute, and dlopen of such a bundle fails with an opaque AMFI/Gatekeeper error
+    // in a hardened host. Stripping is gated on the trust validation in loadProvider having
+    // succeeded right before this call; a failed validation never reaches this point.
+    //
+    // Best-effort by design: an inspector failure here must not block the load — a
+    // non-hardened (Debug) host dlopens quarantined bundles just fine, and on a hardened
+    // host dlopen fails exactly as it did before this strip existed, with the warning
+    // below explaining why. The strict, user-facing quarantine error belongs to the
+    // install path in PluginPackageStore.
+    private func stripLingeringQuarantine(from record: PluginPackageRecord) {
+        do {
+            let quarantinedItems = try quarantineInspector.quarantinedItemURLs(in: record.packageURL)
+            guard !quarantinedItems.isEmpty else {
+                return
+            }
+
+            try quarantineInspector.stripQuarantine(at: record.packageURL)
+            AppLog.dynamicPlugins.info(
+                "Stripped lingering quarantine from \(quarantinedItems.count, privacy: .public) item(s) in installed package \(record.id, privacy: .public)"
+            )
+        } catch {
+            AppLog.dynamicPlugins.warning(
+                "Could not strip lingering quarantine from installed package \(record.id, privacy: .public); a hardened host may refuse to load it: \(error.localizedDescription, privacy: .private)"
+            )
+        }
     }
 
     static func validateLoadedPlugins(

--- a/Sources/Core/Plugins/Dynamic/Package/PluginQuarantineInspector.swift
+++ b/Sources/Core/Plugins/Dynamic/Package/PluginQuarantineInspector.swift
@@ -1,0 +1,134 @@
+import Darwin
+import Foundation
+
+enum PluginQuarantineError: LocalizedError, Equatable {
+    case enumerationFailed(path: String)
+    case attributeCheckFailed(path: String, reason: String)
+    case stripFailed(failedCount: Int, path: String, reason: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .enumerationFailed(path):
+            return AppL10n.pluginsFormat(
+                "plugin.error.quarantine.enumerationFailedFormat",
+                defaultValue: "无法检查插件包的隔离状态：%@",
+                path
+            )
+        case let .attributeCheckFailed(path, reason):
+            return AppL10n.pluginsFormat(
+                "plugin.error.quarantine.attributeCheckFailedFormat",
+                defaultValue: "无法读取插件文件的隔离标记：%@（%@）",
+                path,
+                reason
+            )
+        case let .stripFailed(failedCount, path, reason):
+            return AppL10n.pluginsFormat(
+                "plugin.error.quarantine.stripFailedFormat",
+                defaultValue: "无法移除 %d 个插件文件的隔离标记，例如 %@（%@）。",
+                failedCount,
+                path,
+                reason
+            )
+        }
+    }
+}
+
+protocol PluginQuarantineInspecting {
+    func quarantinedItemURLs(in packageURL: URL) throws -> [URL]
+    func stripQuarantine(at packageURL: URL) throws
+}
+
+/// Detects and removes the `com.apple.quarantine` extended attribute from plugin packages.
+///
+/// Browser-downloaded zips carry the quarantine attribute and both `ditto` extraction and
+/// `FileManager` copy/move propagate it onto every file of the package. A quarantined,
+/// codesigned-but-not-notarized bundle is rejected by Gatekeeper when a hardened host
+/// dlopens it, so the attribute must be gone before the bundle reaches the loader.
+struct PluginQuarantineInspector: PluginQuarantineInspecting {
+    static let quarantineAttributeName = "com.apple.quarantine"
+
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func quarantinedItemURLs(in packageURL: URL) throws -> [URL] {
+        try packageItemURLs(in: packageURL).filter { itemURL in
+            try hasQuarantineAttribute(atPath: itemURL.path)
+        }
+    }
+
+    func stripQuarantine(at packageURL: URL) throws {
+        var failures: [(path: String, reason: String)] = []
+
+        for itemURL in try packageItemURLs(in: packageURL) {
+            let path = itemURL.path
+            guard removexattr(path, Self.quarantineAttributeName, XATTR_NOFOLLOW) != 0 else {
+                continue
+            }
+
+            let code = errno
+            // ENOATTR: already clean. ENOTSUP: the file system cannot carry xattrs,
+            // so it cannot carry a quarantine flag either.
+            if code == ENOATTR || code == ENOTSUP {
+                continue
+            }
+
+            failures.append((path: path, reason: Self.errnoDescription(code)))
+        }
+
+        guard let firstFailure = failures.first else {
+            return
+        }
+
+        throw PluginQuarantineError.stripFailed(
+            failedCount: failures.count,
+            path: firstFailure.path,
+            reason: firstFailure.reason
+        )
+    }
+
+    // Every file-system object in the package is visited, not just the bundle executable:
+    // ditto stamps each extracted entry and Gatekeeper evaluates nested bundle items, so a
+    // single missed file keeps dlopen blocked. Packages are small, which makes one xattr
+    // syscall per entry cheaper than reasoning about which files matter.
+    //
+    // The path-based enumerator yields paths relative to the package root, so every
+    // returned URL keeps the caller's root prefix (the URL-based enumerator rewrites
+    // children to /private/var while the root stays /var, producing mixed prefixes).
+    // It also never descends into symlinked directories.
+    private func packageItemURLs(in packageURL: URL) throws -> [URL] {
+        guard let enumerator = fileManager.enumerator(atPath: packageURL.path) else {
+            throw PluginQuarantineError.enumerationFailed(path: packageURL.path)
+        }
+
+        var itemURLs = [packageURL]
+
+        for case let relativePath as String in enumerator {
+            itemURLs.append(packageURL.appendingPathComponent(relativePath))
+        }
+
+        return itemURLs
+    }
+
+    private func hasQuarantineAttribute(atPath path: String) throws -> Bool {
+        // XATTR_NOFOLLOW everywhere: a crafted package could contain symlinks pointing
+        // outside the package, and following them would inspect or strip foreign files.
+        let size = getxattr(path, Self.quarantineAttributeName, nil, 0, 0, XATTR_NOFOLLOW)
+        if size >= 0 {
+            return true
+        }
+
+        let code = errno
+        if code == ENOATTR || code == ENOTSUP {
+            return false
+        }
+
+        throw PluginQuarantineError.attributeCheckFailed(path: path, reason: Self.errnoDescription(code))
+    }
+
+    private static func errnoDescription(_ code: Int32) -> String {
+        String(cString: strerror(code))
+    }
+}

--- a/Sources/Core/Plugins/Dynamic/PluginPackageStore.swift
+++ b/Sources/Core/Plugins/Dynamic/PluginPackageStore.swift
@@ -56,17 +56,23 @@ final class PluginPackageStore {
     private let fileManager: FileManager
     private let userDefaults: UserDefaults
     let hostVersion: String
+    private let trustValidator: PluginTrustValidating
+    private let quarantineInspector: PluginQuarantineInspecting
     private var pendingRestartPluginIDs: Set<String> = []
 
     init(
         rootDirectory: URL? = nil,
         fileManager: FileManager = .default,
         userDefaults: UserDefaults = .standard,
-        hostVersion: String = AppMetadata.shortVersion ?? "0"
+        hostVersion: String = AppMetadata.shortVersion ?? "0",
+        trustValidator: PluginTrustValidating = SameTeamPluginTrustValidator(),
+        quarantineInspector: PluginQuarantineInspecting = PluginQuarantineInspector()
     ) {
         self.fileManager = fileManager
         self.userDefaults = userDefaults
         self.hostVersion = hostVersion
+        self.trustValidator = trustValidator
+        self.quarantineInspector = quarantineInspector
 
         let root = rootDirectory ?? Self.defaultRootDirectory(fileManager: fileManager)
         self.rootDirectory = root
@@ -194,6 +200,20 @@ final class PluginPackageStore {
 
             guard fileManager.fileExists(atPath: stagedBundleURL.path) else {
                 throw PluginPackageStoreError.invalidPackage(stagingURL)
+            }
+
+            // Browser-downloaded zips carry com.apple.quarantine and ditto/copy propagate
+            // it onto every file; Gatekeeper then rejects dlopen of the non-notarized
+            // bundle in a hardened host. Strip the attribute from the staged copy, but
+            // only after the staged bundle passed trust validation — a bundle failing
+            // validation keeps its quarantine and the install fails closed.
+            let quarantinedItems = try quarantineInspector.quarantinedItemURLs(in: stagingURL)
+            if !quarantinedItems.isEmpty {
+                try trustValidator.validatePluginBundle(at: stagedBundleURL)
+                try quarantineInspector.stripQuarantine(at: stagingURL)
+                AppLog.dynamicPlugins.info(
+                    "Stripped quarantine from \(quarantinedItems.count, privacy: .public) item(s) in staged package \(stagedManifest.id, privacy: .public)"
+                )
             }
 
             if hadExistingPackage {

--- a/Sources/Resources/Localization/Plugins.xcstrings
+++ b/Sources/Resources/Localization/Plugins.xcstrings
@@ -1361,6 +1361,57 @@
         }
       }
     },
+    "plugin.error.quarantine.attributeCheckFailedFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to read the quarantine flag of a plugin file: %@ (%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取插件文件的隔离标记：%@（%@）"
+          }
+        }
+      }
+    },
+    "plugin.error.quarantine.enumerationFailedFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to inspect the plugin package for quarantine: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法检查插件包的隔离状态：%@"
+          }
+        }
+      }
+    },
+    "plugin.error.quarantine.stripFailedFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to remove the quarantine flag from %d plugin file(s), for example %@ (%@)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法移除 %d 个插件文件的隔离标记，例如 %@（%@）。"
+          }
+        }
+      }
+    },
     "plugin.error.store.alreadyInstalledFormat": {
       "extractionState": "manual",
       "localizations": {

--- a/Tests/Core/Plugins/Dynamic/DynamicPluginLoaderTests.swift
+++ b/Tests/Core/Plugins/Dynamic/DynamicPluginLoaderTests.swift
@@ -5,6 +5,29 @@ import MacToolsPluginKit
 
 @MainActor
 final class DynamicPluginLoaderTests: XCTestCase {
+    private var temporaryRoot: URL!
+    private var defaults: UserDefaults!
+    private let suiteName = "DynamicPluginLoaderTests"
+
+    override func setUpWithError() throws {
+        temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DynamicPluginLoaderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryRoot {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+        if let defaults {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        defaults = nil
+        temporaryRoot = nil
+    }
+
     func testValidateLoadedPluginsAcceptsSinglePluginMatchingManifestID() throws {
         let record = makeRecord(id: "com.example.demo")
         let plugin = MockLoadedPlugin(id: "com.example.demo")
@@ -50,8 +73,63 @@ final class DynamicPluginLoaderTests: XCTestCase {
         }
     }
 
-    private func makeRecord(id: String) -> PluginPackageRecord {
-        let packageURL = URL(fileURLWithPath: "/tmp/\(id).mactoolsplugin", isDirectory: true)
+    func testLoadStripsQuarantineFromInstalledPackageAfterTrustValidationPasses() throws {
+        let packageURL = try makeInstalledPackage(id: "com.example.demo")
+        PluginQuarantineTestSupport.setQuarantine(atPath: packageURL.path)
+        PluginQuarantineTestSupport.setQuarantine(
+            atPath: packageURL.appendingPathComponent("plugin.json").path
+        )
+        let record = makeRecord(id: "com.example.demo", packageURL: packageURL)
+        let loader = makeLoader(trustValidator: RecordingTrustValidator())
+
+        let results = loader.loadInstalledPlugins(from: [record])
+
+        // Loading the fixture bundle still fails (it has no real executable), but the
+        // quarantine flag must already be gone by the time dlopen is attempted.
+        XCTAssertEqual(results.count, 1)
+        XCTAssertNotNil(results.first?.errorMessage)
+        XCTAssertEqual(PluginQuarantineTestSupport.quarantinedPaths(under: packageURL), [])
+    }
+
+    func testLoadKeepsQuarantineWhenTrustValidationFails() throws {
+        let packageURL = try makeInstalledPackage(id: "com.example.demo")
+        PluginQuarantineTestSupport.setQuarantine(atPath: packageURL.path)
+        let record = makeRecord(id: "com.example.demo", packageURL: packageURL)
+        let validator = RecordingTrustValidator()
+        validator.validationError = PluginTrustValidatorError.hostTeamIdentifierUnavailable
+        let loader = makeLoader(trustValidator: validator)
+
+        let results = loader.loadInstalledPlugins(from: [record])
+
+        XCTAssertEqual(
+            results.first?.errorMessage,
+            PluginTrustValidatorError.hostTeamIdentifierUnavailable.localizedDescription
+        )
+        XCTAssertTrue(PluginQuarantineTestSupport.hasQuarantine(atPath: packageURL.path))
+    }
+
+    private func makeLoader(trustValidator: PluginTrustValidating) -> DynamicPluginLoader {
+        let store = PluginPackageStore(
+            rootDirectory: temporaryRoot.appendingPathComponent("Store", isDirectory: true),
+            userDefaults: defaults,
+            hostVersion: "1.0.0",
+            trustValidator: trustValidator
+        )
+        return DynamicPluginLoader(packageStore: store, trustValidator: trustValidator)
+    }
+
+    private func makeInstalledPackage(id: String) throws -> URL {
+        let packageURL = temporaryRoot
+            .appendingPathComponent(id, isDirectory: true)
+            .appendingPathExtension("mactoolsplugin")
+        let bundleURL = packageURL.appendingPathComponent("Demo.bundle", isDirectory: true)
+        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        try Data("manifest".utf8).write(to: packageURL.appendingPathComponent("plugin.json"))
+        return packageURL
+    }
+
+    private func makeRecord(id: String, packageURL: URL? = nil) -> PluginPackageRecord {
+        let packageURL = packageURL ?? URL(fileURLWithPath: "/tmp/\(id).mactoolsplugin", isDirectory: true)
         return PluginPackageRecord(
             id: id,
             manifest: PluginPackageManifest(
@@ -66,6 +144,19 @@ final class DynamicPluginLoaderTests: XCTestCase {
             state: .enabled,
             requiresRestartToFullyUnload: false
         )
+    }
+}
+
+private final class RecordingTrustValidator: PluginTrustValidating {
+    private(set) var validatedBundleURLs: [URL] = []
+    var validationError: Error?
+
+    func validatePluginBundle(at bundleURL: URL) throws {
+        validatedBundleURLs.append(bundleURL)
+
+        if let validationError {
+            throw validationError
+        }
     }
 }
 

--- a/Tests/Core/Plugins/Dynamic/PluginPackageStoreTests.swift
+++ b/Tests/Core/Plugins/Dynamic/PluginPackageStoreTests.swift
@@ -146,6 +146,52 @@ final class PluginPackageStoreTests: XCTestCase {
         XCTAssertEqual(record.state, .disabled)
     }
 
+    func testInstallStripsQuarantineAfterTrustValidationPasses() throws {
+        let sourceURL = try makePackage(id: "com.example.demo")
+        quarantineSourcePackage(at: sourceURL)
+        let validator = RecordingTrustValidator()
+        let store = makeStore(trustValidator: validator)
+
+        let record = try store.installPackage(from: sourceURL)
+
+        XCTAssertEqual(validator.validatedBundleURLs.map(\.lastPathComponent), ["Demo.bundle"])
+        XCTAssertEqual(PluginQuarantineTestSupport.quarantinedPaths(under: record.packageURL), [])
+        // The source package is never modified, only the staged/installed copy is stripped.
+        XCTAssertTrue(PluginQuarantineTestSupport.hasQuarantine(atPath: sourceURL.path))
+    }
+
+    func testInstallFailsClosedWhenQuarantinedPackageFailsTrustValidation() throws {
+        let sourceURL = try makePackage(id: "com.example.demo")
+        quarantineSourcePackage(at: sourceURL)
+        let validator = RecordingTrustValidator()
+        validator.validationError = PluginTrustValidatorError.hostTeamIdentifierUnavailable
+        let store = makeStore(trustValidator: validator)
+
+        XCTAssertThrowsError(try store.installPackage(from: sourceURL)) { error in
+            guard case let PluginPackageStoreError.installFailed(reason) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+
+            XCTAssertEqual(reason, PluginTrustValidatorError.hostTeamIdentifierUnavailable.localizedDescription)
+        }
+
+        XCTAssertTrue(store.installedRecords().isEmpty)
+        XCTAssertTrue(PluginQuarantineTestSupport.hasQuarantine(atPath: sourceURL.path))
+        let stagedItems = try FileManager.default.contentsOfDirectory(atPath: store.stagingDirectory.path)
+        XCTAssertEqual(stagedItems, [])
+    }
+
+    func testInstallWithoutQuarantineSkipsTrustValidation() throws {
+        let sourceURL = try makePackage(id: "com.example.demo")
+        let validator = RecordingTrustValidator()
+        let store = makeStore(trustValidator: validator)
+
+        let record = try store.installPackage(from: sourceURL)
+
+        XCTAssertEqual(record.state, .enabled)
+        XCTAssertTrue(validator.validatedBundleURLs.isEmpty)
+    }
+
     func testDefaultRootDirectoryUsesCurrentApplicationSupportScope() {
         let rootDirectory = PluginPackageStore.defaultRootDirectory(fileManager: .default)
 
@@ -156,11 +202,24 @@ final class PluginPackageStoreTests: XCTestCase {
         )
     }
 
-    private func makeStore() -> PluginPackageStore {
+    private func makeStore(
+        trustValidator: PluginTrustValidating = RecordingTrustValidator()
+    ) -> PluginPackageStore {
         PluginPackageStore(
             rootDirectory: temporaryRoot,
             userDefaults: defaults,
-            hostVersion: "1.0.0"
+            hostVersion: "1.0.0",
+            trustValidator: trustValidator
+        )
+    }
+
+    private func quarantineSourcePackage(at packageURL: URL) {
+        PluginQuarantineTestSupport.setQuarantine(atPath: packageURL.path)
+        PluginQuarantineTestSupport.setQuarantine(
+            atPath: packageURL.appendingPathComponent("plugin.json").path
+        )
+        PluginQuarantineTestSupport.setQuarantine(
+            atPath: packageURL.appendingPathComponent("Demo.bundle", isDirectory: true).path
         )
     }
 
@@ -194,5 +253,18 @@ final class PluginPackageStoreTests: XCTestCase {
         try data.write(to: packageURL.appendingPathComponent("plugin.json"))
 
         return packageURL
+    }
+}
+
+private final class RecordingTrustValidator: PluginTrustValidating {
+    private(set) var validatedBundleURLs: [URL] = []
+    var validationError: Error?
+
+    func validatePluginBundle(at bundleURL: URL) throws {
+        validatedBundleURLs.append(bundleURL)
+
+        if let validationError {
+            throw validationError
+        }
     }
 }

--- a/Tests/Core/Plugins/Dynamic/PluginQuarantineInspectorTests.swift
+++ b/Tests/Core/Plugins/Dynamic/PluginQuarantineInspectorTests.swift
@@ -1,0 +1,135 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import MacTools
+
+final class PluginQuarantineInspectorTests: XCTestCase {
+    private var temporaryRoot: URL!
+    private let inspector = PluginQuarantineInspector()
+
+    override func setUpWithError() throws {
+        temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PluginQuarantineInspectorTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryRoot {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+        temporaryRoot = nil
+    }
+
+    func testDetectsQuarantineOnRootAndNestedItems() throws {
+        let package = try makePackage()
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.rootURL.path)
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.executableURL.path)
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.hiddenFileURL.path)
+
+        let quarantinedURLs = try inspector.quarantinedItemURLs(in: package.rootURL)
+
+        XCTAssertEqual(
+            Set(quarantinedURLs.map(\.path)),
+            [package.rootURL.path, package.executableURL.path, package.hiddenFileURL.path]
+        )
+    }
+
+    func testCleanPackageReportsNoQuarantinedItems() throws {
+        let package = try makePackage()
+
+        XCTAssertEqual(try inspector.quarantinedItemURLs(in: package.rootURL), [])
+    }
+
+    func testStripRemovesQuarantineFromEveryItem() throws {
+        let package = try makePackage()
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.rootURL.path)
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.manifestURL.path)
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.executableURL.path)
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.hiddenFileURL.path)
+
+        try inspector.stripQuarantine(at: package.rootURL)
+
+        XCTAssertEqual(PluginQuarantineTestSupport.quarantinedPaths(under: package.rootURL), [])
+        XCTAssertEqual(try inspector.quarantinedItemURLs(in: package.rootURL), [])
+    }
+
+    func testStripFailureOnReadOnlyFileMapsToStripFailedError() throws {
+        let package = try makePackage()
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.manifestURL.path)
+        PluginQuarantineTestSupport.setQuarantine(atPath: package.executableURL.path)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o444],
+            ofItemAtPath: package.executableURL.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o644],
+                ofItemAtPath: package.executableURL.path
+            )
+        }
+
+        XCTAssertThrowsError(try inspector.stripQuarantine(at: package.rootURL)) { error in
+            guard case let PluginQuarantineError.stripFailed(failedCount, path, reason) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+
+            XCTAssertEqual(failedCount, 1)
+            XCTAssertEqual(path, package.executableURL.path)
+            XCTAssertFalse(reason.isEmpty)
+            XCTAssertNotNil((error as? PluginQuarantineError)?.errorDescription)
+        }
+
+        // Writable files were still stripped; only the read-only one keeps the flag.
+        XCTAssertFalse(PluginQuarantineTestSupport.hasQuarantine(atPath: package.manifestURL.path))
+        XCTAssertTrue(PluginQuarantineTestSupport.hasQuarantine(atPath: package.executableURL.path))
+    }
+
+    func testStripDoesNotFollowSymlinksOutsideThePackage() throws {
+        let package = try makePackage()
+        let outsideFileURL = temporaryRoot.appendingPathComponent("outside.txt")
+        try Data("outside".utf8).write(to: outsideFileURL)
+        PluginQuarantineTestSupport.setQuarantine(atPath: outsideFileURL.path)
+
+        let symlinkURL = package.rootURL.appendingPathComponent("escape-link")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: outsideFileURL)
+        PluginQuarantineTestSupport.setQuarantine(atPath: symlinkURL.path)
+
+        let quarantinedURLs = try inspector.quarantinedItemURLs(in: package.rootURL)
+        XCTAssertEqual(quarantinedURLs.map(\.path), [symlinkURL.path])
+
+        try inspector.stripQuarantine(at: package.rootURL)
+
+        XCTAssertFalse(PluginQuarantineTestSupport.hasQuarantine(atPath: symlinkURL.path))
+        XCTAssertTrue(PluginQuarantineTestSupport.hasQuarantine(atPath: outsideFileURL.path))
+    }
+
+    private struct FixturePackage {
+        let rootURL: URL
+        let manifestURL: URL
+        let executableURL: URL
+        let hiddenFileURL: URL
+    }
+
+    private func makePackage() throws -> FixturePackage {
+        let rootURL = temporaryRoot.appendingPathComponent("Demo.mactoolsplugin", isDirectory: true)
+        let macOSURL = rootURL
+            .appendingPathComponent("Demo.bundle", isDirectory: true)
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macOSURL, withIntermediateDirectories: true)
+
+        let manifestURL = rootURL.appendingPathComponent("plugin.json")
+        let executableURL = macOSURL.appendingPathComponent("Demo")
+        let hiddenFileURL = rootURL.appendingPathComponent(".hidden")
+        try Data("manifest".utf8).write(to: manifestURL)
+        try Data("binary".utf8).write(to: executableURL)
+        try Data("hidden".utf8).write(to: hiddenFileURL)
+
+        return FixturePackage(
+            rootURL: rootURL,
+            manifestURL: manifestURL,
+            executableURL: executableURL,
+            hiddenFileURL: hiddenFileURL
+        )
+    }
+}

--- a/Tests/Core/Plugins/Dynamic/PluginQuarantineTestSupport.swift
+++ b/Tests/Core/Plugins/Dynamic/PluginQuarantineTestSupport.swift
@@ -1,0 +1,52 @@
+import Darwin
+import Foundation
+import XCTest
+
+/// Shared xattr helpers for quarantine tests. They call the xattr syscalls directly so
+/// assertions stay independent from `PluginQuarantineInspector`'s own implementation.
+enum PluginQuarantineTestSupport {
+    static let attributeName = "com.apple.quarantine"
+
+    static func setQuarantine(
+        atPath path: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let valueBytes = Array("0083;00000000;TestBrowser;".utf8)
+        let result = valueBytes.withUnsafeBytes { buffer in
+            setxattr(path, attributeName, buffer.baseAddress, buffer.count, 0, XATTR_NOFOLLOW)
+        }
+        XCTAssertEqual(
+            result,
+            0,
+            "setxattr failed for \(path): \(String(cString: strerror(errno)))",
+            file: file,
+            line: line
+        )
+    }
+
+    static func hasQuarantine(atPath path: String) -> Bool {
+        getxattr(path, attributeName, nil, 0, 0, XATTR_NOFOLLOW) >= 0
+    }
+
+    static func quarantinedPaths(under rootURL: URL) -> [String] {
+        var paths: [String] = []
+
+        if hasQuarantine(atPath: rootURL.path) {
+            paths.append(rootURL.path)
+        }
+
+        let enumerator = FileManager.default.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: nil,
+            options: []
+        )
+        while let itemURL = enumerator?.nextObject() as? URL {
+            if hasQuarantine(atPath: itemURL.path) {
+                paths.append(itemURL.path)
+            }
+        }
+
+        return paths
+    }
+}

--- a/docs/plugins/local-native-plugins.md
+++ b/docs/plugins/local-native-plugins.md
@@ -4,6 +4,8 @@ MacTools supports trusted local native plugins through a host-owned package stor
 
 This phase intentionally supports only trusted local plugins built by the same developer identity as the host app. The host validates the plugin bundle signature before loading code. Disabling or uninstalling a plugin immediately removes its contributions from the UI and deletes package files when requested, while already-loaded native code is fully released after the app restarts.
 
+Locally installed packages that carry `com.apple.quarantine` (typically zips downloaded with a browser — `ditto` propagates the attribute into the extracted bundle) have the attribute stripped during install, strictly after trust validation succeeds; a package that fails validation keeps its quarantine and the install fails. If stripping itself fails, the install reports a clear error instead of leaving a package that a hardened (Release) host would later refuse to `dlopen` with an opaque Gatekeeper/AMFI error. Catalog downloads are unaffected (`URLSession` downloads carry no quarantine).
+
 For catalog-based installation, GitHub release distribution, and Debug `file://` development catalogs, see [plugin-catalog.md](plugin-catalog.md).
 
 ## Package Layout


### PR DESCRIPTION
A locally installed `.mactoolsplugin` can carry the `com.apple.quarantine` xattr (e.g. a browser-downloaded zip), which blocks `dlopen` under Gatekeeper on a hardened/Release host. After the same-team trust validator passes, this strips quarantine from the staged bundle (install path) and best-effort from the package tree on load.

## Safety

- The strip runs **only after** `validatePluginBundle` succeeds (fail-closed) — a validation failure leaves quarantine intact and throws.
- The load-path strip is best-effort: failures are logged, never block a previously-working load.
- Uses `XATTR_NOFOLLOW` (never follows a symlink out of the package).
- Catalog / URLSession installs carry no xattr, so the strip is skipped entirely and behavior is unchanged for them.

## Scope

Surfaced during the macOS 27 beta audit but **not macOS 27-specific** — the quarantine/Gatekeeper interaction applies to every macOS. Split out from the menu-bar beta PR (#142) so it can land on its own merits and risk profile.

## Testing

Build + the Dynamic-plugin test suite green (`PluginQuarantineInspectorTests`, `DynamicPluginLoaderTests`, `PluginPackageStoreTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## SECURITY REVIEW ✓ APPROVED

**Quarantine Stripping Integrity:**
- ✓ **Fail-closed trust guard**: Both stripping sites validate `trustValidator.validatePluginBundle()` BEFORE calling `quarantineInspector.stripQuarantine()`. If validation throws, stripping never executes and quarantine remains.
  - **PluginPackageStore** (line 212): trust validation → stripping
  - **DynamicPluginLoader** (lines 71–72): trust validation → stripping
- ✓ **Symlink safety**: `XATTR_NOFOLLOW` flag used throughout (evident in test support `setxattr(path, attributeName, buffer.baseAddress, buffer.count, 0, XATTR_NOFOLLOW)`) prevents symlink-based escape from package boundary.
- ✓ **Best-effort load-path safety**: `stripLingeringQuarantine()` in `DynamicPluginLoader` catches all exceptions (lines 113–119), logs as warning (non-fatal), never blocks plugin load.
- ✓ **No privilege escalation**: Operates within user context, no setuid/daemon involved, no clipboard/keychain access.

**Observation:** Catalog and URLSession downloads carry no quarantine attribute (confirmed in PR objectives); they skip stripping entirely. No regression risk.

---

## STABILITY & ROBUSTNESS ✓ ACCEPTABLE

**Error Handling:**
- ✓ All xattr syscalls result-checked (no unchecked errno)
- ✓ `stripLingeringQuarantine()` catches generic `Error`, logs with context
- ✓ File enumeration wrapped in try-catch; errors don't block load
- ✓ **No force unwraps** (`!`) or `try!` found in quarantine code
- ✓ **No fatal errors** in quarantine stripping paths

**Initialization Safety:**
- ✓ Quarantine stripping deferred to load/install time, not during init
- ✓ Load-time stripping wrapped in catch block; failures logged as warnings
- ✓ Install-time stripping nested inside existing `installPackage` try-catch; failures thrown as `PluginPackageStoreError`

---

## PERFORMANCE ✓ ACCEPTABLE

**Resource Efficiency:**
- ✓ Single `FileManager.enumerator(atPath:)` pass per operation (no per-directory recursion)
- ✓ Quarantine detection batched into one lookup; only enumerates if needed
- ✓ xattr calls only execute when quarantine detected (early exit line 211–212 in PluginPackageStore)
- ✓ No polling loops, timers, or high-frequency operations
- ✓ Load-time stripping guarded by `quarantinedItems.isEmpty` check (line 106 in DynamicPluginLoader)

**Main Thread Impact:** 
- ✓ Load-time stripping is `@MainActor` but errors caught non-fatally; no blocking I/O
- ✓ Install-time stripping in synchronous `installPackage()` path (expected for install operations)

---

## CODE CONVENTIONS & STYLING ✓ MEETS STANDARDS

**Dependency Injection & Architecture:**
- ✓ `PluginQuarantineInspecting` protocol enables testing/mocking (test double `RecordingTrustValidator` added)
- ✓ Dependencies injected with sensible defaults (`PluginQuarantineInspector()`) in initializers
- ✓ Consistent with existing `PluginTrustValidating` injection pattern
- ✓ `@MainActor` qualifier maintained on `DynamicPluginLoader`

**Logging & Localization:**
- ✓ Uses `AppLog.dynamicPlugins` (new logger in `AppLog` enum) consistent with framework logging
- ✓ Privacy markers applied (`privacy: .public` for counts, `.private` for paths)
- ✓ Localized error descriptions in `Plugins.xcstrings` (en + zh-Hans)
- ✓ Error messages provide actionable context (e.g., item count, bundle ID)

**Test Coverage:**
- ✓ `PluginQuarantineInspectorTests` validates core stripping behavior
- ✓ Symlink safety explicitly tested (enumerator does not follow symlinks outside package)
- ✓ Read-only file handling tested (maps to `stripFailed` error with reason)
- ✓ `DynamicPluginLoaderTests` and `PluginPackageStoreTests` validate integration paths

---

## RISK ASSESSMENT: **VERY LOW**

This PR implements a narrow, high-confidence fix for a real Gatekeeper hardening issue. The fail-closed trust-first validation gate is robust: stripping only succeeds if trust validation succeeds, and failures are either fatal (install path) or logged-only (load path). No regressions: secure downloads bypass stripping entirely.

**Recommendation:** ✓ **APPROVE** — Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->