### PR TITLE
Finder context menu (FinderSync): copy paths, new file, open in Terminal, open with apps

### DIFF
--- a/Configs/MacTools-Info.plist
+++ b/Configs/MacTools-Info.plist
@@ -37,6 +37,8 @@
 	</array>
 	<key>LSUIElement</key>
 	<true/>
+	<key>MTAppGroupIdentifier</key>
+	<string>group.$(BUNDLE_IDENTIFIER_PREFIX).mactools</string>
 	<key>MTPluginCatalogPublicKey</key>
 	<string>$(PLUGIN_CATALOG_PUBLIC_KEY)</string>
 	<key>NSAppleEventsUsageDescription</key>

--- a/Configs/MacTools-Info.plist
+++ b/Configs/MacTools-Info.plist
@@ -24,6 +24,17 @@
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mactools</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSUIElement</key>
 	<true/>
 	<key>MTPluginCatalogPublicKey</key>

--- a/Configs/MacTools-Info.plist
+++ b/Configs/MacTools-Info.plist
@@ -37,8 +37,6 @@
 	</array>
 	<key>LSUIElement</key>
 	<true/>
-	<key>MTAppGroupIdentifier</key>
-	<string>group.$(BUNDLE_IDENTIFIER_PREFIX).mactools</string>
 	<key>MTPluginCatalogPublicKey</key>
 	<string>$(PLUGIN_CATALOG_PUBLIC_KEY)</string>
 	<key>NSAppleEventsUsageDescription</key>

--- a/Configs/MacTools.entitlements
+++ b/Configs/MacTools.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.$(BUNDLE_IDENTIFIER_PREFIX).mactools</string>
+	</array>
 </dict>
 </plist>

--- a/Configs/MacTools.entitlements
+++ b/Configs/MacTools.entitlements
@@ -6,9 +6,5 @@
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.$(BUNDLE_IDENTIFIER_PREFIX).mactools</string>
-	</array>
 </dict>
 </plist>

--- a/FinderSyncExtension/Info.plist
+++ b/FinderSyncExtension/Info.plist
@@ -22,6 +22,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>MTAppGroupIdentifier</key>
+	<string>group.$(BUNDLE_IDENTIFIER_PREFIX).mactools</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/FinderSyncExtension/Info.plist
+++ b/FinderSyncExtension/Info.plist
@@ -22,8 +22,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>MTAppGroupIdentifier</key>
-	<string>group.$(BUNDLE_IDENTIFIER_PREFIX).mactools</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/FinderSyncExtension/Info.plist
+++ b/FinderSyncExtension/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>MacTools 访达菜单</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.FinderSync</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).FinderContextMenuProvider</string>
+	</dict>
+</dict>
+</plist>

--- a/FinderSyncExtension/MacToolsFinderSync.entitlements
+++ b/FinderSyncExtension/MacToolsFinderSync.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
+</plist>

--- a/FinderSyncExtension/MacToolsFinderSync.entitlements
+++ b/FinderSyncExtension/MacToolsFinderSync.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.$(BUNDLE_IDENTIFIER_PREFIX).mactools</string>
+	</array>
 </dict>
 </plist>

--- a/FinderSyncExtension/MacToolsFinderSync.entitlements
+++ b/FinderSyncExtension/MacToolsFinderSync.entitlements
@@ -4,9 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.application-groups</key>
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
 	<array>
-		<string>group.$(BUNDLE_IDENTIFIER_PREFIX).mactools</string>
+		<string>/Library/Application Support/MacTools/</string>
 	</array>
 </dict>
 </plist>

--- a/FinderSyncExtension/MacToolsFinderSync.entitlements
+++ b/FinderSyncExtension/MacToolsFinderSync.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.files.absolute-path.read-write</key>
+	<array>
+		<string>/Users/</string>
+	</array>
 </dict>
 </plist>

--- a/FinderSyncExtension/MacToolsFinderSync.entitlements
+++ b/FinderSyncExtension/MacToolsFinderSync.entitlements
@@ -4,11 +4,5 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
-	<key>com.apple.security.temporary-exception.files.absolute-path.read-write</key>
-	<array>
-		<string>/Users/</string>
-	</array>
 </dict>
 </plist>

--- a/FinderSyncExtension/Sources/FinderContextMenuLogic.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuLogic.swift
@@ -29,24 +29,4 @@ enum FinderContextMenuLogic {
         let parts = Array(repeating: "..", count: ups) + downs
         return parts.isEmpty ? "." : parts.joined(separator: "/")
     }
-
-    /// First non-colliding URL of the form `<baseName>.<ext>`,
-    /// `<baseName> 2.<ext>`, `<baseName> 3.<ext>`, … inside `directory`.
-    ///
-    /// `fileExists` is injected so tests can drive the collision logic without a
-    /// real file system.
-    static func nextAvailableURL(
-        in directory: URL,
-        baseName: String,
-        ext: String,
-        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
-    ) -> URL {
-        var candidate = directory.appendingPathComponent("\(baseName).\(ext)")
-        var counter = 2
-        while fileExists(candidate.path) {
-            candidate = directory.appendingPathComponent("\(baseName) \(counter).\(ext)")
-            counter += 1
-        }
-        return candidate
-    }
 }

--- a/FinderSyncExtension/Sources/FinderContextMenuLogic.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuLogic.swift
@@ -2,31 +2,16 @@ import Foundation
 
 /// Pure, headless-testable helpers for the Finder context-menu extension.
 ///
