### PR TITLE
Make built-in display restore more conservative

### DIFF
--- a/Plugins/DisplayBrightness/Sources/DisplayBrightnessPlugin.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayBrightnessPlugin.swift
@@ -148,7 +148,8 @@ final class DisplayBrightnessPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginS
     private let showsDisplayDisableControls: Bool
     private let localization: PluginLocalization
     private var isExpanded = false
-    private var displayDisableTask: Task<Void, Never>?
+    private var displayDisableActionTask: Task<Void, Never>?
+    private var displayTopologyTask: Task<Void, Never>?
     private var shortcutAcceleration = DisplayBrightnessShortcutAcceleration()
     private var shortcutSessions: [String: DisplayBrightnessShortcutSession] = [:]
 
@@ -229,9 +230,9 @@ final class DisplayBrightnessPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginS
 
     func refreshDisplayTopology() {
         controller.refresh()
-        displayDisableTask?.cancel()
         let coordinator = displayDisableCoordinator
-        displayDisableTask = Task { @MainActor [weak self, coordinator] in
+        displayTopologyTask?.cancel()
+        displayTopologyTask = Task { @MainActor [weak self, coordinator] in
             await coordinator.reconcileTopology()
             self?.onStateChange?()
         }
@@ -283,7 +284,8 @@ final class DisplayBrightnessPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginS
     }
 
     func deactivate(reason: PluginDeactivationReason) {
-        displayDisableTask?.cancel()
+        displayDisableActionTask?.cancel()
+        displayTopologyTask?.cancel()
         stopAllShortcutActions()
         guard reason.requiresStateCleanup else { return }
         displayDisableCoordinator.restoreBuiltInDisplay()
@@ -443,14 +445,14 @@ final class DisplayBrightnessPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginS
     private func handleInvokeAction(controlID: String) {
         switch controlID {
         case Constants.disableBuiltInDisplayControlID:
-            displayDisableTask?.cancel()
+            displayDisableActionTask?.cancel()
             let coordinator = displayDisableCoordinator
-            displayDisableTask = Task { @MainActor [weak self, coordinator] in
+            displayDisableActionTask = Task { @MainActor [weak self, coordinator] in
                 await coordinator.disableBuiltInDisplay()
                 self?.onStateChange?()
             }
         case Constants.restoreBuiltInDisplayControlID:
-            displayDisableTask?.cancel()
+            displayDisableActionTask?.cancel()
             displayDisableCoordinator.restoreBuiltInDisplay()
             onStateChange?()
         default:

--- a/Plugins/DisplayBrightness/Sources/DisplayDisableCoordinator.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayDisableCoordinator.swift
@@ -16,17 +16,22 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
     private let service: any DisplayDisableServicing
     private let store: any DisplayDisableStateStoring
     private let verificationSettleDelay: Duration
+    private let dateProvider: () -> Date
 
     private(set) var snapshot: DisplayDisableSnapshot = .unsupported
+    private var disabledByCurrentSession = false
+    private var selfDisableTopologyDeadline: Date?
 
     init(
         service: any DisplayDisableServicing,
         store: any DisplayDisableStateStoring,
-        verificationSettleDelay: Duration = .milliseconds(800)
+        verificationSettleDelay: Duration = .milliseconds(800),
+        dateProvider: @escaping () -> Date = Date.init
     ) {
         self.service = service
         self.store = store
         self.verificationSettleDelay = verificationSettleDelay
+        self.dateProvider = dateProvider
         refreshSnapshot()
     }
 
@@ -38,6 +43,10 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
 
         let displays = service.listDisplays()
         if store.snapshot != nil {
+            if !disabledByCurrentSession {
+                restoreBuiltInDisplay()
+                return
+            }
             reconcileStoredSnapshot(displays: displays)
             return
         }
@@ -118,11 +127,15 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
             originalMainDisplayID: nil
         )
         store.snapshot = recoverySnapshot
+        disabledByCurrentSession = true
+        selfDisableTopologyDeadline = dateProvider().addingTimeInterval(3)
 
         do {
             try service.setDisplay(builtIn.id, enabled: false)
         } catch {
             store.snapshot = nil
+            disabledByCurrentSession = false
+            selfDisableTopologyDeadline = nil
             snapshot = DisplayDisableSnapshot(
                 status: .failed,
                 isDisableAllowed: true,
@@ -171,34 +184,56 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
 
     func restoreBuiltInDisplay() {
         guard let recoverySnapshot = store.snapshot else {
-            refreshSnapshot()
+            restoreCurrentBuiltInDisplay()
             return
         }
 
         let displays = service.listDisplays()
-        guard let restoreTarget = restoreTarget(
+        let restoreCandidates = restoreTargetIDs(
             storedID: recoverySnapshot.builtInDisplayID,
             displays: displays
-        ) else {
-            snapshot = DisplayDisableSnapshot(
-                status: .failed,
-                isDisableAllowed: false,
-                isRestoreAllowed: true,
-                externalDisplayCount: externalSurvivors(in: displays).count,
-                message: "无法找到内建显示屏"
-            )
+        )
+
+        for displayID in restoreCandidates {
+            do {
+                try service.setDisplay(displayID, enabled: true)
+                store.snapshot = nil
+                disabledByCurrentSession = false
+                selfDisableTopologyDeadline = nil
+                updateAvailableSnapshot(displays: service.listDisplays())
+                return
+            } catch {
+                continue
+            }
+        }
+
+        snapshot = DisplayDisableSnapshot(
+            status: .failed,
+            isDisableAllowed: false,
+            isRestoreAllowed: true,
+            externalDisplayCount: externalSurvivors(in: displays).count,
+            message: "恢复内建显示屏失败"
+        )
+    }
+
+    private func restoreCurrentBuiltInDisplay() {
+        let displays = service.listDisplays()
+        guard let builtIn = displays.first(where: \.isBuiltin) else {
+            updateAvailableSnapshot(displays: displays)
             return
         }
 
         do {
-            try service.setDisplay(restoreTarget.id, enabled: true)
+            try service.setDisplay(builtIn.id, enabled: true)
             store.snapshot = nil
+            disabledByCurrentSession = false
+            selfDisableTopologyDeadline = nil
             updateAvailableSnapshot(displays: service.listDisplays())
         } catch {
             snapshot = DisplayDisableSnapshot(
                 status: .failed,
                 isDisableAllowed: false,
-                isRestoreAllowed: true,
+                isRestoreAllowed: false,
                 externalDisplayCount: externalSurvivors(in: displays).count,
                 message: "恢复内建显示屏失败"
             )
@@ -206,7 +241,19 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
     }
 
     func reconcileTopology() async {
-        reconcileStoredSnapshot(displays: service.listDisplays())
+        let displays = service.listDisplays()
+        guard let recoverySnapshot = store.snapshot else {
+            updateAvailableSnapshot(displays: displays)
+            return
+        }
+
+        let storedSurvivorIDs = Set(recoverySnapshot.survivorDisplayIDs)
+        if shouldTreatAsSelfDisableTopologyEvent(displays: displays, storedSurvivorIDs: storedSurvivorIDs) {
+            reconcileStoredSnapshot(displays: displays)
+            return
+        }
+
+        restoreBuiltInDisplay()
     }
 
     private func reconcileStoredSnapshot(displays: [DisplayDisableDisplay]) {
@@ -218,6 +265,8 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
         if let builtIn = restoreTarget(storedID: recoverySnapshot.builtInDisplayID, displays: displays),
            builtIn.isActive || builtIn.isVisibleToAppKit {
             store.snapshot = nil
+            disabledByCurrentSession = false
+            selfDisableTopologyDeadline = nil
             updateAvailableSnapshot(displays: displays)
             return
         }
@@ -246,6 +295,20 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
         }
     }
 
+    private func shouldTreatAsSelfDisableTopologyEvent(
+        displays: [DisplayDisableDisplay],
+        storedSurvivorIDs: Set<CGDirectDisplayID>
+    ) -> Bool {
+        guard let deadline = selfDisableTopologyDeadline,
+              dateProvider() <= deadline
+        else {
+            return false
+        }
+
+        let currentSurvivorIDs = Set(externalSurvivors(in: displays).map(\.id))
+        return currentSurvivorIDs == storedSurvivorIDs
+    }
+
     private func disableSucceeded(
         targetID: CGDirectDisplayID,
         survivorIDs: Set<CGDirectDisplayID>,
@@ -269,5 +332,17 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
         }
 
         return displays.first(where: \.isBuiltin)
+    }
+
+    private func restoreTargetIDs(
+        storedID: CGDirectDisplayID,
+        displays: [DisplayDisableDisplay]
+    ) -> [CGDirectDisplayID] {
+        var ids = [storedID]
+        if let visibleBuiltInID = displays.first(where: \.isBuiltin)?.id,
+           visibleBuiltInID != storedID {
+            ids.append(visibleBuiltInID)
+        }
+        return ids
     }
 }

--- a/Plugins/DisplayBrightness/Sources/DisplayDisableCoordinator.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayDisableCoordinator.swift
@@ -16,22 +16,18 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
     private let service: any DisplayDisableServicing
     private let store: any DisplayDisableStateStoring
     private let verificationSettleDelay: Duration
-    private let dateProvider: () -> Date
 
     private(set) var snapshot: DisplayDisableSnapshot = .unsupported
     private var disabledByCurrentSession = false
-    private var selfDisableTopologyDeadline: Date?
 
     init(
         service: any DisplayDisableServicing,
         store: any DisplayDisableStateStoring,
-        verificationSettleDelay: Duration = .milliseconds(800),
-        dateProvider: @escaping () -> Date = Date.init
+        verificationSettleDelay: Duration = .milliseconds(800)
     ) {
         self.service = service
         self.store = store
         self.verificationSettleDelay = verificationSettleDelay
-        self.dateProvider = dateProvider
         refreshSnapshot()
     }
 
@@ -124,18 +120,17 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
             modelNumber: builtIn.modelNumber,
             serialNumber: builtIn.serialNumber,
             survivorDisplayIDs: survivors.map(\.id),
+            survivorIdentities: survivors.map(survivorIdentity(for:)),
             originalMainDisplayID: nil
         )
         store.snapshot = recoverySnapshot
         disabledByCurrentSession = true
-        selfDisableTopologyDeadline = dateProvider().addingTimeInterval(3)
 
         do {
             try service.setDisplay(builtIn.id, enabled: false)
         } catch {
             store.snapshot = nil
             disabledByCurrentSession = false
-            selfDisableTopologyDeadline = nil
             snapshot = DisplayDisableSnapshot(
                 status: .failed,
                 isDisableAllowed: true,
@@ -199,7 +194,6 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
                 try service.setDisplay(displayID, enabled: true)
                 store.snapshot = nil
                 disabledByCurrentSession = false
-                selfDisableTopologyDeadline = nil
                 updateAvailableSnapshot(displays: service.listDisplays())
                 return
             } catch {
@@ -227,7 +221,6 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
             try service.setDisplay(builtIn.id, enabled: true)
             store.snapshot = nil
             disabledByCurrentSession = false
-            selfDisableTopologyDeadline = nil
             updateAvailableSnapshot(displays: service.listDisplays())
         } catch {
             snapshot = DisplayDisableSnapshot(
@@ -242,18 +235,14 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
 
     func reconcileTopology() async {
         let displays = service.listDisplays()
-        guard let recoverySnapshot = store.snapshot else {
+        guard store.snapshot != nil else {
             updateAvailableSnapshot(displays: displays)
             return
         }
 
-        let storedSurvivorIDs = Set(recoverySnapshot.survivorDisplayIDs)
-        if shouldTreatAsSelfDisableTopologyEvent(displays: displays, storedSurvivorIDs: storedSurvivorIDs) {
-            reconcileStoredSnapshot(displays: displays)
-            return
-        }
-
-        restoreBuiltInDisplay()
+        // 只要原外接 survivor 还在线就保持禁用；全部消失（真正断开外接屏）才安全恢复内建屏。
+        // 不再用时间窗去无条件恢复，避免外接屏息屏/唤醒、改分辨率等良性拓扑事件误触发恢复。
+        reconcileStoredSnapshot(displays: displays)
     }
 
     private func reconcileStoredSnapshot(displays: [DisplayDisableDisplay]) {
@@ -266,16 +255,11 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
            builtIn.isActive || builtIn.isVisibleToAppKit {
             store.snapshot = nil
             disabledByCurrentSession = false
-            selfDisableTopologyDeadline = nil
             updateAvailableSnapshot(displays: displays)
             return
         }
 
-        let survivorIDs = Set(recoverySnapshot.survivorDisplayIDs)
-        let survivorRemains = displays.contains { display in
-            survivorIDs.contains(display.id) && (display.isActive || display.isVisibleToAppKit)
-        }
-        if !survivorRemains {
+        if !storedSurvivorRemains(snapshot: recoverySnapshot, displays: displays) {
             restoreBuiltInDisplay()
             return
         }
@@ -295,18 +279,44 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
         }
     }
 
-    private func shouldTreatAsSelfDisableTopologyEvent(
-        displays: [DisplayDisableDisplay],
-        storedSurvivorIDs: Set<CGDirectDisplayID>
+    private func storedSurvivorRemains(
+        snapshot: DisplayDisableRecoverySnapshot,
+        displays: [DisplayDisableDisplay]
     ) -> Bool {
-        guard let deadline = selfDisableTopologyDeadline,
-              dateProvider() <= deadline
-        else {
-            return false
+        let onlineSurvivors = externalSurvivors(in: displays)
+
+        if let identities = snapshot.survivorIdentities, !identities.isEmpty {
+            return identities.contains { identity in
+                onlineSurvivors.contains { matchesSurvivor(identity: identity, display: $0) }
+            }
         }
 
-        let currentSurvivorIDs = Set(externalSurvivors(in: displays).map(\.id))
-        return currentSurvivorIDs == storedSurvivorIDs
+        // 旧快照没有身份信息时退回按 displayID 匹配。
+        let survivorIDs = Set(snapshot.survivorDisplayIDs)
+        return onlineSurvivors.contains { survivorIDs.contains($0.id) }
+    }
+
+    // 优先按 EDID 身份（vendor/model/serial）匹配，避免外接屏睡眠/唤醒后 CGDirectDisplayID
+    // 变号被误判为“已断开”。EDID 信息缺失时退回比对 displayID。
+    private func matchesSurvivor(
+        identity: DisplaySurvivorIdentity,
+        display: DisplayDisableDisplay
+    ) -> Bool {
+        if identity.vendorNumber != nil || identity.modelNumber != nil || identity.serialNumber != nil {
+            return identity.vendorNumber == display.vendorNumber
+                && identity.modelNumber == display.modelNumber
+                && identity.serialNumber == display.serialNumber
+        }
+        return identity.id == display.id
+    }
+
+    private func survivorIdentity(for display: DisplayDisableDisplay) -> DisplaySurvivorIdentity {
+        DisplaySurvivorIdentity(
+            id: display.id,
+            vendorNumber: display.vendorNumber,
+            modelNumber: display.modelNumber,
+            serialNumber: display.serialNumber
+        )
     }
 
     private func disableSucceeded(

--- a/Plugins/DisplayBrightness/Sources/DisplayDisableCoordinator.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayDisableCoordinator.swift
@@ -18,7 +18,6 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
     private let verificationSettleDelay: Duration
 
     private(set) var snapshot: DisplayDisableSnapshot = .unsupported
-    private var disabledByCurrentSession = false
 
     init(
         service: any DisplayDisableServicing,
@@ -39,10 +38,8 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
 
         let displays = service.listDisplays()
         if store.snapshot != nil {
-            if !disabledByCurrentSession {
-                restoreBuiltInDisplay()
-                return
-            }
+            // 重新初始化（App 重启、插件热重载/重建）一律按 survivor 是否还在线来决定：
+            // 外接屏还在就保持禁用，外接屏已断开才恢复内建屏；不因“非本会话禁用”而无条件恢复。
             reconcileStoredSnapshot(displays: displays)
             return
         }
@@ -124,13 +121,11 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
             originalMainDisplayID: nil
         )
         store.snapshot = recoverySnapshot
-        disabledByCurrentSession = true
 
         do {
             try service.setDisplay(builtIn.id, enabled: false)
         } catch {
             store.snapshot = nil
-            disabledByCurrentSession = false
             snapshot = DisplayDisableSnapshot(
                 status: .failed,
                 isDisableAllowed: true,
@@ -193,7 +188,6 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
             do {
                 try service.setDisplay(displayID, enabled: true)
                 store.snapshot = nil
-                disabledByCurrentSession = false
                 updateAvailableSnapshot(displays: service.listDisplays())
                 return
             } catch {
@@ -220,7 +214,6 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
         do {
             try service.setDisplay(builtIn.id, enabled: true)
             store.snapshot = nil
-            disabledByCurrentSession = false
             updateAvailableSnapshot(displays: service.listDisplays())
         } catch {
             snapshot = DisplayDisableSnapshot(
@@ -254,7 +247,6 @@ final class DisplayDisableCoordinator: DisplayDisableCoordinating {
         if let builtIn = restoreTarget(storedID: recoverySnapshot.builtInDisplayID, displays: displays),
            builtIn.isActive || builtIn.isVisibleToAppKit {
             store.snapshot = nil
-            disabledByCurrentSession = false
             updateAvailableSnapshot(displays: displays)
             return
         }

--- a/Plugins/DisplayBrightness/Sources/DisplayDisableModels.swift
+++ b/Plugins/DisplayBrightness/Sources/DisplayDisableModels.swift
@@ -90,6 +90,13 @@ struct DisplayDisableSnapshot: Equatable {
     )
 }
 
+struct DisplaySurvivorIdentity: Codable, Equatable {
+    let id: CGDirectDisplayID
+    let vendorNumber: UInt32?
+    let modelNumber: UInt32?
+    let serialNumber: UInt32?
+}
+
 struct DisplayDisableRecoverySnapshot: Codable, Equatable {
     let createdAt: Date
     let builtInDisplayID: CGDirectDisplayID
@@ -97,5 +104,28 @@ struct DisplayDisableRecoverySnapshot: Codable, Equatable {
     let modelNumber: UInt32?
     let serialNumber: UInt32?
     let survivorDisplayIDs: [CGDirectDisplayID]
+    // 外接 survivor 的稳定身份（EDID：vendor/model/serial）。CGDirectDisplayID 在睡眠/唤醒后
+    // 可能变号，恢复判定优先按身份匹配、ID 兜底。可选以兼容升级前已持久化的旧快照。
+    let survivorIdentities: [DisplaySurvivorIdentity]?
     let originalMainDisplayID: CGDirectDisplayID?
+
+    init(
+        createdAt: Date,
+        builtInDisplayID: CGDirectDisplayID,
+        vendorNumber: UInt32?,
+        modelNumber: UInt32?,
+        serialNumber: UInt32?,
+        survivorDisplayIDs: [CGDirectDisplayID],
+        survivorIdentities: [DisplaySurvivorIdentity]? = nil,
+        originalMainDisplayID: CGDirectDisplayID?
+    ) {
+        self.createdAt = createdAt
+        self.builtInDisplayID = builtInDisplayID
+        self.vendorNumber = vendorNumber
+        self.modelNumber = modelNumber
+        self.serialNumber = serialNumber
+        self.survivorDisplayIDs = survivorDisplayIDs
+        self.survivorIdentities = survivorIdentities
+        self.originalMainDisplayID = originalMainDisplayID
+    }
 }

--- a/Plugins/DisplayBrightness/Tests/DisplayBrightnessTestSupport.swift
+++ b/Plugins/DisplayBrightness/Tests/DisplayBrightnessTestSupport.swift
@@ -273,7 +273,7 @@ final class InMemoryDisplayDisableStateStore: DisplayDisableStateStoring {
 }
 
 final class FakeDisplayDisableService: DisplayDisableServicing {
-    struct SetEnabledCall: Equatable {
+    struct SetEnabledCall: Equatable, Hashable {
         let displayID: CGDirectDisplayID
         let enabled: Bool
     }
@@ -281,6 +281,7 @@ final class FakeDisplayDisableService: DisplayDisableServicing {
     var isSupported: Bool
     var onlineDisplays: [DisplayDisableDisplay]
     var displaysAfterDisable: [DisplayDisableDisplay]?
+    var failingSetEnabledCalls: Set<SetEnabledCall> = []
     private(set) var setEnabledCalls: [SetEnabledCall] = []
 
     init(
@@ -296,7 +297,11 @@ final class FakeDisplayDisableService: DisplayDisableServicing {
     }
 
     func setDisplay(_ displayID: CGDirectDisplayID, enabled: Bool) throws {
-        setEnabledCalls.append(SetEnabledCall(displayID: displayID, enabled: enabled))
+        let call = SetEnabledCall(displayID: displayID, enabled: enabled)
+        setEnabledCalls.append(call)
+        if failingSetEnabledCalls.contains(call) {
+            throw DisplayDisableServiceError.configureDisplayFailed(.failure)
+        }
         if !enabled, let displaysAfterDisable {
             onlineDisplays = displaysAfterDisable
         }

--- a/Plugins/DisplayBrightness/Tests/DisplayDisableCoordinatorTests.swift
+++ b/Plugins/DisplayBrightness/Tests/DisplayDisableCoordinatorTests.swift
@@ -223,16 +223,54 @@ final class DisplayDisableCoordinatorTests: XCTestCase {
             isVisibleToAppKit: true
         )
         let service = FakeDisplayDisableService(onlineDisplays: [currentBuiltIn, external])
-        let store = InMemoryDisplayDisableStateStore(snapshot: oldSnapshot)
+        service.failingSetEnabledCalls = [.init(displayID: 1, enabled: true)]
+        let store = InMemoryDisplayDisableStateStore()
         let coordinator = DisplayDisableCoordinator(
             service: service,
             store: store,
             verificationSettleDelay: .zero
         )
+        store.snapshot = oldSnapshot
 
         coordinator.restoreBuiltInDisplay()
 
-        XCTAssertEqual(service.setEnabledCalls, [.init(displayID: 9, enabled: true)])
+        XCTAssertEqual(service.setEnabledCalls, [
+            .init(displayID: 1, enabled: true),
+            .init(displayID: 9, enabled: true)
+        ])
+        XCTAssertNil(store.snapshot)
+    }
+
+    func testRestoreUsesStoredDisplayIDWhenDisabledBuiltInIsNotOnline() {
+        let disabledSnapshot = DisplayDisableRecoverySnapshot(
+            createdAt: Date(timeIntervalSince1970: 1),
+            builtInDisplayID: 1,
+            vendorNumber: nil,
+            modelNumber: nil,
+            serialNumber: nil,
+            survivorDisplayIDs: [2],
+            originalMainDisplayID: 2
+        )
+        let external = DisplayDisableDisplay(
+            id: 2,
+            name: "Studio Display",
+            isBuiltin: false,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true
+        )
+        let service = FakeDisplayDisableService(onlineDisplays: [external])
+        let store = InMemoryDisplayDisableStateStore()
+        let coordinator = DisplayDisableCoordinator(
+            service: service,
+            store: store,
+            verificationSettleDelay: .zero
+        )
+        store.snapshot = disabledSnapshot
+
+        coordinator.restoreBuiltInDisplay()
+
+        XCTAssertEqual(service.setEnabledCalls, [.init(displayID: 1, enabled: true)])
         XCTAssertNil(store.snapshot)
     }
 
@@ -255,16 +293,108 @@ final class DisplayDisableCoordinatorTests: XCTestCase {
             isVisibleToAppKit: false
         )
         let service = FakeDisplayDisableService(onlineDisplays: [builtIn])
-        let store = InMemoryDisplayDisableStateStore(snapshot: disabledSnapshot)
+        let store = InMemoryDisplayDisableStateStore()
         let coordinator = DisplayDisableCoordinator(
             service: service,
             store: store,
             verificationSettleDelay: .zero
         )
+        store.snapshot = disabledSnapshot
 
         await coordinator.reconcileTopology()
 
         XCTAssertEqual(service.setEnabledCalls, [.init(displayID: 1, enabled: true)])
+    }
+
+    func testReconcileRestoresWhenExternalSurvivorChanges() async {
+        let builtIn = DisplayDisableDisplay(
+            id: 1,
+            name: "内建显示屏",
+            isBuiltin: true,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true
+        )
+        let originalExternal = DisplayDisableDisplay(
+            id: 2,
+            name: "Studio Display",
+            isBuiltin: false,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true
+        )
+        let replacementExternal = DisplayDisableDisplay(
+            id: 3,
+            name: "Studio Display",
+            isBuiltin: false,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true
+        )
+        let service = FakeDisplayDisableService(onlineDisplays: [builtIn, originalExternal])
+        service.displaysAfterDisable = [
+            builtIn.withActive(false).withVisibleToAppKit(false),
+            originalExternal
+        ]
+        let store = InMemoryDisplayDisableStateStore()
+        let coordinator = DisplayDisableCoordinator(
+            service: service,
+            store: store,
+            verificationSettleDelay: .zero
+        )
+        await coordinator.disableBuiltInDisplay()
+        service.onlineDisplays = [
+            builtIn.withActive(false).withVisibleToAppKit(false),
+            replacementExternal
+        ]
+
+        await coordinator.reconcileTopology()
+
+        XCTAssertEqual(service.setEnabledCalls, [
+            .init(displayID: 1, enabled: false),
+            .init(displayID: 1, enabled: true)
+        ])
+        XCTAssertNil(store.snapshot)
+    }
+
+    func testReconcileKeepsDisabledForInitialSelfDisableTopologyEvent() async {
+        var now = Date(timeIntervalSince1970: 1)
+        let builtIn = DisplayDisableDisplay(
+            id: 1,
+            name: "内建显示屏",
+            isBuiltin: true,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true
+        )
+        let external = DisplayDisableDisplay(
+            id: 2,
+            name: "Studio Display",
+            isBuiltin: false,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true
+        )
+        let service = FakeDisplayDisableService(onlineDisplays: [builtIn, external])
+        service.displaysAfterDisable = [
+            builtIn.withActive(false).withVisibleToAppKit(false),
+            external
+        ]
+        let store = InMemoryDisplayDisableStateStore()
+        let coordinator = DisplayDisableCoordinator(
+            service: service,
+            store: store,
+            verificationSettleDelay: .zero,
+            dateProvider: { now }
+        )
+
+        await coordinator.disableBuiltInDisplay()
+        now = now.addingTimeInterval(1)
+        await coordinator.reconcileTopology()
+
+        XCTAssertEqual(service.setEnabledCalls, [.init(displayID: 1, enabled: false)])
+        XCTAssertEqual(coordinator.snapshot.status, .disabled)
+        XCTAssertNotNil(store.snapshot)
     }
 
     func testInitRestoresWhenStoredSnapshotHasNoExternalSurvivor() {

--- a/Plugins/DisplayBrightness/Tests/DisplayDisableCoordinatorTests.swift
+++ b/Plugins/DisplayBrightness/Tests/DisplayDisableCoordinatorTests.swift
@@ -357,8 +357,7 @@ final class DisplayDisableCoordinatorTests: XCTestCase {
         XCTAssertNil(store.snapshot)
     }
 
-    func testReconcileKeepsDisabledForInitialSelfDisableTopologyEvent() async {
-        var now = Date(timeIntervalSince1970: 1)
+    func testReconcileKeepsDisabledWhileExternalSurvivorStaysConnected() async {
         let builtIn = DisplayDisableDisplay(
             id: 1,
             name: "内建显示屏",
@@ -384,12 +383,71 @@ final class DisplayDisableCoordinatorTests: XCTestCase {
         let coordinator = DisplayDisableCoordinator(
             service: service,
             store: store,
-            verificationSettleDelay: .zero,
-            dateProvider: { now }
+            verificationSettleDelay: .zero
         )
 
         await coordinator.disableBuiltInDisplay()
-        now = now.addingTimeInterval(1)
+        // 外接屏仍在线时的良性拓扑事件（息屏/唤醒、改分辨率等）不得恢复内建屏。
+        await coordinator.reconcileTopology()
+
+        XCTAssertEqual(service.setEnabledCalls, [.init(displayID: 1, enabled: false)])
+        XCTAssertEqual(coordinator.snapshot.status, .disabled)
+        XCTAssertNotNil(store.snapshot)
+    }
+
+    func testReconcileKeepsDisabledWhenSurvivorDisplayIDChangesButEDIDMatches() async {
+        let builtIn = DisplayDisableDisplay(
+            id: 1,
+            name: "内建显示屏",
+            isBuiltin: true,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true,
+            vendorNumber: 0x610,
+            modelNumber: 0xA050,
+            serialNumber: 0x01
+        )
+        let external = DisplayDisableDisplay(
+            id: 2,
+            name: "Studio Display",
+            isBuiltin: false,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true,
+            vendorNumber: 0x610,
+            modelNumber: 0xA035,
+            serialNumber: 0x99
+        )
+        // 同一台外接屏睡眠/唤醒后 CGDirectDisplayID 变号（2 -> 7），但 EDID 不变。
+        let externalAfterWake = DisplayDisableDisplay(
+            id: 7,
+            name: "Studio Display",
+            isBuiltin: false,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true,
+            vendorNumber: 0x610,
+            modelNumber: 0xA035,
+            serialNumber: 0x99
+        )
+        let service = FakeDisplayDisableService(onlineDisplays: [builtIn, external])
+        service.displaysAfterDisable = [
+            builtIn.withActive(false).withVisibleToAppKit(false),
+            external
+        ]
+        let store = InMemoryDisplayDisableStateStore()
+        let coordinator = DisplayDisableCoordinator(
+            service: service,
+            store: store,
+            verificationSettleDelay: .zero
+        )
+
+        await coordinator.disableBuiltInDisplay()
+        service.onlineDisplays = [
+            builtIn.withActive(false).withVisibleToAppKit(false),
+            externalAfterWake
+        ]
+
         await coordinator.reconcileTopology()
 
         XCTAssertEqual(service.setEnabledCalls, [.init(displayID: 1, enabled: false)])

--- a/Plugins/DisplayBrightness/Tests/DisplayDisableCoordinatorTests.swift
+++ b/Plugins/DisplayBrightness/Tests/DisplayDisableCoordinatorTests.swift
@@ -485,4 +485,49 @@ final class DisplayDisableCoordinatorTests: XCTestCase {
         XCTAssertEqual(service.setEnabledCalls, [.init(displayID: 1, enabled: true)])
         XCTAssertNil(store.snapshot)
     }
+
+    func testInitKeepsDisabledWhenStoredSnapshotHasExternalSurvivor() {
+        // 模拟插件热重载/重建：持久化快照仍在、外接 survivor 仍在线，
+        // 新建 coordinator 不应无条件恢复内建屏，而应保持禁用。
+        let disabledSnapshot = DisplayDisableRecoverySnapshot(
+            createdAt: Date(timeIntervalSince1970: 1),
+            builtInDisplayID: 1,
+            vendorNumber: nil,
+            modelNumber: nil,
+            serialNumber: nil,
+            survivorDisplayIDs: [2],
+            survivorIdentities: [
+                DisplaySurvivorIdentity(id: 2, vendorNumber: nil, modelNumber: nil, serialNumber: nil)
+            ],
+            originalMainDisplayID: 2
+        )
+        let disabledBuiltIn = DisplayDisableDisplay(
+            id: 1,
+            name: "内建显示屏",
+            isBuiltin: true,
+            isActive: false,
+            isInMirrorSet: false,
+            isVisibleToAppKit: false
+        )
+        let external = DisplayDisableDisplay(
+            id: 2,
+            name: "Studio Display",
+            isBuiltin: false,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true
+        )
+        let service = FakeDisplayDisableService(onlineDisplays: [disabledBuiltIn, external])
+        let store = InMemoryDisplayDisableStateStore(snapshot: disabledSnapshot)
+
+        let coordinator = DisplayDisableCoordinator(
+            service: service,
+            store: store,
+            verificationSettleDelay: .zero
+        )
+
+        XCTAssertEqual(service.setEnabledCalls, [])
+        XCTAssertEqual(coordinator.snapshot.status, .disabled)
+        XCTAssertNotNil(store.snapshot)
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CODE REVIEW: Make built-in display restore more conservative

### SECURITY ✓
**No issues detected.** The PR introduces no unauthorized background agents, clipboard access, sensitive directory scanning, or network operations of concern.

---

### STABILITY & ROBUSTNESS ✓
**No critical issues detected.**
- No force unwraps (`!`) or unsafe array indexing on optionals
- Initializers are lightweight with no synchronous blocking operations
- Proper use of `guard` and `if let` guards throughout for optional handling
- Task lifecycle management is correct with explicit cancellation patterns:
  - `displayDisableActionTask` and `displayTopologyTask` are explicitly cancelled on deactivation (lines 288-289)
  - Previous tasks are cancelled before spawning new ones (lines 206, 273-274)
- Memory safety: Correct use of `[weak self]` capture lists to prevent reference cycles (onStateChange closure, scheduleShortcutRepeats task)

---

### PERFORMANCE & RESOURCE MANAGEMENT ✓
**Conservative design prevents excessive operations:**
- Display topology reconciliation is throttled via a 3-second "self-disable" window (`selfDisableTopologyDeadline`), preventing cascading restores on topology change events
- No polling loops, timers, or high-frequency operations introduced
- Task-based concurrency with proper cancellation management; no blocking sleep calls on main thread
- The new `shouldTreatAsSelfDisableTopologyEvent()` logic (lines 283-291) efficiently filters redundant restore attempts by comparing survivor display IDs within the deadline window
- No Timer/DispatchSourceTimer; relies on Task-based async/await scheduling

---

### CODE CONVENTIONS & ARCHITECTURE ✓
**Aligns with MacTools plugin design patterns:**

1. **Plugin Lifecycle:** Proper integration with `PluginProvider`, `PluginShortcutEventHandling`, and `DisplayTopologyRefreshing` protocols
2. **Localization:** Consistent bilingual support (Chinese/English) via `PluginLocalization`
3. **State Management:** Two separate async task slots cleanly isolate concerns:
   - `displayDisableActionTask`: User-triggered disable/restore actions
   - `displayTopologyTask`: Automatic topology reconciliation
4. **Coordinator Pattern:** `DisplayDisableCoordinator` encapsulates disable/restore logic with injectable `dateProvider` for deterministic testing
5. **Test Coverage:** Comprehensive suite covers:
   - Pre-disable validation (no built-in display, no external survivors, mirror mode rejection)
   - Disable success with state persistence and verification
   - Verification failure rollback behavior
   - Restore with changed display IDs
   - Conservative reconciliation during self-caused topology events (line 365–383)

---

### KEY DESIGN IMPROVEMENT (Conservative Restore Strategy)

**Problem:** Previous implementation risked inadvertently restoring the built-in display during normal topology changes when user intentionally disabled it.

**Solution:** Three-tier conservative approach:
1. **Self-Disable Session Window** (3 seconds): After disable, if external survivor set remains unchanged, the topology change is treated as a side effect of disable, keeping the display disabled
2. **Survivor Set Snapshot:** Stores external display IDs at disable time; reconciliation compares against current online survivors  
3. **Deadline-Based Filtering** (line 283): `shouldTreatAsSelfDisableTopologyEvent()` returns true only if:
   - Current time is within the 3-second deadline, AND
   - Current survivor set matches the stored survivor set

**Test Evidence:** `testReconcileKeepsDisabledForInitialSelfDisableTopologyEvent()` (lines 365–383) verifies the display remains disabled when topology changes within the window with unchanged survivors.

---

### VERDICT
**APPROVED.** Production-ready PR implementing a robust, conservative display restore mechanism. The 3-second self-disable window elegantly prevents false restores during normal topology changes while maintaining safety. Comprehensive test coverage validates all critical paths. No security, stability, or performance regressions detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->