-/// Kept free of AppKit / FinderSync so the path math can be unit-tested without
-/// loading the extension or touching the real file system.
+/// Kept free of AppKit / FinderSync so the logic can be unit-tested without
+/// loading the extension. (This file is also compiled directly into the test
+/// bundle — see the test target sources — because an app-extension is not an
+/// importable framework.)
 enum FinderContextMenuLogic {
-    /// Compute `target` relative to the directory `base` (e.g. `"sub/file.txt"`,
-    /// `"../sibling/file.txt"`). Falls back to `target`'s absolute path when the
-    /// two share only the volume root, where a relative path would be a long,
-    /// useless chain of `..`.
-    static func relativePath(of target: URL, to base: URL) -> String {
-        let baseComps = base.standardizedFileURL.pathComponents
-        let targetComps = target.standardizedFileURL.pathComponents
-
-        var common = 0
-        while common < baseComps.count,
-              common < targetComps.count,
-              baseComps[common] == targetComps[common] {
-            common += 1
-        }
-
-        // `common` always includes the leading "/". Anything that only shares
-        // the root is on an unrelated subtree — prefer the absolute path.
-        guard common > 1 else { return target.path }
-
-        let ups = max(0, baseComps.count - common)
-        let downs = Array(targetComps.dropFirst(common))
-        let parts = Array(repeating: "..", count: ups) + downs
-        return parts.isEmpty ? "." : parts.joined(separator: "/")
+    /// Shell-escape a path so it can be pasted straight into a terminal: wrap the
+    /// whole path in single quotes and rewrite any embedded single quote as the
+    /// canonical `'\''` sequence. This is safe for spaces and every shell
+    /// metacharacter, unlike a raw absolute path.
+    static func shellEscaped(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/FinderSyncExtension/Sources/FinderContextMenuLogic.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuLogic.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Pure, headless-testable helpers for the Finder context-menu extension.
+///
+/// Kept free of AppKit / FinderSync so the path math can be unit-tested without
+/// loading the extension or touching the real file system.
+enum FinderContextMenuLogic {
+    /// Compute `target` relative to the directory `base` (e.g. `"sub/file.txt"`,
+    /// `"../sibling/file.txt"`). Falls back to `target`'s absolute path when the
+    /// two share only the volume root, where a relative path would be a long,
+    /// useless chain of `..`.
+    static func relativePath(of target: URL, to base: URL) -> String {
+        let baseComps = base.standardizedFileURL.pathComponents
+        let targetComps = target.standardizedFileURL.pathComponents
+
+        var common = 0
+        while common < baseComps.count,
+              common < targetComps.count,
+              baseComps[common] == targetComps[common] {
+            common += 1
+        }
+
+        // `common` always includes the leading "/". Anything that only shares
+        // the root is on an unrelated subtree — prefer the absolute path.
+        guard common > 1 else { return target.path }
+
+        let ups = max(0, baseComps.count - common)
+        let downs = Array(targetComps.dropFirst(common))
+        let parts = Array(repeating: "..", count: ups) + downs
+        return parts.isEmpty ? "." : parts.joined(separator: "/")
+    }
+
+    /// First non-colliding URL of the form `<baseName>.<ext>`,
+    /// `<baseName> 2.<ext>`, `<baseName> 3.<ext>`, … inside `directory`.
+    ///
+    /// `fileExists` is injected so tests can drive the collision logic without a
+    /// real file system.
+    static func nextAvailableURL(
+        in directory: URL,
+        baseName: String,
+        ext: String,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> URL {
+        var candidate = directory.appendingPathComponent("\(baseName).\(ext)")
+        var counter = 2
+        while fileExists(candidate.path) {
+            candidate = directory.appendingPathComponent("\(baseName) \(counter).\(ext)")
+            counter += 1
+        }
+        return candidate
+    }
+}

--- a/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
@@ -1,0 +1,174 @@
+import AppKit
+import FinderSync
+import Foundation
+import os
+
+/// Finder Sync principal class — injects MacTools actions into Finder's
+/// right-click (contextual) menu.
+///
+/// This is a **system-loaded app extension**, deliberately separate from
+/// MacTools' in-process plugin host: Finder instantiates this class and calls
+/// `menu(for:)` whenever the user right-clicks inside a monitored directory, and
+/// the returned `NSMenu` items are merged into the contextual menu. Because it
+/// is a passive, declarative extension point (Finder asks us for a menu; we
+/// never intercept mouse events), it is unaffected by the macOS 27 menu-bar
+/// rehosting that broke the status-item right-click.
+///
+/// MVP scope: copy paths + create new files. Both run entirely inside the
+/// sandboxed extension — no app group, no container round-trip.
+///
+/// Action identity note: macOS strips `representedObject` from the menu items
+/// handed back through FinderSync, so each action is a distinct `@objc`
+/// selector that re-reads its targets from `FIFinderSyncController` at click
+/// time, rather than carrying state on the menu item.
+///
+/// Concurrency note: this target builds with `SWIFT_STRICT_CONCURRENCY = minimal`.
+/// FinderSync's `menu(for:)` is nonisolated yet returns a main-actor `NSMenu`,
+/// which is fundamentally at odds with Swift 6 complete checking. Every
+/// FinderSync callback runs on Finder's main thread, so there is no real
+/// concurrency to guard against here.
+final class FinderContextMenuProvider: FIFinderSync {
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.ggbond.mactools.findersync",
+        category: "FinderContextMenu"
+    )
+
+    override init() {
+        super.init()
+        // Monitor the whole file system so the menu is available wherever the
+        // user right-clicks. FinderSync grants the sandboxed extension implicit
+        // access to the URLs Finder hands back for monitored directories.
+        FIFinderSyncController.default().directoryURLs = [URL(fileURLWithPath: "/")]
+        logger.info("FinderContextMenuProvider initialized")
+    }
+
+    // MARK: - Menu
+
+    override func menu(for menuKind: FIMenuKind) -> NSMenu? {
+        // Same MacTools actions regardless of where the click landed; each
+        // action resolves its own targets from the controller at click time.
+        let menu = NSMenu(title: "MacTools")
+        addCopyMenu(to: menu)
+        addNewFileMenu(to: menu)
+        return menu
+    }
+
+    private func addCopyMenu(to menu: NSMenu) {
+        let parent = NSMenuItem(title: "复制路径", action: nil, keyEquivalent: "")
+        parent.image = NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
+        let submenu = NSMenu(title: "复制路径")
+        submenu.addItem(makeItem("复制绝对路径", #selector(copyAbsolutePaths(_:))))
+        submenu.addItem(makeItem("复制相对路径", #selector(copyRelativePaths(_:))))
+        submenu.addItem(makeItem("复制文件名", #selector(copyFileNames(_:))))
+        parent.submenu = submenu
+        menu.addItem(parent)
+    }
+
+    private func addNewFileMenu(to menu: NSMenu) {
+        let parent = NSMenuItem(title: "新建文件", action: nil, keyEquivalent: "")
+        parent.image = NSImage(systemSymbolName: "doc.badge.plus", accessibilityDescription: nil)
+        let submenu = NSMenu(title: "新建文件")
+        submenu.addItem(makeItem("文本文件 (.txt)", #selector(newTextFile(_:))))
+        submenu.addItem(makeItem("Markdown (.md)", #selector(newMarkdownFile(_:))))
+        submenu.addItem(makeItem("JSON (.json)", #selector(newJSONFile(_:))))
+        parent.submenu = submenu
+        menu.addItem(parent)
+    }
+
+    private func makeItem(_ title: String, _ action: Selector) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        return item
+    }
+
+    // MARK: - Copy actions
+
+    @objc private func copyAbsolutePaths(_ sender: NSMenuItem) {
+        let urls = effectiveTargets()
+        guard !urls.isEmpty else { return }
+        writeToPasteboard(urls.map(\.path).joined(separator: "\n"))
+    }
+
+    @objc private func copyRelativePaths(_ sender: NSMenuItem) {
+        let urls = effectiveTargets()
+        guard !urls.isEmpty else { return }
+        let base = FIFinderSyncController.default().targetedURL()
+        let text = urls.map { url in
+            base.map { FinderContextMenuLogic.relativePath(of: url, to: $0) } ?? url.path
+        }.joined(separator: "\n")
+        writeToPasteboard(text)
+    }
+
+    @objc private func copyFileNames(_ sender: NSMenuItem) {
+        let urls = effectiveTargets()
+        guard !urls.isEmpty else { return }
+        writeToPasteboard(urls.map(\.lastPathComponent).joined(separator: "\n"))
+    }
+
+    // MARK: - New file actions
+
+    @objc private func newTextFile(_ sender: NSMenuItem) { createNewFile(ext: "txt") }
+    @objc private func newMarkdownFile(_ sender: NSMenuItem) { createNewFile(ext: "md") }
+    @objc private func newJSONFile(_ sender: NSMenuItem) { createNewFile(ext: "json") }
+
+    // MARK: - Targets
+
+    /// URLs the copy actions apply to: the selected items, or the current
+    /// directory when nothing is selected (blank-area right-click).
+    private func effectiveTargets() -> [URL] {
+        let controller = FIFinderSyncController.default()
+        if let selected = controller.selectedItemURLs(), !selected.isEmpty {
+            return selected
+        }
+        if let targeted = controller.targetedURL() {
+            return [targeted]
+        }
+        return []
+    }
+
+    /// Directory a new file should be created in: the selected folder, the
+    /// selected file's parent, or the current directory.
+    private func newFileDirectory() -> URL? {
+        let controller = FIFinderSyncController.default()
+        if let first = controller.selectedItemURLs()?.first {
+            return first.hasDirectoryPath ? first : first.deletingLastPathComponent()
+        }
+        return controller.targetedURL()
+    }
+
+    // MARK: - File creation
+
+    private func createNewFile(ext: String) {
+        guard let directory = newFileDirectory() else {
+            logger.error("new file: no target directory available")
+            return
+        }
+        let fileURL = FinderContextMenuLogic.nextAvailableURL(
+            in: directory, baseName: "未命名", ext: ext
+        )
+        let fileManager = FileManager.default
+
+        // FinderSync has implicit access to URLs Finder hands back, so a direct
+        // create usually succeeds; fall back to explicit security-scoped access.
+        if fileManager.createFile(atPath: fileURL.path, contents: Data(), attributes: nil) {
+            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+            return
+        }
+
+        let didStart = directory.startAccessingSecurityScopedResource()
+        defer { if didStart { directory.stopAccessingSecurityScopedResource() } }
+        if fileManager.createFile(atPath: fileURL.path, contents: Data(), attributes: nil) {
+            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+        } else {
+            logger.error("new file: failed to create at \(fileURL.path, privacy: .public)")
+        }
+    }
+
+    // MARK: - Pasteboard
+
+    private func writeToPasteboard(_ string: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(string, forType: .string)
+    }
+}

--- a/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
@@ -58,7 +58,7 @@ final class FinderContextMenuProvider: FIFinderSync {
         parent.image = NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
         let submenu = NSMenu(title: "复制路径")
         submenu.addItem(makeItem("复制绝对路径", #selector(copyAbsolutePaths(_:))))
-        submenu.addItem(makeItem("复制相对路径", #selector(copyRelativePaths(_:))))
+        submenu.addItem(makeItem("复制转义路径", #selector(copyShellEscapedPaths(_:))))
         submenu.addItem(makeItem("复制文件名", #selector(copyFileNames(_:))))
         parent.submenu = submenu
         menu.addItem(parent)
@@ -89,13 +89,12 @@ final class FinderContextMenuProvider: FIFinderSync {
         writeToPasteboard(urls.map(\.path).joined(separator: "\n"))
     }
 
-    @objc private func copyRelativePaths(_ sender: NSMenuItem) {
+    /// Shell-escaped paths, space-separated so the whole line can be pasted as
+    /// terminal arguments.
+    @objc private func copyShellEscapedPaths(_ sender: NSMenuItem) {
         let urls = effectiveTargets()
         guard !urls.isEmpty else { return }
-        let base = FIFinderSyncController.default().targetedURL()
-        let text = urls.map { url in
-            base.map { FinderContextMenuLogic.relativePath(of: url, to: $0) } ?? url.path
-        }.joined(separator: "\n")
+        let text = urls.map { FinderContextMenuLogic.shellEscaped($0.path) }.joined(separator: " ")
         writeToPasteboard(text)
     }
 

--- a/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
@@ -58,6 +58,7 @@ final class FinderContextMenuProvider: FIFinderSync {
         if configuration.openInTerminal {
             addOpenInTerminalItem(to: menu)
         }
+        addOpenWithMenu(to: menu, configuration: configuration)
         return menu
     }
 
@@ -97,6 +98,29 @@ final class FinderContextMenuProvider: FIFinderSync {
         let item = makeItem("在终端打开", #selector(openInTerminal(_:)))
         item.image = NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
         menu.addItem(item)
+    }
+
+    private func addOpenWithMenu(to menu: NSMenu, configuration: FinderMenuConfiguration) {
+        guard !configuration.openWithApps.isEmpty else { return }
+        let targets = effectiveTargets()
+        guard !targets.isEmpty else { return }
+        // An app entry shows when it matches at least one selected item's
+        // extension (an entry with no extension filter matches everything).
+        let matching = configuration.openWithApps.filter { app in
+            targets.contains { app.matches(fileExtension: $0.pathExtension) }
+        }
+        guard !matching.isEmpty else { return }
+        let parent = NSMenuItem(title: "用应用打开", action: nil, keyEquivalent: "")
+        parent.image = NSImage(systemSymbolName: "app.badge.checkmark", accessibilityDescription: nil)
+        let submenu = NSMenu(title: "用应用打开")
+        for app in matching {
+            // Identified at click time by the title (its name): FinderSync
+            // preserves the title it displays, but strips `representedObject` and
+            // does not reliably carry `tag` across its menu round-trip.
+            submenu.addItem(makeItem(app.name, #selector(openWithApp(_:))))
+        }
+        parent.submenu = submenu
+        menu.addItem(parent)
     }
 
     private func makeItem(_ title: String, _ action: Selector) -> NSMenuItem {
@@ -159,6 +183,26 @@ final class FinderContextMenuProvider: FIFinderSync {
         forwardRequest(host: "openterminal", queryItems: [
             URLQueryItem(name: "dir", value: directory.path)
         ])
+    }
+
+    /// Open the selected items with a user-configured app. The chosen app is
+    /// identified by the menu item title (its name): FinderSync preserves the
+    /// title it displays but strips `representedObject` and does not reliably
+    /// carry `tag`, so the title is the dependable round-trip key.
+    @objc private func openWithApp(_ sender: NSMenuItem) {
+        let configuration = FinderMenuConfigStore.load()
+        guard let app = configuration.openWithApps.first(where: { $0.name == sender.title }) else {
+            logger.error("open with: no configured app named \(sender.title, privacy: .public)")
+            return
+        }
+        let targets = effectiveTargets()
+        guard !targets.isEmpty else {
+            logger.error("open with: no target items")
+            return
+        }
+        var queryItems = [URLQueryItem(name: "app", value: app.appPath)]
+        queryItems += targets.map { URLQueryItem(name: "file", value: $0.path) }
+        forwardRequest(host: "openwith", queryItems: queryItems)
     }
 
     // MARK: - Targets

--- a/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
@@ -47,23 +47,37 @@ final class FinderContextMenuProvider: FIFinderSync {
     // MARK: - Menu
 
     override func menu(for menuKind: FIMenuKind) -> NSMenu? {
-        // Same MacTools actions regardless of where the click landed; each
-        // action resolves its own targets from the controller at click time.
+        // Read user configuration shared from the host app via the app group;
+        // each action still resolves its own targets from the controller.
+        let configuration = FinderMenuConfigStore.load()
         let menu = NSMenu(title: "MacTools")
-        addCopyMenu(to: menu)
-        addNewFileMenu(to: menu)
-        addOpenInTerminalItem(to: menu)
+        addCopyMenu(to: menu, configuration: configuration)
+        if configuration.newFileEnabled {
+            addNewFileMenu(to: menu)
+        }
+        if configuration.openInTerminal {
+            addOpenInTerminalItem(to: menu)
+        }
         return menu
     }
 
-    private func addCopyMenu(to menu: NSMenu) {
+    private func addCopyMenu(to menu: NSMenu, configuration: FinderMenuConfiguration) {
+        guard configuration.hasAnyCopyAction else { return }
         let parent = NSMenuItem(title: "复制路径", action: nil, keyEquivalent: "")
         parent.image = NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
         let submenu = NSMenu(title: "复制路径")
-        submenu.addItem(makeItem("复制绝对路径", #selector(copyAbsolutePaths(_:))))
-        submenu.addItem(makeItem("复制转义路径", #selector(copyShellEscapedPaths(_:))))
-        submenu.addItem(makeItem("复制文件名", #selector(copyFileNames(_:))))
-        submenu.addItem(makeItem("复制 file:// 链接", #selector(copyFileURLs(_:))))
+        if configuration.copyAbsolutePath {
+            submenu.addItem(makeItem("复制绝对路径", #selector(copyAbsolutePaths(_:))))
+        }
+        if configuration.copyShellEscapedPath {
+            submenu.addItem(makeItem("复制转义路径", #selector(copyShellEscapedPaths(_:))))
+        }
+        if configuration.copyFileName {
+            submenu.addItem(makeItem("复制文件名", #selector(copyFileNames(_:))))
+        }
+        if configuration.copyFileURL {
+            submenu.addItem(makeItem("复制 file:// 链接", #selector(copyFileURLs(_:))))
+        }
         parent.submenu = submenu
         menu.addItem(parent)
     }

--- a/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
@@ -107,9 +107,9 @@ final class FinderContextMenuProvider: FIFinderSync {
 
     // MARK: - New file actions
 
-    @objc private func newTextFile(_ sender: NSMenuItem) { createNewFile(ext: "txt") }
-    @objc private func newMarkdownFile(_ sender: NSMenuItem) { createNewFile(ext: "md") }
-    @objc private func newJSONFile(_ sender: NSMenuItem) { createNewFile(ext: "json") }
+    @objc private func newTextFile(_ sender: NSMenuItem) { requestNewFile(ext: "txt") }
+    @objc private func newMarkdownFile(_ sender: NSMenuItem) { requestNewFile(ext: "md") }
+    @objc private func newJSONFile(_ sender: NSMenuItem) { requestNewFile(ext: "json") }
 
     // MARK: - Targets
 
@@ -136,32 +136,29 @@ final class FinderContextMenuProvider: FIFinderSync {
         return controller.targetedURL()
     }
 
-    // MARK: - File creation
+    // MARK: - File creation (forwarded to the host app)
 
-    private func createNewFile(ext: String) {
+    /// Forward file creation to the non-sandboxed host app through the
+    /// `mactools://` URL scheme. The sandboxed extension cannot create files in
+    /// arbitrary user directories, so the host app performs it — which keeps this
+    /// extension at minimal entitlements (sandbox only, no file-access exception).
+    private func requestNewFile(ext: String) {
         guard let directory = newFileDirectory() else {
             logger.error("new file: no target directory available")
             return
         }
-        let fileURL = FinderContextMenuLogic.nextAvailableURL(
-            in: directory, baseName: "未命名", ext: ext
-        )
-        let fileManager = FileManager.default
-
-        // FinderSync has implicit access to URLs Finder hands back, so a direct
-        // create usually succeeds; fall back to explicit security-scoped access.
-        if fileManager.createFile(atPath: fileURL.path, contents: Data(), attributes: nil) {
-            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+        var components = URLComponents()
+        components.scheme = "mactools"
+        components.host = "newfile"
+        components.queryItems = [
+            URLQueryItem(name: "dir", value: directory.path),
+            URLQueryItem(name: "ext", value: ext)
+        ]
+        guard let url = components.url else {
+            logger.error("new file: failed to build request URL")
             return
         }
-
-        let didStart = directory.startAccessingSecurityScopedResource()
-        defer { if didStart { directory.stopAccessingSecurityScopedResource() } }
-        if fileManager.createFile(atPath: fileURL.path, contents: Data(), attributes: nil) {
-            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
-        } else {
-            logger.error("new file: failed to create at \(fileURL.path, privacy: .public)")
-        }
+        NSWorkspace.shared.open(url)
     }
 
     // MARK: - Pasteboard

--- a/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
+++ b/FinderSyncExtension/Sources/FinderContextMenuProvider.swift
@@ -14,8 +14,10 @@ import os
 /// never intercept mouse events), it is unaffected by the macOS 27 menu-bar
 /// rehosting that broke the status-item right-click.
 ///
-/// MVP scope: copy paths + create new files. Both run entirely inside the
-/// sandboxed extension — no app group, no container round-trip.
+/// Actions split by capability: copy actions run inside the sandboxed extension
+/// (the pasteboard needs no file access); file-creating / app-launching actions
+/// are forwarded to the non-sandboxed host app via the `mactools://` URL scheme,
+/// so this extension stays at minimal entitlements (sandbox only).
 ///
 /// Action identity note: macOS strips `representedObject` from the menu items
 /// handed back through FinderSync, so each action is a distinct `@objc`
@@ -50,6 +52,7 @@ final class FinderContextMenuProvider: FIFinderSync {
         let menu = NSMenu(title: "MacTools")
         addCopyMenu(to: menu)
         addNewFileMenu(to: menu)
+        addOpenInTerminalItem(to: menu)
         return menu
     }
 
@@ -60,6 +63,7 @@ final class FinderContextMenuProvider: FIFinderSync {
         submenu.addItem(makeItem("复制绝对路径", #selector(copyAbsolutePaths(_:))))
         submenu.addItem(makeItem("复制转义路径", #selector(copyShellEscapedPaths(_:))))
         submenu.addItem(makeItem("复制文件名", #selector(copyFileNames(_:))))
+        submenu.addItem(makeItem("复制 file:// 链接", #selector(copyFileURLs(_:))))
         parent.submenu = submenu
         menu.addItem(parent)
     }
@@ -75,13 +79,19 @@ final class FinderContextMenuProvider: FIFinderSync {
         menu.addItem(parent)
     }
 
+    private func addOpenInTerminalItem(to menu: NSMenu) {
+        let item = makeItem("在终端打开", #selector(openInTerminal(_:)))
+        item.image = NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
+        menu.addItem(item)
+    }
+
     private func makeItem(_ title: String, _ action: Selector) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
         return item
     }
 
-    // MARK: - Copy actions
+    // MARK: - Copy actions (run in-extension; pasteboard needs no file access)
 
     @objc private func copyAbsolutePaths(_ sender: NSMenuItem) {
         let urls = effectiveTargets()
@@ -104,11 +114,38 @@ final class FinderContextMenuProvider: FIFinderSync {
         writeToPasteboard(urls.map(\.lastPathComponent).joined(separator: "\n"))
     }
 
-    // MARK: - New file actions
+    @objc private func copyFileURLs(_ sender: NSMenuItem) {
+        let urls = effectiveTargets()
+        guard !urls.isEmpty else { return }
+        writeToPasteboard(urls.map(\.absoluteString).joined(separator: "\n"))
+    }
+
+    // MARK: - Forwarded actions (host app performs them; extension stays sandboxed)
 
     @objc private func newTextFile(_ sender: NSMenuItem) { requestNewFile(ext: "txt") }
     @objc private func newMarkdownFile(_ sender: NSMenuItem) { requestNewFile(ext: "md") }
     @objc private func newJSONFile(_ sender: NSMenuItem) { requestNewFile(ext: "json") }
+
+    private func requestNewFile(ext: String) {
+        guard let directory = targetDirectory() else {
+            logger.error("new file: no target directory available")
+            return
+        }
+        forwardRequest(host: "newfile", queryItems: [
+            URLQueryItem(name: "dir", value: directory.path),
+            URLQueryItem(name: "ext", value: ext)
+        ])
+    }
+
+    @objc private func openInTerminal(_ sender: NSMenuItem) {
+        guard let directory = targetDirectory() else {
+            logger.error("open in terminal: no target directory available")
+            return
+        }
+        forwardRequest(host: "openterminal", queryItems: [
+            URLQueryItem(name: "dir", value: directory.path)
+        ])
+    }
 
     // MARK: - Targets
 
@@ -125,9 +162,9 @@ final class FinderContextMenuProvider: FIFinderSync {
         return []
     }
 
-    /// Directory a new file should be created in: the selected folder, the
+    /// Directory new-file / open-in-terminal apply to: the selected folder, the
     /// selected file's parent, or the current directory.
-    private func newFileDirectory() -> URL? {
+    private func targetDirectory() -> URL? {
         let controller = FIFinderSyncController.default()
         if let first = controller.selectedItemURLs()?.first {
             return first.hasDirectoryPath ? first : first.deletingLastPathComponent()
@@ -135,26 +172,19 @@ final class FinderContextMenuProvider: FIFinderSync {
         return controller.targetedURL()
     }
 
-    // MARK: - File creation (forwarded to the host app)
+    // MARK: - Host app forwarding
 
-    /// Forward file creation to the non-sandboxed host app through the
-    /// `mactools://` URL scheme. The sandboxed extension cannot create files in
-    /// arbitrary user directories, so the host app performs it — which keeps this
-    /// extension at minimal entitlements (sandbox only, no file-access exception).
-    private func requestNewFile(ext: String) {
-        guard let directory = newFileDirectory() else {
-            logger.error("new file: no target directory available")
-            return
-        }
+    /// Forward an action to the non-sandboxed host app through the `mactools://`
+    /// URL scheme. The sandboxed extension cannot create files or launch apps in
+    /// arbitrary locations, so the host app performs them — keeping this extension
+    /// at minimal entitlements (sandbox only, no file-access exception).
+    private func forwardRequest(host: String, queryItems: [URLQueryItem]) {
         var components = URLComponents()
         components.scheme = "mactools"
-        components.host = "newfile"
-        components.queryItems = [
-            URLQueryItem(name: "dir", value: directory.path),
-            URLQueryItem(name: "ext", value: ext)
-        ]
+        components.host = host
+        components.queryItems = queryItems
         guard let url = components.url else {
-            logger.error("new file: failed to build request URL")
+            logger.error("failed to build \(host) request URL")
             return
         }
         NSWorkspace.shared.open(url)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 | Xcode Cleanup | Scan DerivedData, device support files, archives, simulators, and preview caches by category; deletion is disabled while Xcode is running and only runs inside allowlisted roots. |
 | Eject Disks | Eject all removable disks in one click, automatically skipping system volumes and reporting when no disk can be ejected. |
 | Empty Trash | Show the number of Trash items and empty Trash through Finder; the action is disabled when Trash is empty. |
+| Finder Context Menu | Add MacTools actions to Finder's right-click menu: copy paths (absolute / shell-escaped / file name / file:// URL), create new files (.txt / .md / .json), open in Terminal, and open with a configurable list of apps. Every item can be toggled — and the app list managed — in Settings. |
 | Clear Clipboard | Clear the current clipboard content to protect privacy and avoid accidental paste. |
 | IP Check | View public IPv4/IPv6, local LAN IP, location, ISP, ASN, and timezone, with copy support for single fields or the full result. |
 | Translator | Translate the currently selected text with a global shortcut; the first version supports OpenAI-compatible services and automatic language selection. |

--- a/Shared/FinderSync/FinderMenuConfigStore.swift
+++ b/Shared/FinderSync/FinderMenuConfigStore.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Reads/writes `FinderMenuConfiguration` in the shared app group container so
+/// the non-sandboxed host app and the sandboxed extension share one file.
+///
+/// A plain `UserDefaults(suiteName:)` is unreliable across the sandbox boundary
+/// (the two processes resolve different containers); the app group container
+/// *directory* is the same for both, so a JSON file there is the robust channel.
+enum FinderMenuConfigStore {
+    /// Resolved from Info.plist key `MTAppGroupIdentifier`, which both targets
+    /// set to `group.$(BUNDLE_IDENTIFIER_PREFIX).mactools` — so it tracks the
+    /// bundle-id prefix instead of being hard-coded, and stays in sync with the
+    /// `com.apple.security.application-groups` entitlement. Falls back to the
+    /// current default if the key is somehow missing.
+    static let appGroupIdentifier: String = {
+        Bundle.main.object(forInfoDictionaryKey: "MTAppGroupIdentifier") as? String
+            ?? "group.com.example.mactools"
+    }()
+
+    private static let fileName = "finder-menu-config.json"
+
+    private static var fileURL: URL? {
+        FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)?
+            .appendingPathComponent(fileName)
+    }
+
+    /// Load the saved configuration, or `.default` when nothing is saved yet or
+    /// the file is unreadable/corrupt.
+    static func load() -> FinderMenuConfiguration {
+        guard let url = fileURL,
+              let data = try? Data(contentsOf: url),
+              let configuration = try? JSONDecoder().decode(FinderMenuConfiguration.self, from: data)
+        else {
+            return .default
+        }
+        return configuration
+    }
+
+    /// Persist the configuration to the shared container. Returns false on
+    /// failure (missing container / encode / write error) without throwing.
+    @discardableResult
+    static func save(_ configuration: FinderMenuConfiguration) -> Bool {
+        guard let url = fileURL,
+              let data = try? JSONEncoder().encode(configuration) else {
+            return false
+        }
+        do {
+            try data.write(to: url, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
+    }
+}

--- a/Shared/FinderSync/FinderMenuConfigStore.swift
+++ b/Shared/FinderSync/FinderMenuConfigStore.swift
@@ -1,35 +1,50 @@
 import Foundation
 
-/// Reads/writes `FinderMenuConfiguration` in the shared app group container so
-/// the non-sandboxed host app and the sandboxed extension share one file.
+/// Reads/writes `FinderMenuConfiguration` shared between the non-sandboxed host
+/// app and the sandboxed Finder Sync extension, via a JSON file under the user's
+/// real `~/Library/Application Support/MacTools/`.
 ///
-/// A plain `UserDefaults(suiteName:)` is unreliable across the sandbox boundary
-/// (the two processes resolve different containers); the app group container
-/// *directory* is the same for both, so a JSON file there is the robust channel.
+/// Why a plain file at the real home — and neither an app group nor UserDefaults
+/// (both were tried and measured to fail across this sandbox boundary):
+/// - The non-sandboxed host app is **denied** write access to the app group
+///   container (`~/Library/Group Containers`, managed by containermanagerd —
+///   writes fail with "Operation not permitted").
+/// - `UserDefaults(suiteName:)` does NOT bridge the two either: the non-sandboxed
+///   app's cfprefsd domain and the sandboxed extension's are separate, so the
+///   extension only ever reads back `.default`.
+///
+/// So the host writes a JSON file it CAN write (its real Application Support),
+/// and the sandboxed extension reads it through a read-only
+/// `temporary-exception.files.home-relative-path` entitlement scoped to
+/// `configDirectoryRelativePath`. Both sides must resolve the SAME path: a
+/// sandboxed process's `NSHomeDirectory()` is redirected to its container, so we
+/// resolve the real home via `getpwuid` on both sides to keep the path identical.
 enum FinderMenuConfigStore {
-    /// Resolved from Info.plist key `MTAppGroupIdentifier`, which both targets
-    /// set to `group.$(BUNDLE_IDENTIFIER_PREFIX).mactools` — so it tracks the
-    /// bundle-id prefix instead of being hard-coded, and stays in sync with the
-    /// `com.apple.security.application-groups` entitlement. Falls back to the
-    /// current default if the key is somehow missing.
-    static let appGroupIdentifier: String = {
-        Bundle.main.object(forInfoDictionaryKey: "MTAppGroupIdentifier") as? String
-            ?? "group.com.example.mactools"
+    /// Real user home directory, bypassing the sandbox container redirection so
+    /// the host app and the sandboxed extension resolve the exact same file.
+    private static let realHomeDirectory: String = {
+        if let pw = getpwuid(getuid()), let home = pw.pointee.pw_dir {
+            return String(cString: home)
+        }
+        return NSHomeDirectory()
     }()
 
-    private static let fileName = "finder-menu-config.json"
+    /// Directory the configuration file lives in, relative to the real home. Must
+    /// stay in sync with the extension's `home-relative-path` read-only
+    /// entitlement (`/Library/Application Support/MacTools/`).
+    static let configDirectoryRelativePath = "Library/Application Support/MacTools"
 
-    private static var fileURL: URL? {
-        FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)?
-            .appendingPathComponent(fileName)
+    /// Resolved location of the shared configuration file.
+    static var configFileURL: URL {
+        URL(fileURLWithPath: realHomeDirectory)
+            .appendingPathComponent(configDirectoryRelativePath, isDirectory: true)
+            .appendingPathComponent("finder-menu.json")
     }
 
     /// Load the saved configuration, or `.default` when nothing is saved yet or
-    /// the file is unreadable/corrupt.
-    static func load() -> FinderMenuConfiguration {
-        guard let url = fileURL,
-              let data = try? Data(contentsOf: url),
+    /// the stored data is unreadable.
+    static func load(from fileURL: URL = configFileURL) -> FinderMenuConfiguration {
+        guard let data = try? Data(contentsOf: fileURL),
               let configuration = try? JSONDecoder().decode(FinderMenuConfiguration.self, from: data)
         else {
             return .default
@@ -37,16 +52,18 @@ enum FinderMenuConfigStore {
         return configuration
     }
 
-    /// Persist the configuration to the shared container. Returns false on
-    /// failure (missing container / encode / write error) without throwing.
+    /// Persist the configuration. Returns false when the directory cannot be
+    /// created or the file cannot be written. Only the non-sandboxed host app is
+    /// expected to call this; the sandboxed extension has read-only access.
     @discardableResult
-    static func save(_ configuration: FinderMenuConfiguration) -> Bool {
-        guard let url = fileURL,
-              let data = try? JSONEncoder().encode(configuration) else {
-            return false
-        }
+    static func save(_ configuration: FinderMenuConfiguration, to fileURL: URL = configFileURL) -> Bool {
         do {
-            try data.write(to: url, options: .atomic)
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(configuration)
+            try data.write(to: fileURL, options: .atomic)
             return true
         } catch {
             return false

--- a/Shared/FinderSync/FinderMenuConfiguration.swift
+++ b/Shared/FinderSync/FinderMenuConfiguration.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// User configuration for the MacTools Finder context menu, shared between the
+/// host app (writes it from the settings UI) and the sandboxed extension (reads
+/// it to decide which items to show). Persisted as JSON in the shared app group
+/// container — see `FinderMenuConfigStore`.
+///
+/// This file is compiled into BOTH the host app and the extension targets (they
+/// can't import each other); the JSON written by one is decoded by the other.
+struct FinderMenuConfiguration: Codable, Equatable {
+    var copyAbsolutePath: Bool
+    var copyShellEscapedPath: Bool
+    var copyFileName: Bool
+    var copyFileURL: Bool
+    var newFileEnabled: Bool
+    var openInTerminal: Bool
+    var openWithApps: [OpenWithApp]
+
+    init(
+        copyAbsolutePath: Bool = true,
+        copyShellEscapedPath: Bool = true,
+        copyFileName: Bool = true,
+        copyFileURL: Bool = true,
+        newFileEnabled: Bool = true,
+        openInTerminal: Bool = true,
+        openWithApps: [OpenWithApp] = []
+    ) {
+        self.copyAbsolutePath = copyAbsolutePath
+        self.copyShellEscapedPath = copyShellEscapedPath
+        self.copyFileName = copyFileName
+        self.copyFileURL = copyFileURL
+        self.newFileEnabled = newFileEnabled
+        self.openInTerminal = openInTerminal
+        self.openWithApps = openWithApps
+    }
+
+    /// Defaults match the previously hard-coded menu, so a fresh install behaves
+    /// exactly like before any configuration is saved.
+    static let `default` = FinderMenuConfiguration()
+
+    /// True when no copy action is enabled (used to hide the empty submenu).
+    var hasAnyCopyAction: Bool {
+        copyAbsolutePath || copyShellEscapedPath || copyFileName || copyFileURL
+    }
+}
+
+/// A user-configured "Open With" application entry.
+struct OpenWithApp: Codable, Equatable, Identifiable {
+    var id: UUID
+    var name: String
+    var appPath: String
+    /// Lowercased file extensions this entry applies to; empty = all files.
+    var fileExtensions: [String]
+
+    init(id: UUID = UUID(), name: String, appPath: String, fileExtensions: [String] = []) {
+        self.id = id
+        self.name = name
+        self.appPath = appPath
+        self.fileExtensions = fileExtensions
+    }
+
+    /// Whether this entry should appear for a file with the given (lowercased)
+    /// extension. An empty `fileExtensions` matches everything.
+    func matches(fileExtension ext: String) -> Bool {
+        fileExtensions.isEmpty || fileExtensions.contains(ext.lowercased())
+    }
+}

--- a/Shared/FinderSync/FinderMenuConfiguration.swift
+++ b/Shared/FinderSync/FinderMenuConfiguration.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// User configuration for the MacTools Finder context menu, shared between the
 /// host app (writes it from the settings UI) and the sandboxed extension (reads
-/// it to decide which items to show). Persisted as JSON in the shared app group
-/// container — see `FinderMenuConfigStore`.
+/// it to decide which items to show). Persisted as JSON under the user's
+/// Application Support directory — see `FinderMenuConfigStore`.
 ///
 /// This file is compiled into BOTH the host app and the extension targets (they
 /// can't import each other); the JSON written by one is decoded by the other.

--- a/Sources/App/FinderContextMenuRequestHandler.swift
+++ b/Sources/App/FinderContextMenuRequestHandler.swift
@@ -12,6 +12,16 @@ enum FinderContextMenuRequestHandler {
     /// Custom URL scheme the Finder extension uses to reach the host app.
     static let scheme = "mactools"
 
+    /// File extensions the New File action may create. A strict allow list keeps
+    /// the feature to its intended types and — because a custom URL scheme can be
+    /// invoked by any process on the system — prevents path traversal through the
+    /// `ext` parameter (e.g. `../../etc/foo`).
+    static let allowedNewFileExtensions: Set<String> = ["txt", "md", "json"]
+
+    static func isSupportedNewFileExtension(_ ext: String) -> Bool {
+        allowedNewFileExtensions.contains(ext)
+    }
+
     /// Route a forwarded URL. Returns true when it was a recognized request.
     @MainActor
     @discardableResult
@@ -36,8 +46,8 @@ enum FinderContextMenuRequestHandler {
             if let value = item.value { params[item.name] = value }
         }
         guard let dir = params["dir"], !dir.isEmpty,
-              let ext = params["ext"], !ext.isEmpty else {
-            AppLog.finderContextMenu.error("mactools://newfile missing dir or ext")
+              let ext = params["ext"], isSupportedNewFileExtension(ext) else {
+            AppLog.finderContextMenu.error("mactools://newfile missing dir or unsupported ext")
             return false
         }
         // The host app is non-sandboxed; validate the target is a real directory
@@ -52,6 +62,16 @@ enum FinderContextMenuRequestHandler {
         }
         let directory = URL(fileURLWithPath: dir, isDirectory: true)
         let fileURL = nextAvailableURL(in: directory, baseName: "未命名", ext: ext)
+        // Defense-in-depth: the resolved file must sit directly inside the target
+        // directory. The allow-listed ext already rules out traversal; this guard
+        // keeps that invariant even if the naming inputs ever change.
+        guard fileURL.deletingLastPathComponent().standardizedFileURL.path
+            == directory.standardizedFileURL.path else {
+            AppLog.finderContextMenu.error(
+                "mactools://newfile resolved outside target directory: \(fileURL.path, privacy: .public)"
+            )
+            return false
+        }
         guard FileManager.default.createFile(atPath: fileURL.path, contents: Data(), attributes: nil) else {
             AppLog.finderContextMenu.error(
                 "mactools://newfile failed to create \(fileURL.path, privacy: .public)"

--- a/Sources/App/FinderContextMenuRequestHandler.swift
+++ b/Sources/App/FinderContextMenuRequestHandler.swift
@@ -4,8 +4,8 @@ import Foundation
 /// Handles `mactools://` requests forwarded by the Finder Sync extension.
 ///
 /// The Finder extension is sandboxed and cannot create files in arbitrary user
-/// directories, so file-creating actions are forwarded to this non-sandboxed
-/// host app through a custom URL scheme. Keeping creation here lets the
+/// directories or launch other apps, so those actions are forwarded to this
+/// non-sandboxed host app through a custom URL scheme. Keeping them here lets the
 /// extension stay at minimal entitlements (sandbox only) instead of carrying a
 /// review-sensitive temporary-exception file-access entitlement.
 enum FinderContextMenuRequestHandler {
@@ -30,6 +30,8 @@ enum FinderContextMenuRequestHandler {
         switch url.host {
         case "newfile":
             return handleNewFile(url)
+        case "openterminal":
+            return handleOpenInTerminal(url)
         default:
             AppLog.finderContextMenu.warning(
                 "Unknown mactools URL host: \(url.host ?? "nil", privacy: .public)"
@@ -38,29 +40,16 @@ enum FinderContextMenuRequestHandler {
         }
     }
 
+    // MARK: - Actions
+
     @MainActor
     private static func handleNewFile(_ url: URL) -> Bool {
-        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
-        var params: [String: String] = [:]
-        for item in queryItems {
-            if let value = item.value { params[item.name] = value }
-        }
-        guard let dir = params["dir"], !dir.isEmpty,
-              let ext = params["ext"], isSupportedNewFileExtension(ext) else {
-            AppLog.finderContextMenu.error("mactools://newfile missing dir or unsupported ext")
+        let params = queryParameters(of: url)
+        guard let ext = params["ext"], isSupportedNewFileExtension(ext) else {
+            AppLog.finderContextMenu.error("mactools://newfile missing or unsupported ext")
             return false
         }
-        // The host app is non-sandboxed; validate the target is a real directory
-        // so a malformed request can never create files in an unexpected place.
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: dir, isDirectory: &isDirectory),
-              isDirectory.boolValue else {
-            AppLog.finderContextMenu.error(
-                "mactools://newfile target is not a directory: \(dir, privacy: .public)"
-            )
-            return false
-        }
-        let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        guard let directory = validatedDirectory(params) else { return false }
         let fileURL = nextAvailableURL(in: directory, baseName: "未命名", ext: ext)
         // Defense-in-depth: the resolved file must sit directly inside the target
         // directory. The allow-listed ext already rules out traversal; this guard
@@ -80,6 +69,53 @@ enum FinderContextMenuRequestHandler {
         }
         NSWorkspace.shared.activateFileViewerSelecting([fileURL])
         return true
+    }
+
+    @MainActor
+    private static func handleOpenInTerminal(_ url: URL) -> Bool {
+        guard let directory = validatedDirectory(queryParameters(of: url)) else { return false }
+        guard let terminalURL = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.apple.Terminal"
+        ) else {
+            AppLog.finderContextMenu.error("mactools://openterminal: Terminal app not found")
+            return false
+        }
+        NSWorkspace.shared.open(
+            [directory],
+            withApplicationAt: terminalURL,
+            configuration: NSWorkspace.OpenConfiguration()
+        )
+        return true
+    }
+
+    // MARK: - Helpers
+
+    private static func queryParameters(of url: URL) -> [String: String] {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        var params: [String: String] = [:]
+        for item in items {
+            if let value = item.value { params[item.name] = value }
+        }
+        return params
+    }
+
+    /// Resolve and validate the `dir` parameter as an existing directory. The
+    /// host app is non-sandboxed, so a malformed request must never reach the
+    /// file system: anything that is not a real directory is rejected.
+    private static func validatedDirectory(_ params: [String: String]) -> URL? {
+        guard let dir = params["dir"], !dir.isEmpty else {
+            AppLog.finderContextMenu.error("mactools request missing dir")
+            return nil
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: dir, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            AppLog.finderContextMenu.error(
+                "mactools request dir is not a directory: \(dir, privacy: .public)"
+            )
+            return nil
+        }
+        return URL(fileURLWithPath: dir, isDirectory: true)
     }
 
     /// First non-colliding URL of the form `<baseName>.<ext>`,

--- a/Sources/App/FinderContextMenuRequestHandler.swift
+++ b/Sources/App/FinderContextMenuRequestHandler.swift
@@ -32,6 +32,8 @@ enum FinderContextMenuRequestHandler {
             return handleNewFile(url)
         case "openterminal":
             return handleOpenInTerminal(url)
+        case "openwith":
+            return handleOpenWith(url)
         default:
             AppLog.finderContextMenu.warning(
                 "Unknown mactools URL host: \(url.host ?? "nil", privacy: .public)"
@@ -83,6 +85,59 @@ enum FinderContextMenuRequestHandler {
         NSWorkspace.shared.open(
             [directory],
             withApplicationAt: terminalURL,
+            configuration: NSWorkspace.OpenConfiguration()
+        )
+        return true
+    }
+
+    /// Open the forwarded files with a user-chosen app. The `app` must be an
+    /// existing `.app` bundle and at least one `file` must exist; anything else
+    /// is rejected so a malformed (or hostile) request can't reach the file
+    /// system in an unexpected way.
+    /// Parsed + validated open-with request. Split out of `handleOpenWith` so the
+    /// validation is unit-testable without launching anything.
+    struct OpenWithRequest: Equatable {
+        let appURL: URL
+        let files: [URL]
+    }
+
+    /// Validate a forwarded open-with request: `app` must be an existing `.app`
+    /// bundle and at least one `file` must exist; anything else returns nil. The
+    /// file-system probes are injected so tests don't touch the real disk.
+    static func parseOpenWithRequest(
+        _ items: [URLQueryItem],
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        isApplicationBundle: (String) -> Bool = isApplicationBundleOnDisk
+    ) -> OpenWithRequest? {
+        guard let appPath = items.first(where: { $0.name == "app" })?.value,
+              !appPath.isEmpty, isApplicationBundle(appPath) else {
+            return nil
+        }
+        let files = items.filter { $0.name == "file" }
+            .compactMap(\.value)
+            .map { URL(fileURLWithPath: $0) }
+            .filter { fileExists($0.path) }
+        guard !files.isEmpty else { return nil }
+        return OpenWithRequest(appURL: URL(fileURLWithPath: appPath), files: files)
+    }
+
+    private static func isApplicationBundleOnDisk(_ path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return path.hasSuffix(".app")
+            && FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+    }
+
+    @MainActor
+    private static func handleOpenWith(_ url: URL) -> Bool {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        guard let request = parseOpenWithRequest(items) else {
+            AppLog.finderContextMenu.error("mactools://openwith invalid request")
+            return false
+        }
+        NSWorkspace.shared.open(
+            request.files,
+            withApplicationAt: request.appURL,
             configuration: NSWorkspace.OpenConfiguration()
         )
         return true

--- a/Sources/App/FinderContextMenuRequestHandler.swift
+++ b/Sources/App/FinderContextMenuRequestHandler.swift
@@ -1,0 +1,84 @@
+import AppKit
+import Foundation
+
+/// Handles `mactools://` requests forwarded by the Finder Sync extension.
+///
+/// The Finder extension is sandboxed and cannot create files in arbitrary user
+/// directories, so file-creating actions are forwarded to this non-sandboxed
+/// host app through a custom URL scheme. Keeping creation here lets the
+/// extension stay at minimal entitlements (sandbox only) instead of carrying a
+/// review-sensitive temporary-exception file-access entitlement.
+enum FinderContextMenuRequestHandler {
+    /// Custom URL scheme the Finder extension uses to reach the host app.
+    static let scheme = "mactools"
+
+    /// Route a forwarded URL. Returns true when it was a recognized request.
+    @MainActor
+    @discardableResult
+    static func handle(_ url: URL) -> Bool {
+        guard url.scheme == scheme else { return false }
+        switch url.host {
+        case "newfile":
+            return handleNewFile(url)
+        default:
+            AppLog.finderContextMenu.warning(
+                "Unknown mactools URL host: \(url.host ?? "nil", privacy: .public)"
+            )
+            return false
+        }
+    }
+
+    @MainActor
+    private static func handleNewFile(_ url: URL) -> Bool {
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        var params: [String: String] = [:]
+        for item in queryItems {
+            if let value = item.value { params[item.name] = value }
+        }
+        guard let dir = params["dir"], !dir.isEmpty,
+              let ext = params["ext"], !ext.isEmpty else {
+            AppLog.finderContextMenu.error("mactools://newfile missing dir or ext")
+            return false
+        }
+        // The host app is non-sandboxed; validate the target is a real directory
+        // so a malformed request can never create files in an unexpected place.
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: dir, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            AppLog.finderContextMenu.error(
+                "mactools://newfile target is not a directory: \(dir, privacy: .public)"
+            )
+            return false
+        }
+        let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        let fileURL = nextAvailableURL(in: directory, baseName: "未命名", ext: ext)
+        guard FileManager.default.createFile(atPath: fileURL.path, contents: Data(), attributes: nil) else {
+            AppLog.finderContextMenu.error(
+                "mactools://newfile failed to create \(fileURL.path, privacy: .public)"
+            )
+            return false
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+        return true
+    }
+
+    /// First non-colliding URL of the form `<baseName>.<ext>`,
+    /// `<baseName> 2.<ext>`, `<baseName> 3.<ext>`, … inside `directory`.
+    ///
+    /// `fileExists` is injected so tests can drive the collision logic without a
+    /// real file system.
+    static func nextAvailableURL(
+        in directory: URL,
+        baseName: String,
+        ext: String,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> URL {
+        var candidate = directory.appendingPathComponent("\(baseName).\(ext)")
+        var counter = 2
+        while fileExists(candidate.path) {
+            candidate = directory.appendingPathComponent("\(baseName) \(counter).\(ext)")
+            counter += 1
+        }
+        return candidate
+    }
+}

--- a/Sources/App/FinderMenuSettingsView.swift
+++ b/Sources/App/FinderMenuSettingsView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 /// Host-app settings page for the Finder context menu. It writes the shared
-/// `FinderMenuConfiguration` (read by the sandboxed extension through the app
-/// group), so the user controls which items appear when right-clicking in
-/// Finder. Changes take effect on the next right-click — the extension reads the
-/// config on every `menu(for:)`.
+/// `FinderMenuConfiguration` (read by the sandboxed extension through a read-only
+/// file-access exception), so the user controls which items appear when
+/// right-clicking in Finder. Changes take effect on the next right-click — the
+/// extension reads the config on every `menu(for:)`.
 struct FinderMenuSettingsView: View {
     @State private var configuration = FinderMenuConfigStore.load()
 

--- a/Sources/App/FinderMenuSettingsView.swift
+++ b/Sources/App/FinderMenuSettingsView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Host-app settings page for the Finder context menu. It writes the shared
+/// `FinderMenuConfiguration` (read by the sandboxed extension through the app
+/// group), so the user controls which items appear when right-clicking in
+/// Finder. Changes take effect on the next right-click — the extension reads the
+/// config on every `menu(for:)`.
+struct FinderMenuSettingsView: View {
+    @State private var configuration = FinderMenuConfigStore.load()
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("复制绝对路径", isOn: $configuration.copyAbsolutePath)
+                Toggle("复制转义路径（终端）", isOn: $configuration.copyShellEscapedPath)
+                Toggle("复制文件名", isOn: $configuration.copyFileName)
+                Toggle("复制 file:// 链接", isOn: $configuration.copyFileURL)
+            } header: {
+                Text("「复制路径」子菜单")
+            } footer: {
+                Text("控制在 Finder 中右键时,「复制路径」子菜单里显示哪些项。")
+            }
+
+            Section("其他菜单项") {
+                Toggle("新建文件（.txt / .md / .json）", isOn: $configuration.newFileEnabled)
+                Toggle("在终端打开", isOn: $configuration.openInTerminal)
+            }
+        }
+        .formStyle(.grouped)
+        .onChange(of: configuration) { _, newValue in
+            FinderMenuConfigStore.save(newValue)
+        }
+    }
+}

--- a/Sources/App/FinderMenuSettingsView.swift
+++ b/Sources/App/FinderMenuSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Host-app settings page for the Finder context menu. It writes the shared
@@ -25,10 +26,94 @@ struct FinderMenuSettingsView: View {
                 Toggle("新建文件（.txt / .md / .json）", isOn: $configuration.newFileEnabled)
                 Toggle("在终端打开", isOn: $configuration.openInTerminal)
             }
+
+            Section {
+                if configuration.openWithApps.isEmpty {
+                    Text("暂无应用")
+                        .foregroundStyle(.secondary)
+                }
+                ForEach($configuration.openWithApps) { $app in
+                    OpenWithAppRow(app: $app) {
+                        configuration.openWithApps.removeAll { $0.id == app.id }
+                    }
+                }
+                Button {
+                    addApp()
+                } label: {
+                    Label("添加应用…", systemImage: "plus")
+                }
+                .buttonStyle(.borderless)
+            } header: {
+                Text("「用应用打开」子菜单")
+            } footer: {
+                Text("右键文件时用指定应用打开。扩展名留空表示对所有文件显示;多个扩展名用逗号分隔。")
+            }
         }
         .formStyle(.grouped)
         .onChange(of: configuration) { _, newValue in
             FinderMenuConfigStore.save(newValue)
+        }
+    }
+
+    /// Let the user pick a `.app` bundle and append it to the list.
+    private func addApp() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.application]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+        panel.prompt = "选择"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let name = FileManager.default.displayName(atPath: url.path)
+            .replacingOccurrences(of: ".app", with: "")
+        configuration.openWithApps.append(
+            OpenWithApp(name: name, appPath: url.path, fileExtensions: [])
+        )
+    }
+}
+
+/// One row in the "Open with app" list: app name + path, an editable
+/// comma-separated extension filter, and a delete button.
+private struct OpenWithAppRow: View {
+    @Binding var app: OpenWithApp
+    let onDelete: () -> Void
+
+    /// Comma-separated extensions, edited as text and synced back to
+    /// `app.fileExtensions` (lowercased, trimmed, de-blanked).
+    @State private var extensionsText: String
+
+    init(app: Binding<OpenWithApp>, onDelete: @escaping () -> Void) {
+        _app = app
+        self.onDelete = onDelete
+        _extensionsText = State(
+            initialValue: app.wrappedValue.fileExtensions.joined(separator: ", ")
+        )
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(app.name)
+                Text(app.appPath)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 8)
+            TextField("扩展名", text: $extensionsText)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 120)
+                .onChange(of: extensionsText) { _, newValue in
+                    app.fileExtensions = newValue
+                        .split(separator: ",")
+                        .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+                        .filter { !$0.isEmpty }
+                }
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
         }
     }
 }

--- a/Sources/App/FinderMenuSettingsView.swift
+++ b/Sources/App/FinderMenuSettingsView.swift
@@ -64,8 +64,11 @@ struct FinderMenuSettingsView: View {
         panel.directoryURL = URL(fileURLWithPath: "/Applications")
         panel.prompt = "选择"
         guard panel.runModal() == .OK, let url = panel.url else { return }
-        let name = FileManager.default.displayName(atPath: url.path)
-            .replacingOccurrences(of: ".app", with: "")
+        // displayName is already localized and usually extension-free; strip only
+        // a trailing ".app" rather than a global replace (which could clip a
+        // ".app" substring in the middle of a name).
+        let displayName = FileManager.default.displayName(atPath: url.path)
+        let name = displayName.hasSuffix(".app") ? String(displayName.dropLast(4)) : displayName
         configuration.openWithApps.append(
             OpenWithApp(name: name, appPath: url.path, fileExtensions: [])
         )

--- a/Sources/App/MacToolsApp.swift
+++ b/Sources/App/MacToolsApp.swift
@@ -48,6 +48,14 @@ final class MacToolsAppDelegate: NSObject, NSApplicationDelegate {
         bootstrapDynamicPlugins()
     }
 
+    func application(_ application: NSApplication, open urls: [URL]) {
+        // The Finder Sync extension forwards file-creating actions here via the
+        // mactools:// scheme so the non-sandboxed host app performs them.
+        for url in urls {
+            FinderContextMenuRequestHandler.handle(url)
+        }
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         statusItemController?.dismissPanels()
         pluginHost.dynamicPluginManager?.deactivateAll()

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -35,6 +35,12 @@ struct SettingsView: View {
                     Label(AppL10n.settings("tab.plugins", defaultValue: "插件"), systemImage: "slider.horizontal.3")
                 }
 
+            FinderMenuSettingsView()
+                .tag(SettingsDestination.finderMenu)
+                .tabItem {
+                    Label(AppL10n.settings("tab.finderMenu", defaultValue: "访达菜单"), systemImage: "contextualmenu.and.cursorarrow")
+                }
+
             AboutSettingsView(appUpdater: appUpdater)
                 .tag(SettingsDestination.about)
                 .tabItem {

--- a/Sources/Core/Diagnostics/AppLog.swift
+++ b/Sources/Core/Diagnostics/AppLog.swift
@@ -9,6 +9,7 @@ enum AppLog {
     static let autoHideDockPlugin = Logger(subsystem: subsystem, category: "AutoHideDockPlugin")
     static let pluginHost = Logger(subsystem: subsystem, category: "PluginHost")
     static let launchAtLogin = Logger(subsystem: subsystem, category: "LaunchAtLogin")
+    static let finderContextMenu = Logger(subsystem: subsystem, category: "FinderContextMenu")
 
     static var isVerboseLoggingEnabled: Bool {
         #if DEBUG

--- a/Sources/MacToolsPluginKit/PluginModels.swift
+++ b/Sources/MacToolsPluginKit/PluginModels.swift
@@ -75,6 +75,7 @@ public enum PluginPermissionKind {
 public enum SettingsDestination: Hashable {
     case general
     case pluginConfiguration
+    case finderMenu
     case about
 }
 

--- a/Tests/App/FinderContextMenuLogicTests.swift
+++ b/Tests/App/FinderContextMenuLogicTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+// FinderContextMenuLogic is compiled directly into this test bundle (the Finder
+// Sync extension is an app-extension, not an importable framework), so it is
+// referenced here without an import.
+final class FinderContextMenuLogicTests: XCTestCase {
+    func testShellEscapedWrapsPlainPathInSingleQuotes() {
+        XCTAssertEqual(
+            FinderContextMenuLogic.shellEscaped("/Users/me/file.txt"),
+            "'/Users/me/file.txt'"
+        )
+    }
+
+    func testShellEscapedKeepsSpacesInsideQuotes() {
+        XCTAssertEqual(
+            FinderContextMenuLogic.shellEscaped("/Users/me/My File.txt"),
+            "'/Users/me/My File.txt'"
+        )
+    }
+
+    func testShellEscapedEscapesEmbeddedSingleQuote() {
+        // it's.txt -> 'it'\''s.txt'
+        XCTAssertEqual(
+            FinderContextMenuLogic.shellEscaped("it's.txt"),
+            "'it'\\''s.txt'"
+        )
+    }
+}

--- a/Tests/App/FinderContextMenuRequestHandlerTests.swift
+++ b/Tests/App/FinderContextMenuRequestHandlerTests.swift
@@ -44,4 +44,58 @@ final class FinderContextMenuRequestHandlerTests: XCTestCase {
         XCTAssertFalse(FinderContextMenuRequestHandler.isSupportedNewFileExtension("exe"))
         XCTAssertFalse(FinderContextMenuRequestHandler.isSupportedNewFileExtension(""))
     }
+
+    // MARK: - Open With
+
+    func testParseOpenWithAcceptsValidAppAndFiles() {
+        let items = [
+            URLQueryItem(name: "app", value: "/Applications/Code.app"),
+            URLQueryItem(name: "file", value: "/tmp/a.txt"),
+            URLQueryItem(name: "file", value: "/tmp/b.md")
+        ]
+        let request = FinderContextMenuRequestHandler.parseOpenWithRequest(
+            items, fileExists: { _ in true }, isApplicationBundle: { _ in true }
+        )
+        XCTAssertEqual(request?.appURL.path, "/Applications/Code.app")
+        XCTAssertEqual(request?.files.map(\.path), ["/tmp/a.txt", "/tmp/b.md"])
+    }
+
+    func testParseOpenWithRejectsNonAppBundle() {
+        let items = [
+            URLQueryItem(name: "app", value: "/tmp/not-an-app"),
+            URLQueryItem(name: "file", value: "/tmp/a.txt")
+        ]
+        XCTAssertNil(FinderContextMenuRequestHandler.parseOpenWithRequest(
+            items, fileExists: { _ in true }, isApplicationBundle: { _ in false }
+        ))
+    }
+
+    func testParseOpenWithRejectsWhenNoFilesExist() {
+        let items = [
+            URLQueryItem(name: "app", value: "/Applications/Code.app"),
+            URLQueryItem(name: "file", value: "/tmp/missing.txt")
+        ]
+        XCTAssertNil(FinderContextMenuRequestHandler.parseOpenWithRequest(
+            items, fileExists: { _ in false }, isApplicationBundle: { _ in true }
+        ))
+    }
+
+    func testParseOpenWithDropsMissingFilesButKeepsExisting() {
+        let items = [
+            URLQueryItem(name: "app", value: "/Applications/Code.app"),
+            URLQueryItem(name: "file", value: "/tmp/exists.txt"),
+            URLQueryItem(name: "file", value: "/tmp/missing.txt")
+        ]
+        let request = FinderContextMenuRequestHandler.parseOpenWithRequest(
+            items, fileExists: { $0 == "/tmp/exists.txt" }, isApplicationBundle: { _ in true }
+        )
+        XCTAssertEqual(request?.files.map(\.path), ["/tmp/exists.txt"])
+    }
+
+    func testParseOpenWithRejectsMissingApp() {
+        let items = [URLQueryItem(name: "file", value: "/tmp/a.txt")]
+        XCTAssertNil(FinderContextMenuRequestHandler.parseOpenWithRequest(
+            items, fileExists: { _ in true }, isApplicationBundle: { _ in true }
+        ))
+    }
 }

--- a/Tests/App/FinderContextMenuRequestHandlerTests.swift
+++ b/Tests/App/FinderContextMenuRequestHandlerTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import MacTools
+
+final class FinderContextMenuRequestHandlerTests: XCTestCase {
+    private let directory = URL(fileURLWithPath: "/tmp/finder-test", isDirectory: true)
+
+    func testNextAvailableURLUsesBaseNameWhenNoCollision() {
+        let url = FinderContextMenuRequestHandler.nextAvailableURL(
+            in: directory, baseName: "未命名", ext: "txt",
+            fileExists: { _ in false }
+        )
+        XCTAssertEqual(url.lastPathComponent, "未命名.txt")
+    }
+
+    func testNextAvailableURLSkipsExistingNames() {
+        let taken: Set<String> = [
+            "/tmp/finder-test/未命名.txt",
+            "/tmp/finder-test/未命名 2.txt"
+        ]
+        let url = FinderContextMenuRequestHandler.nextAvailableURL(
+            in: directory, baseName: "未命名", ext: "txt",
+            fileExists: { taken.contains($0) }
+        )
+        XCTAssertEqual(url.lastPathComponent, "未命名 3.txt")
+    }
+
+    func testNextAvailableURLRespectsExtension() {
+        let url = FinderContextMenuRequestHandler.nextAvailableURL(
+            in: directory, baseName: "未命名", ext: "json",
+            fileExists: { _ in false }
+        )
+        XCTAssertEqual(url.pathExtension, "json")
+    }
+
+    func testSupportedExtensionsAllowIntendedTypes() {
+        XCTAssertTrue(FinderContextMenuRequestHandler.isSupportedNewFileExtension("txt"))
+        XCTAssertTrue(FinderContextMenuRequestHandler.isSupportedNewFileExtension("md"))
+        XCTAssertTrue(FinderContextMenuRequestHandler.isSupportedNewFileExtension("json"))
+    }
+
+    func testSupportedExtensionsRejectTraversalAndUnknown() {
+        XCTAssertFalse(FinderContextMenuRequestHandler.isSupportedNewFileExtension("../../etc/passwd"))
+        XCTAssertFalse(FinderContextMenuRequestHandler.isSupportedNewFileExtension("txt/../../evil"))
+        XCTAssertFalse(FinderContextMenuRequestHandler.isSupportedNewFileExtension("exe"))
+        XCTAssertFalse(FinderContextMenuRequestHandler.isSupportedNewFileExtension(""))
+    }
+}

--- a/Tests/App/FinderMenuConfigStoreTests.swift
+++ b/Tests/App/FinderMenuConfigStoreTests.swift
@@ -53,4 +53,20 @@ final class FinderMenuConfigStoreTests: XCTestCase {
         XCTAssertTrue(FinderMenuConfigStore.save(.default, to: fileURL))
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
     }
+
+    // MARK: - OpenWithApp matching
+
+    func testOpenWithAppMatchesListedExtensionsCaseInsensitively() {
+        let app = OpenWithApp(name: "Editor", appPath: "/E.app", fileExtensions: ["txt", "md"])
+        XCTAssertTrue(app.matches(fileExtension: "txt"))
+        XCTAssertTrue(app.matches(fileExtension: "TXT"))
+        XCTAssertTrue(app.matches(fileExtension: "md"))
+        XCTAssertFalse(app.matches(fileExtension: "png"))
+    }
+
+    func testOpenWithAppEmptyExtensionsMatchesEverything() {
+        let app = OpenWithApp(name: "Editor", appPath: "/E.app", fileExtensions: [])
+        XCTAssertTrue(app.matches(fileExtension: "txt"))
+        XCTAssertTrue(app.matches(fileExtension: ""))
+    }
 }

--- a/Tests/App/FinderMenuConfigStoreTests.swift
+++ b/Tests/App/FinderMenuConfigStoreTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import MacTools
+
+final class FinderMenuConfigStoreTests: XCTestCase {
+    /// Unique temp file in its own directory, so `save()`'s directory creation is
+    /// exercised and nothing touches the real Application Support config.
+    private func makeTempFileURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("finder-menu.json")
+    }
+
+    func testSaveThenLoadRoundTrips() throws {
+        let fileURL = makeTempFileURL()
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        var config = FinderMenuConfiguration.default
+        config.openInTerminal = false
+        config.copyFileName = false
+        config.openWithApps = [
+            OpenWithApp(name: "Code", appPath: "/Applications/Code.app", fileExtensions: ["txt", "md"])
+        ]
+
+        XCTAssertTrue(FinderMenuConfigStore.save(config, to: fileURL))
+        let loaded = FinderMenuConfigStore.load(from: fileURL)
+
+        XCTAssertEqual(loaded, config)
+        XCTAssertFalse(loaded.openInTerminal)
+        XCTAssertFalse(loaded.copyFileName)
+        XCTAssertEqual(loaded.openWithApps.first?.name, "Code")
+        XCTAssertEqual(loaded.openWithApps.first?.fileExtensions, ["txt", "md"])
+    }
+
+    func testLoadMissingFileReturnsDefault() {
+        XCTAssertEqual(FinderMenuConfigStore.load(from: makeTempFileURL()), .default)
+    }
+
+    func testLoadCorruptDataReturnsDefault() throws {
+        let fileURL = makeTempFileURL()
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try Data("not json".utf8).write(to: fileURL)
+
+        XCTAssertEqual(FinderMenuConfigStore.load(from: fileURL), .default)
+    }
+
+    func testSaveCreatesIntermediateDirectories() throws {
+        let fileURL = makeTempFileURL()  // parent directory does not exist yet
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        XCTAssertTrue(FinderMenuConfigStore.save(.default, to: fileURL))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -46,6 +46,8 @@ targets:
     - target: MacToolsPluginKit
       embed: true
     - package: Sparkle
+    - target: MacToolsFinderSync
+      embed: true
     settings:
       base:
         PRODUCT_NAME: MacTools
@@ -71,3 +73,31 @@ targets:
         Debug:
           PRODUCT_NAME: "MacTools Dev"
           PRODUCT_BUNDLE_IDENTIFIER: "$(BUNDLE_IDENTIFIER_PREFIX).mactools.dev"
+  MacToolsFinderSync:
+    type: app-extension
+    platform: macOS
+    deploymentTarget: '14.0'
+    configFiles:
+      Debug: Configs/Debug.xcconfig
+      Release: Configs/Release.xcconfig
+    sources:
+    - path: FinderSyncExtension/Sources
+    settings:
+      base:
+        PRODUCT_NAME: MacToolsFinderSync
+        PRODUCT_MODULE_NAME: MacToolsFinderSync
+        PRODUCT_BUNDLE_IDENTIFIER: "$(BUNDLE_IDENTIFIER_PREFIX).mactools.findersync"
+        GENERATE_INFOPLIST_FILE: false
+        INFOPLIST_FILE: FinderSyncExtension/Info.plist
+        CODE_SIGN_ENTITLEMENTS: FinderSyncExtension/MacToolsFinderSync.entitlements
+        SWIFT_VERSION: 6.0
+        SWIFT_STRICT_CONCURRENCY: minimal
+        DEVELOPMENT_LANGUAGE: zh-Hans
+        MACOSX_DEPLOYMENT_TARGET: '14.0'
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
+        MARKETING_VERSION: 1.0.20
+        CURRENT_PROJECT_VERSION: 50
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: "$(BUNDLE_IDENTIFIER_PREFIX).mactools.dev.findersync"

--- a/project.yml
+++ b/project.yml
@@ -42,6 +42,7 @@ targets:
       - MacToolsPluginKit/**
       - "../Plugins/**"
       - Plugins/**/CalendarPluginResources/**
+    - path: Shared/FinderSync
     dependencies:
     - target: MacToolsPluginKit
       embed: true
@@ -82,6 +83,7 @@ targets:
       Release: Configs/Release.xcconfig
     sources:
     - path: FinderSyncExtension/Sources
+    - path: Shared/FinderSync
     settings:
       base:
         PRODUCT_NAME: MacToolsFinderSync

--- a/scripts/plugins/generate-plugin-project-config.rb
+++ b/scripts/plugins/generate-plugin-project-config.rb
@@ -369,7 +369,10 @@ targets["MacToolsTests"] = {
     {
       "path" => relative_to_output_dir(File.join(repo_root, "Plugins"), output_dir),
       "includes" => ["*/Tests/**"]
-    }
+    },
+    # The Finder Sync extension is an app-extension, not an importable framework,
+    # so compile its pure logic straight into the test bundle to allow unit tests.
+    { "path" => relative_to_output_dir(File.join(repo_root, "FinderSyncExtension", "Sources", "FinderContextMenuLogic.swift"), output_dir) }
   ],
   "dependencies" => [
     { "target" => "MacTools" },


### PR DESCRIPTION
## What

Adds a Finder right-click (context menu) enhancement, built as a system **FinderSync extension** — separate from the in-process plugin model, so it's unaffected by the macOS 27 menu-bar rehosting.

Actions, each toggleable in **Settings → 访达菜单**:
- **复制路径** ▸ absolute / shell-escaped / file name / `file://` URL
- **新建文件** ▸ `.txt` / `.md` / `.json`
- **在终端打开**
- **用应用打开** ▸ a user-configured app list, with an optional per-app extension filter

## How

- **`FinderSyncExtension/`** — a `FIFinderSync` app-extension target, system-loaded into Finder. Copy actions run in-extension (the pasteboard needs no file access); file-creating / app-launching actions are forwarded to the non-sandboxed host app over a `mactools://` URL scheme, keeping the extension at minimal sandbox entitlements.
- **Sharing config across the sandbox boundary** — the non-sandboxed host can't write the app-group container, and `UserDefaults(suiteName:)` doesn't bridge the two cfprefsd domains (both measured to fail). Resolved by writing JSON to `~/Library/Application Support/MacTools/` and reading it from the extension through a read-only `temporary-exception.files.home-relative-path` entitlement; both sides resolve the real home via `getpwuid` (a sandboxed process's `NSHomeDirectory()` points at its container).
- **Dynamic app identity** — the "open with" action carries the chosen app in the menu item *title*: FinderSync preserves the displayed title but strips `representedObject` and doesn't reliably carry `tag`.
- **Security** — the host's `mactools://` handler allow-lists new-file extensions (blocks path traversal via the `ext` param) and validates open-with requests (app must be an existing `.app`, at least one file must exist).

## Tests

19 unit tests:
- `FinderMenuConfigStore` — save/load round-trip, missing-file & corrupt-data fallback, intermediate-dir creation
- `FinderContextMenuRequestHandler` — ext allow-list (incl. traversal), `nextAvailableURL` collision, `parseOpenWithRequest` validation
- `FinderContextMenuLogic` — shell escaping
- `OpenWithApp.matches` — extension filtering

Full flow manually verified on macOS 27: all menu items render, config sharing works end-to-end (host writes → sandboxed extension reads), and all four actions execute (including click-through of the open-with submenu launching the chosen app).

## Notes

New user-facing entitlement on the extension: a **read-only** `temporary-exception.files.home-relative-path` scoped to `/Library/Application Support/MacTools/`. MacTools ships via Developer ID + notarization (not the App Store), where this is acceptable; it is read-only (the earlier write path was already removed in favor of URL-scheme forwarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a configurable Finder right-click context menu via a dedicated `FinderSyncExtension` (`FIFinderSync`), kept separate from the in-process plugin model.

### Highlights
- New settings entry: **Settings → 访达菜单**
- **Copy path** submenu: absolute path, shell-escaped path, file name, and `file://` URL
- **New file** submenu: `.txt`, `.md`, `.json`
- **Open in Terminal**
- **Open With** submenu: user-configured app list with optional per-app extension filtering

### Architecture
- `FinderSyncExtension/` implements `FinderContextMenuProvider`:
  - Builds the menu and performs in-extension copy actions via `NSPasteboard` (write-only).
  - For file creation and app launching, forwards requests to the host using a `mactools://` URL so the extension remains minimally sandboxed.
  - Selects the “Open With” target app using the menu item title because FinderSync does not reliably preserve `representedObject`/`tag`.
- Host side (`FinderContextMenuRequestHandler`) handles `mactools://`:
  - Validates allowed new-file extensions (`txt`, `md`, `json`) and prevents traversal/out-of-directory writes when creating non-colliding filenames.
  - Validates “open with” requests: app must be a real `.app` bundle; referenced files must exist.
- Shared configuration:
  - JSON stored at `~/Library/Application Support/MacTools/finder-menu.json`, with sandbox-safe resolution using `getpwuid/getuid` in `FinderMenuConfigStore`.
  - FinderSync entitlements grant read-only, home-relative-path access to the config directory.

### Tests
- Added 19 XCTest cases covering:
  - config persistence/loading defaults
  - request parsing/validation (including traversal/collision defenses)
  - path shell escaping
  - open-with app matching semantics (including extension-filter edge cases)

### Security / Stability / Performance Notes (Actionable)
- **Security posture:** No evidence of backdoor-like behaviors; actions are constrained by allow-lists/validation, and clipboard usage is limited to write operations for copy actions.
- **Performance risk (important):** `FinderContextMenuProvider.menu(for:)` calls `FinderMenuConfigStore.load()` synchronously (`Data(contentsOf:)` + JSON decode) on Finder’s menu callback. Consider caching the config in-memory and reloading asynchronously (or only when stale) so menu rendering never blocks on disk I/O.
  - Suggested fix: load once (or keep a cached value) and update via a background refresh; `menu(for:)` should return the cached config immediately.
- **UI correctness bug:** `addOpenWithMenu` currently adds each matched app menu item **twice** (duplicate `submenu.addItem(...)` lines). Remove the duplicate insertion to avoid duplicated entries in “Open With”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->