### PR TITLE
feat(plugin): add Homebrew management plugin with custom path support

### DIFF
--- a/Plugins/Homebrew/Bundle/HomebrewPluginBundleEntrypoint.swift
+++ b/Plugins/Homebrew/Bundle/HomebrewPluginBundleEntrypoint.swift
@@ -1,0 +1,3 @@
+import HomebrewPlugin
+
+private let homebrewPluginFactoryAnchor: Any.Type = HomebrewPluginFactory.self

--- a/Plugins/Homebrew/Resources/Localizable.xcstrings
+++ b/Plugins/Homebrew/Resources/Localizable.xcstrings
@@ -1,0 +1,3822 @@
+{
+  "sourceLanguage": "en",
+  "version": "1.0",
+  "strings": {
+    "metadata.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 管理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 管理"
+          }
+        }
+      }
+    },
+    "metadata.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة حزم Homebrew والمستودعات وتشغيل تشخيصات النظام."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Homebrew packages, repositories, and perform system diagnostics."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administrar paquetes de Homebrew, repositorios y realizar diagnósticos del sistema."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérer les paquets Homebrew, les dépôts et effectuer des diagnostics système."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew パッケージ、リポジトリの管理、およびシステム診断の実行。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerenciar pacotes do Homebrew, repositórios e executar diagnósticos do sistema."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理 Homebrew 包、软件仓库并执行系统诊断"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理 Homebrew 包、軟體倉庫並執行系統診斷"
+          }
+        }
+      }
+    },
+    "panel.subtitle.notInstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew غير مثبت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew not installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew no instalado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew non installé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew がインストールされていません"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew não instalado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 未安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 未安裝"
+          }
+        }
+      }
+    },
+    "panel.subtitle.scanning": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاري الفحص..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scanning..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escaneando..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse en cours..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキャン中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escaneando..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在扫描..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在掃描..."
+          }
+        }
+      }
+    },
+    "panel.subtitle.upgradable": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d تحديثات متاحة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d updates available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d actualizaciones disponibles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d mises à jour disponibles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 個のアップデートが利用可能"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d atualizações disponíveis"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 个包可升级"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 個包可升級"
+          }
+        }
+      }
+    },
+    "panel.subtitle.upToDate": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محدث بالكامل"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Up to date"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて最新"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一切最新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一切最新"
+          }
+        }
+      }
+    },
+    "panel.action.scan": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحقق من وجود تحديثات"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des mises à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar atualizações"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查更新"
+          }
+        }
+      }
+    },
+    "panel.action.scanning": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاري الفحص..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scanning..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escaneando..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキャン中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escaneando..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在扫描..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在掃描..."
+          }
+        }
+      }
+    },
+    "panel.action.upgradeAll": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية الكل"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout mettre à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一括アップデート"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar tudo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一键升级"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一鍵升級"
+          }
+        }
+      }
+    },
+    "panel.action.cleanup": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظيف الذاكرة المؤقتة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleanup Cache"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar caché"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyer le cache"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャッシュのクリーンアップ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar cache"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理缓存"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理快取"
+          }
+        }
+      }
+    },
+    "panel.action.stop": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "detail.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مدير Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew Manager"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestor de Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestionnaire Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew マネージャー"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerenciador do Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 管理器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 管理器"
+          }
+        }
+      }
+    },
+    "detail.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة أدوات سطر أوامر Homebrew وتطبيقات سطح المكتب ومستودعات المصادر بصريًا."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Homebrew packages, applications, and repositories visually."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administre visualmente herramientas de línea de comandos, aplicaciones y repositorios de Homebrew."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérez visuellement les outils en ligne de commande, les applications et les dépôts Homebrew."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew コマンドラインツール、デスクトップアプリ、およびリポジトリソースをビジュアルに管理します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerencie visualmente ferramentas de linha de comando, aplicativos e repositórios do Homebrew."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可视化管理电脑上的 Homebrew 命令行工具、桌面应用以及仓库源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "視覺化管理電腦上的 Homebrew 命令列工具、桌面應用程式以及倉庫源"
+          }
+        }
+      }
+    },
+    "detail.status.scanning": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاري فحص الحزم والتحديثات..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scanning packages and updates..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando paquetes y actualizaciones..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse des paquets et des mises à jour..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージとアップデートをスキャン中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando pacotes e atualizações..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在扫描包与更新..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在掃描包與更新..."
+          }
+        }
+      }
+    },
+    "detail.tabs.installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المثبتة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済み"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安裝"
+          }
+        }
+      }
+    },
+    "detail.tabs.search": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بحث وتثبيت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索とインストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋安裝"
+          }
+        }
+      }
+    },
+    "detail.tabs.taps": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المستودعات"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップ源"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "三方源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "三方源"
+          }
+        }
+      }
+    },
+    "detail.tabs.diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الصيانة والتشخيص"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnósticos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メンテナンスと診断"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnósticos"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "维护与诊断"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "維護與診斷"
+          }
+        }
+      }
+    },
+    "detail.filter.all": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الكل"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tudo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
+          }
+        }
+      }
+    },
+    "detail.filter.formula": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        }
+      }
+    },
+    "detail.filter.cask": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        }
+      }
+    },
+    "detail.search.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث في الحزم المثبتة..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search installed packages..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar paquetes instalados..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des paquets installés..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済みパッケージを検索..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar pacotes instalados..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索已安装的包..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋已安裝的包..."
+          }
+        }
+      }
+    },
+    "detail.search.onlinePlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث عن صيغ أو تطبيقات عبر الإنترنت..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search online formulae or casks..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar fórmulas o casks en línea..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des formules ou casks en ligne..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンラインパッケージまたはアプリを検索..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar fórmulas ou casks online..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索在线公式或应用..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋線上公式或應用程式..."
+          }
+        }
+      }
+    },
+    "detail.search.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بحث"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋"
+          }
+        }
+      }
+    },
+    "detail.search.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدخل الكلمات المفتاحية للبحث عبر سطر الأوامر."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter keywords to search on Homebrew"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingrese palabras clave para buscar en Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrez des mots-clés pour rechercher sur Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーワードを入力してHomebrewを検索します"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insira palavras-chave para buscar no Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入关键字并在命令行进行搜索"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入關鍵字並在命令列進行搜尋"
+          }
+        }
+      }
+    },
+    "detail.search.noMatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد حزم مثبتة مطابقة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching installed packages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron paquetes instalados coincidentes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun paquet installé correspondant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するインストール済みパッケージはありません"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum pacote instalado correspondente"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无匹配的已安装包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無匹配的已安裝包"
+          }
+        }
+      }
+    },
+    "detail.search.searching": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاري البحث في Homebrew..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Searching Homebrew..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando en Homebrew..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche sur Homebrew..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrewを検索中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando no Homebrew..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在搜索 Homebrew..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在搜尋 Homebrew..."
+          }
+        }
+      }
+    },
+    "detail.search.fetchingDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاري جلب البيانات الوصفية التفصيلية..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetching detailed metadata..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obteniendo metadatos detallados..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Récupération des métadonnées détaillées..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細メタデータを取得中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtendo metadados detalhados..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在获取详细元数据..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在獲取詳細元數據..."
+          }
+        }
+      }
+    },
+    "detail.search.installedHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذه الحزمة مثبتة بالفعل على النظام."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This package is already installed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este paquete ya está instalado en el sistema."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce paquet est déjà installé sur le système."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このパッケージはすでにシステムにインストールされています。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este pacote já está instalado no sistema."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此包已在系统中安装。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此包已在系統中安裝。"
+          }
+        }
+      }
+    },
+    "detail.search.installAction": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击安装 (Install)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點擊安裝 (Install)"
+          }
+        }
+      }
+    },
+    "detail.search.installAgainAction": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت مجددًا"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install Again"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar de nuevo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinstaller"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再インストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar novamente"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再次安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再次安裝"
+          }
+        }
+      }
+    },
+    "detail.search.hasUpdate": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث متاح"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización disponible"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートあり"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualização disponível"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有更新"
+          }
+        }
+      }
+    },
+    "detail.detail.selectionHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختر حزمة مثبتة من اليسار لعرض التفاصيل."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select an installed package to view details."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccione un paquete instalado de la izquierda para ver los detalles."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez un paquet installé à gauche pour afficher les détails."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細を表示するには、左側からインストール済みパッケージを選択してください。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecione um pacote instalado à esquerda para ver os detalhes."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择左侧已安装的包以查看详情"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇左側已安裝的包以查看詳情"
+          }
+        }
+      }
+    },
+    "detail.detail.onlineHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حدد نتيجة بحث لتثبيت الحزمة."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select search result to install package."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccione el resultado de búsqueda para instalar el paquete."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez un résultat de recherche pour installer le paquet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージをインストールするには、検索結果を選択してください。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecione o resultado da busca para instalar o pacote."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择搜索结果并安装包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇搜尋結果並安裝包"
+          }
+        }
+      }
+    },
+    "detail.detail.type": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نوع البرنامج"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイプ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "软件类型"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "軟體類型"
+          }
+        }
+      }
+    },
+    "detail.detail.typeFormula": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula (سطر الأوامر)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command-line Formula"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fórmula de línea de comandos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formule en ligne de commande"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドラインパッケージ (Formula)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fórmula de linha de comando"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令行包 (Formula)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令列包 (Formula)"
+          }
+        }
+      }
+    },
+    "detail.detail.typeCask": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask (تطبيق سطح مكتب)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop Application (Cask)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicación de escritorio (Cask)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application de bureau (Cask)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デスクトップアプリ (Cask)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicativo de desktop (Cask)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面应用 (Cask)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面應用程式 (Cask)"
+          }
+        }
+      }
+    },
+    "detail.detail.installedVer": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإصدار المثبت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión instalada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version installée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済みバージョン"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão instalada"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已装版本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已裝版本"
+          }
+        }
+      }
+    },
+    "detail.detail.latestVer": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحدث إصدار"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latest Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新バージョン"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última versão"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新版本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新版本"
+          }
+        }
+      }
+    },
+    "detail.detail.latestAvailableVer": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحدث إصدار متاح"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latest Available Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última versión disponible"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière version disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能な最新バージョン"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última versão disponível"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新可用版本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新可用版本"
+          }
+        }
+      }
+    },
+    "detail.detail.website": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الموقع الرسمي"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitio web"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site web"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウェブサイト"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "官方网站"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "官方網站"
+          }
+        }
+      }
+    },
+    "detail.detail.pinned": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مثبت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinned"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fijado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épinglé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピン留め済み"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已锁定"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已鎖定"
+          }
+        }
+      }
+    },
+    "detail.detail.dependencies": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يعتمد على الحزم (%d)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dependencies (%d)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depende de los paquetes (%d)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dépend des paquets (%d)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依存パッケージ (%d)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depende dos pacotes (%d)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依赖以下包 (%d)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依賴以下包 (%d)"
+          }
+        }
+      }
+    },
+    "detail.detail.usedBy": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مستخدم بواسطة الحزم (%d)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used by (%d)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usado por los paquetes (%d)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisé par les paquets (%d)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "被依存パッケージ (%d)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usado pelos pacotes (%d)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "被以下包使用 (%d)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "被以下包使用 (%d)"
+          }
+        }
+      }
+    },
+    "detail.detail.actionUpgrade": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップグレード"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "升级"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "升級"
+          }
+        }
+      }
+    },
+    "detail.detail.actionPin": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت الإصدار"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fijar versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épingler la version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョンを固定"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixar versão"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "锁定版本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鎖定版本"
+          }
+        }
+      }
+    },
+    "detail.detail.actionUnpin": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء التثبيت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unpin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfijar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déséplingler"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定を解除"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfixar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解锁"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解鎖"
+          }
+        }
+      }
+    },
+    "detail.detail.actionUninstall": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء التثبيت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désinstaller"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アンインストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸载"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸載"
+          }
+        }
+      }
+    },
+    "detail.taps.titleAdd": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة مستودع (Tap)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Tap Repository"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir repositorio (Tap)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter un dépôt (Tap)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップリポジトリを追加 (Tap)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar repositório (Tap)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加三方源 (Tap)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增三方源 (Tap)"
+          }
+        }
+      }
+    },
+    "detail.taps.placeholderAdd": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدخل مسار المستودع (مثال: user/repo أو رابط المستودع)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter tap path (e.g., user/repo or repository URL)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingrese la ruta del tap (ej. user/repo o URL del repositorio)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saisissez le chemin du tap (ex. user/repo ou URL du dépôt)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リポジトリのパスを入力します (例: user/repo または URL)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insira o caminho do tap (ex: user/repo ou URL do repositório)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入源路径 (例如: user/repo 或仓库 URL)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入源路徑 (例如: user/repo 或倉庫 URL)"
+          }
+        }
+      }
+    },
+    "detail.taps.buttonAdd": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增"
+          }
+        }
+      }
+    },
+    "detail.taps.titleList": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المستودعات النشطة (%d)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active Taps (%d)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps activos (%d)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps actifs (%d)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なタップ源 (%d)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps ativos (%d)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已启用的软件源 (%d)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已啟用的軟體源 (%d)"
+          }
+        }
+      }
+    },
+    "detail.taps.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد مستودعات نشطة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active tap repositories"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay repositorios tap activos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun dépôt tap actif"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なタップリポジトリはありません"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum repositório tap ativo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无已启用三方源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無已啟用三方源"
+          }
+        }
+      }
+    },
+    "detail.taps.buttonUntap": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء الاشتراك"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untap"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desregistrar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désinscrire"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登録解除"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desregistrar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注销"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "註銷"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.update.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث مستودعات Homebrew (brew update)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Repositories (brew update)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar repositorios (brew update)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour les dépôts (brew update)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リポジトリリストを更新 (brew update)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar repositórios (brew update)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新软件仓库列表 (brew update)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新軟體倉庫列表 (brew update)"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.update.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مزامنة أحدث قوائم الصيغ والتطبيقات من الخوادم البعيدة."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync the latest list of formulas and casks from remote servers."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronice la última lista de fórmulas y casks desde los servidores remotos."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchroniser la dernière liste des formules et casks depuis les serveurs distants."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートサーバーから最新の Homebrew フォーミュラとアプリリストを同期します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronize a lista mais recente de fórmulas e casks dos servidores remotos."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从远程服务器同步最新的 Homebrew 公式与应用清单。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從遠端伺服器同步最新的 Homebrew 公式與應用程式清單。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.upgrade.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية جميع الحزم منتهية الصلاحية (brew upgrade)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade All Outdated Packages (brew upgrade)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar todos los paquetes obsoletos (brew upgrade)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour tous les paquets obsolètes (brew upgrade)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての古いパッケージをアップグレード (brew upgrade)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar todos os pacotes desatualizados (brew upgrade)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "升级所有过期软件包 (brew upgrade)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "升級所有過期套件 (brew upgrade)"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.upgrade.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية جميع الصيغ والتطبيقات القابلة للتحديث المكتشفة في النظام بضغطة واحدة."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade all outdated formulas and casks currently detected on your system."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualice todas las fórmulas y casks obsoletas actualmente detectadas en su sistema."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour toutes les formules et casks obsolètes actuellement détectés sur votre système."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムで検出されたすべての古いフォーミュラとアプリを一括でアップグレードします。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualize todas as fórmulas e casks desatualizadas atualmente detectadas em seu sistema."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一键升级当前系统已检测到的所有可更新 Formula 与 Cask。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一鍵升級當前系統已檢測到的所有可更新 Formula 與 Cask。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.doctor.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشخيص صحة البيئة (brew doctor)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Health Diagnostics (brew doctor)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico de salud del entorno (brew doctor)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostic de santé de l'environnement (brew doctor)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境の健全性診断 (brew doctor)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico de saúde do ambiente (brew doctor)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境健康诊断 (brew doctor)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境健康診斷 (brew doctor)"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.doctor.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشخيص المشاكل المحتملة في متغيرات البيئة والأذونات ومسارات البناء."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnose potential issues with environment variables, permissions, and build paths."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostique problemas potenciales con variables de entorno, permisos y rutas de compilación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostiquer les problèmes potentiels liés aux variables d'environnement, aux autorisations et aux chemins de build."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数、権限設定、およびビルドパスの潜在的な問題を診断します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostique problemas potenciais com variáveis de ambiente, permissões e caminhos de compilação."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "诊断系统环境变量、权限设置和编译环境的潜在问题。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診斷系統環境變數、權限設定和編譯環境的潛在問題。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.cleanup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظيف المخلفات والذاكرة المؤقتة الزائدة (brew cleanup)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleanup Trash & Caches (brew cleanup)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar basura y cachés redundantes (brew cleanup)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyer les fichiers inutiles et caches (brew cleanup)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不要なファイルとキャッシュをクリア (brew cleanup)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar arquivos desnecessários e caches (brew cleanup)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理垃圾与冗余缓存 (brew cleanup)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理垃圾與冗餘快取 (brew cleanup)"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.cleanup.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة التنزيلات والملفات المؤقتة القديمة لتحرير مساحة القرص."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove outdated local downloads and caches to reclaim disk space."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimine las descargas y cachés locales obsoletas para recuperar espacio en disco."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer les téléchargements locaux et caches obsolètes pour libérer de l'espace disque."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いローカルダウンロードとキャッシュを削除して、ディスク容量を解放します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remova downloads locais e caches desatualizados para recuperar espaço em disco."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除过期的旧版本安装文件和下载包缓存，释放磁盘空间。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除過期的舊版本安裝檔案和下載包快取，釋放磁碟空間。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.buttonExecute": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "执行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行"
+          }
+        }
+      }
+    },
+    "detail.console.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجل وحدة تحكم الأوامر"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command Console Log"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro de la consola de comandos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journal de la console de commande"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドコンソールログ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log do console de comandos"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令行控制台日志"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令列主控台記錄"
+          }
+        }
+      }
+    },
+    "detail.console.buttonClear": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسح"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリア"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清空"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清空"
+          }
+        }
+      }
+    },
+    "detail.console.buttonCancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء العملية"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel Operation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar operación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler l'opération"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作をキャンセル"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar operação"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消操作"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消操作"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تكوين مسار Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew Path Configuration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración de la ruta de Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration du chemin Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew パス設定"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração do caminho do Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 路径设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 路徑設定"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المسار إلى ملف brew القابل للتنفيذ (مثال: /opt/homebrew/bin/brew)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path to brew executable (e.g. /opt/homebrew/bin/brew)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta al ejecutable brew (ej. /opt/homebrew/bin/brew)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin vers l'exécutable brew (ex. /opt/homebrew/bin/brew)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew 実行可能ファイルのパス (例: /opt/homebrew/bin/brew)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho para o executável brew (ex: /opt/homebrew/bin/brew)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入 brew 可执行文件路径 (例如: /opt/homebrew/bin/brew)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入 brew 可執行檔案路徑 (例如: /opt/homebrew/bin/brew)"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathApply": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تطبيق"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appliquer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "套用"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathNotFoundTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم اكتشاف Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew Not Detected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew no detectado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew non détecté"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew が検出されませんでした"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew não detectado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未检测到 Homebrew"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未檢測到 Homebrew"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathNotFoundDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على Homebrew في أدلة النظام القياسية. يرجى التأكد من تثبيته أو توفير المسار المخصص إلى ملف brew القابل للتنفيذ أدناه:"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew was not found in standard system directories. Please ensure it is installed or provide the custom path to the 'brew' executable below:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró Homebrew en los directorios estándar del sistema. Asegúrese de que esté instalado o proporcione la ruta personalizada al ejecutable 'brew' a continuación:"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew n'a pas été trouvé dans les répertoires système standard. Veuillez vous assurer qu'il est installé ou fournir le chemin personnalisé vers l'exécutable 'brew' ci-dessous :"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準のシステムディレクトリに Homebrew が見つかりませんでした。インストールされていることを確認するか、以下の 'brew' 実行可能ファイルへのカスタムパスを指定してください:"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Homebrew não foi encontrado nos diretórios padrão do sistema. Certifique-se de que ele está instalado ou forneça o caminho personalizado para o executável 'brew' abaixo:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在标准系统目录下未检测到 Homebrew 安装。请确保其已正确安装，或在下方指定 'brew' 可执行文件的自定义路径："
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在標準系統目錄下未檢測到 Homebrew 安裝。請確保其已正確安裝，或在下方指定 'brew' 可執行檔案的自定義路徑："
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathHelpTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مواقع التثبيت الشائعة:"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common Installation Locations:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicaciones de instalación comunes:"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacements d'installation courants :"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般的なインストール場所:"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locais de instalação comuns:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常见安装位置："
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常見安裝位置："
+          }
+        }
+      }
+    }
+  }
+}

--- a/Plugins/Homebrew/Resources/Localizable.xcstrings
+++ b/Plugins/Homebrew/Resources/Localizable.xcstrings
@@ -2,6 +2,5677 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "detail.confirm.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "detail.confirm.cleanup.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظيف"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clean"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリーンアップ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理"
+          }
+        }
+      }
+    },
+    "detail.confirm.cleanup.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يشغّل brew cleanup لإزالة إصدارات Homebrew القديمة وذاكرات التنزيل المؤقتة."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs brew cleanup to remove old Homebrew versions and download caches."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta brew cleanup para eliminar versiones antiguas y cachés de descarga de Homebrew."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécute brew cleanup pour supprimer les anciennes versions Homebrew et les caches de téléchargement."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew cleanup を実行して古い Homebrew バージョンとダウンロードキャッシュを削除します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executa brew cleanup para remover versões antigas e caches de download do Homebrew."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将执行 brew cleanup，删除 Homebrew 旧版本和下载缓存。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將執行 brew cleanup，刪除 Homebrew 舊版本與下載快取。"
+          }
+        }
+      }
+    },
+    "detail.confirm.cleanup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظيف ذاكرة Homebrew المؤقتة؟"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clean Homebrew cache?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Limpiar caché de Homebrew?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyer le cache Homebrew ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew キャッシュを削除しますか？"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar cache do Homebrew?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认清理 Homebrew 缓存？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認清理 Homebrew 快取？"
+          }
+        }
+      }
+    },
+    "detail.confirm.defaultTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تأكيد الإجراء"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm Action"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar acción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmer l’action"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作を確認"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar ação"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认操作"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認操作"
+          }
+        }
+      }
+    },
+    "detail.confirm.tap.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入"
+          }
+        }
+      }
+    },
+    "detail.confirm.tap.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يشغّل brew tap %@ ليجلب Homebrew بيانات formula و cask من هذا المصدر."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs brew tap %@ so Homebrew can fetch formula and cask data from this source."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta brew tap %@ para que Homebrew obtenga datos de formula y cask desde esta fuente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécute brew tap %@ afin que Homebrew récupère les données formula et cask depuis cette source."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew tap %@ を実行し、このソースから formula と cask 情報を取得できるようにします。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executa brew tap %@ para que o Homebrew obtenha dados de formula e cask dessa fonte."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将执行 brew tap %@，Homebrew 会从该软件源获取配方和 cask 信息。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將執行 brew tap %@，Homebrew 會從該軟體源取得 formula 與 cask 資訊。"
+          }
+        }
+      }
+    },
+    "detail.confirm.tap.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة مصدر؟"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add tap?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Agregar tap?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter le tap ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap を追加しますか？"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar tap?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认添加软件源？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認加入軟體源？"
+          }
+        }
+      }
+    },
+    "detail.confirm.uninstall.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désinstaller"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アンインストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸载"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解除安裝"
+          }
+        }
+      }
+    },
+    "detail.confirm.uninstall.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يشغّل brew uninstall %@. قد تتأثر الميزات التي تعتمد عليه."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs brew uninstall %@. Features that depend on it may be affected."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta brew uninstall %@. Las funciones que dependen de este paquete pueden verse afectadas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécute brew uninstall %@. Les fonctionnalités qui en dépendent peuvent être affectées."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew uninstall %@ を実行します。他のパッケージが依存している場合、関連機能に影響することがあります。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executa brew uninstall %@. Recursos que dependem dele podem ser afetados."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将执行 brew uninstall %@。如果其他包依赖它，相关功能可能受到影响。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將執行 brew uninstall %@。若其他套件相依於它，相關功能可能受影響。"
+          }
+        }
+      }
+    },
+    "detail.confirm.uninstall.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة %@؟"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall %@?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Desinstalar %@?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désinstaller %@ ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ をアンインストールしますか？"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar %@?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认卸载 %@？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認解除安裝 %@？"
+          }
+        }
+      }
+    },
+    "detail.confirm.untap.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retirer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        }
+      }
+    },
+    "detail.confirm.untap.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يشغّل brew untap %@. قد تتوقف الحزم من هذا المصدر عن تلقي التحديثات."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs brew untap %@. Packages from this source may stop receiving updates."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta brew untap %@. Los paquetes de esta fuente podrían dejar de actualizarse."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécute brew untap %@. Les paquets de cette source peuvent ne plus recevoir de mises à jour."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew untap %@ を実行します。このソースに依存するパッケージは更新できなくなる場合があります。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executa brew untap %@. Pacotes dessa fonte podem deixar de receber atualizações."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将执行 brew untap %@。依赖该软件源的包可能无法继续更新。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將執行 brew untap %@。依賴該軟體源的套件可能無法繼續更新。"
+          }
+        }
+      }
+    },
+    "detail.confirm.untap.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة %@؟"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove %@?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Eliminar %@?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retirer %@ ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を削除しますか？"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover %@?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认移除 %@？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認移除 %@？"
+          }
+        }
+      }
+    },
+    "detail.confirm.upgradeAll.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية الكل"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout mettre à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて更新"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar tudo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新全部"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部更新"
+          }
+        }
+      }
+    },
+    "detail.confirm.upgradeAll.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يشغّل brew upgrade لتحديث كل حزم Homebrew القابلة للترقية. قد تتغير البرامج المثبتة."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs brew upgrade to update all upgradeable Homebrew packages. Installed software may change."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta brew upgrade para actualizar todos los paquetes Homebrew actualizables. El software instalado puede cambiar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécute brew upgrade pour mettre à jour tous les paquets Homebrew disponibles. Les logiciels installés peuvent changer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew upgrade を実行して更新可能な Homebrew パッケージをすべて更新します。インストール済みソフトウェアが変更される場合があります。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executa brew upgrade para atualizar todos os pacotes Homebrew atualizáveis. O software instalado pode mudar."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将执行 brew upgrade，更新所有可升级的 Homebrew 包。此操作可能修改已安装软件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將執行 brew upgrade，更新所有可升級的 Homebrew 套件。此操作可能修改已安裝軟體。"
+          }
+        }
+      }
+    },
+    "detail.confirm.upgradeAll.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية كل الحزم؟"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade all packages?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Actualizar todos los paquetes?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour tous les paquets ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのパッケージを更新しますか？"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar todos os pacotes?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认更新所有包？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認更新所有套件？"
+          }
+        }
+      }
+    },
+    "detail.console.buttonCancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء العملية"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel Operation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar operación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler l’opération"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作をキャンセル"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar operação"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消操作"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消操作"
+          }
+        }
+      }
+    },
+    "detail.console.buttonClear": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسح"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消去"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清空"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
+          }
+        }
+      }
+    },
+    "detail.console.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سجلات وحدة التحكم"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Console Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros de consola"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journaux de console"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンソールログ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logs do console"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制台日志"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主控台記錄"
+          }
+        }
+      }
+    },
+    "detail.detail.actionPin": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت الإصدار"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fijar versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épingler la version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョンを固定"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixar versão"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "锁定版本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鎖定版本"
+          }
+        }
+      }
+    },
+    "detail.detail.actionUninstall": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désinstaller"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アンインストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸载"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解除安裝"
+          }
+        }
+      }
+    },
+    "detail.detail.actionUnpin": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء التثبيت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unpin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dejar de fijar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désépingler"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定解除"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfixar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解除锁定"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解除鎖定"
+          }
+        }
+      }
+    },
+    "detail.detail.actionUpgrade": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップグレード"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "detail.detail.dependencies": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التبعيات (%d)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dependencies (%d)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dependencias (%d)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dépendances (%d)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依存関係（%d）"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dependências (%d)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依赖（%d）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相依套件（%d）"
+          }
+        }
+      }
+    },
+    "detail.detail.installedVer": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المثبت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済み"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装版本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安裝版本"
+          }
+        }
+      }
+    },
+    "detail.detail.latestAvailableVer": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأحدث المتاح"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latest Available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última disponible"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能な最新"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mais recente disponível"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用最新版本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用最新版本"
+          }
+        }
+      }
+    },
+    "detail.detail.latestVer": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأحدث"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latest"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mais recente"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新版本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新版本"
+          }
+        }
+      }
+    },
+    "detail.detail.onlineHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حدد نتيجة بحث للتثبيت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a search result to install"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona un resultado para instalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez un résultat à installer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索結果を選択してインストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecione um resultado para instalar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择搜索结果后安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇搜尋結果後安裝"
+          }
+        }
+      }
+    },
+    "detail.detail.pinned": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مثبت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinned"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fijado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épinglé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定済み"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已锁定"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已鎖定"
+          }
+        }
+      }
+    },
+    "detail.detail.selectionHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حدد حزمة لعرض التفاصيل"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a package to view details"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona un paquete para ver detalles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez un paquet pour voir les détails"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージを選択して詳細を表示"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecione um pacote para ver detalhes"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个包查看详情"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇套件以查看詳情"
+          }
+        }
+      }
+    },
+    "detail.detail.type": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النوع"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "種類"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "类型"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "類型"
+          }
+        }
+      }
+    },
+    "detail.detail.typeCask": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تطبيق رسومي (Cask)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GUI App (Cask)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App gráfica (Cask)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App graphique (Cask)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GUI アプリ（Cask）"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App gráfica (Cask)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图形应用（Cask）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖形 App（Cask）"
+          }
+        }
+      }
+    },
+    "detail.detail.typeFormula": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حزمة سطر أوامر (Formula)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI Package (Formula)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paquete CLI (Formula)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paquet CLI (Formula)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI パッケージ（Formula）"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pacote CLI (Formula)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令行包（Formula）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令列套件（Formula）"
+          }
+        }
+      }
+    },
+    "detail.detail.usedBy": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مطلوب بواسطة (%d)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Required By (%d)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requerido por (%d)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requis par (%d)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必要とするパッケージ（%d）"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigido por (%d)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "被依赖（%d）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "被相依（%d）"
+          }
+        }
+      }
+    },
+    "detail.detail.website": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الصفحة الرئيسية"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homepage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página web"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Page d’accueil"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホームページ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página inicial"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主页"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "首頁"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.buttonExecute": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "执行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.cleanup.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة التنزيلات القديمة والذاكرات المؤقتة."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove old downloads and caches."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina descargas antiguas y cachés."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprime les anciens téléchargements et caches."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いダウンロードとキャッシュを削除します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove downloads antigos e caches."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除旧版本下载和缓存。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除舊版本下載與快取。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.cleanup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظيف الذاكرة المؤقتة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clean Cache"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar caché"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyer le cache"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャッシュをクリーンアップ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar cache"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理缓存"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理快取"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.doctor.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فحص متغيرات البيئة والأذونات ومسارات البناء."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check environment variables, permissions, and build paths."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprueba variables de entorno, permisos y rutas de compilación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifie les variables d’environnement, les autorisations et les chemins de build."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数、権限、ビルドパスを確認します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica variáveis de ambiente, permissões e caminhos de build."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查环境变量、权限和构建路径。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查環境變數、權限與建置路徑。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.doctor.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل التشخيص"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Diagnostics"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar diagnóstico"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancer le diagnostic"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断を実行"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar diagnóstico"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行诊断"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行診斷"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.maintenance.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الصيانة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintenance"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenimiento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintenance"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メンテナンス"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manutenção"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "维护操作"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "維護操作"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathApply": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تطبيق"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appliquer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "套用"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathHelpTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مواقع التثبيت الشائعة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common install locations"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicaciones comunes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacements courants"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般的なインストール場所"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locais comuns de instalação"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常见安装位置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常見安裝位置"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathNotFoundDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ثبّت Homebrew أو اختر مسار ملف brew التنفيذي يدويًا."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install Homebrew or choose the brew executable path manually."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instala Homebrew o elige manualmente la ruta del ejecutable brew."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installez Homebrew ou choisissez manuellement le chemin de l’exécutable brew."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew をインストールするか、brew 実行ファイルのパスを手動で指定してください。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instale o Homebrew ou escolha manualmente o caminho do executável brew."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请确认已安装 Homebrew，或手动指定 brew 可执行文件路径。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請確認已安裝 Homebrew，或手動指定 brew 可執行檔路徑。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathNotFoundTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew Not Found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew introuvable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew が見つかりません"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew não encontrado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未检测到 Homebrew"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未偵測到 Homebrew"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مثال /opt/homebrew/bin/brew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For example /opt/homebrew/bin/brew"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por ejemplo /opt/homebrew/bin/brew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par exemple /opt/homebrew/bin/brew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例: /opt/homebrew/bin/brew"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por exemplo /opt/homebrew/bin/brew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如 /opt/homebrew/bin/brew"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如 /opt/homebrew/bin/brew"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.pathTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسار brew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew Path"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta de brew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin brew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew パス"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho do brew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew 路径"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew 路徑"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.update.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مزامنة قوائم formula و cask في Homebrew."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Homebrew formula and cask lists."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincroniza las listas de formula y cask de Homebrew."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronise les listes formula et cask de Homebrew."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew の formula と cask 一覧を同期します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincroniza as listas de formula e cask do Homebrew."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同步 Homebrew formula 和 cask 列表。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同步 Homebrew formula 與 cask 清單。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.update.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث المصادر"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Taps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar taps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour les taps"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap を更新"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar taps"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新软件源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新軟體源"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.upgrade.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية الحزم القديمة المكتشفة."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade currently detected outdated packages."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualiza los paquetes obsoletos detectados."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Met à jour les paquets obsolètes détectés."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検出された古いパッケージを更新します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualiza os pacotes desatualizados detectados."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新当前检测到的过期包。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新目前偵測到的過期套件。"
+          }
+        }
+      }
+    },
+    "detail.diagnostics.upgrade.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترقية الحزم"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade Packages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar paquetes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour les paquets"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージを更新"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar pacotes"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新所有包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新所有套件"
+          }
+        }
+      }
+    },
+    "detail.filter.all": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الكل"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tudo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
+          }
+        }
+      }
+    },
+    "detail.filter.cask": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cask"
+          }
+        }
+      }
+    },
+    "detail.filter.formula": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formula"
+          }
+        }
+      }
+    },
+    "detail.refresh.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualiser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新整理"
+          }
+        }
+      }
+    },
+    "detail.refresh.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث حالة Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh Homebrew status"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar estado de Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualiser l’état Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew の状態を更新"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar status do Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新 Homebrew 状态"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新整理 Homebrew 狀態"
+          }
+        }
+      }
+    },
+    "detail.search.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بحث"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋"
+          }
+        }
+      }
+    },
+    "detail.search.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدخل كلمة مفتاحية للبحث عن الحزم"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a keyword to search packages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introduce una palabra clave para buscar paquetes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saisissez un mot-clé pour rechercher des paquets"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーワードを入力してパッケージを検索"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digite uma palavra-chave para pesquisar pacotes"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入关键词搜索软件包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入關鍵字搜尋套件"
+          }
+        }
+      }
+    },
+    "detail.search.fetchingDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ تحميل تفاصيل الحزمة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading package details"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando detalles del paquete"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement des détails du paquet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージ詳細を読み込み中"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregando detalhes do pacote"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载包详情"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在載入套件詳情"
+          }
+        }
+      }
+    },
+    "detail.search.hasUpdate": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新可"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualização"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可更新"
+          }
+        }
+      }
+    },
+    "detail.search.installAction": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安裝"
+          }
+        }
+      }
+    },
+    "detail.search.installAgainAction": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت مجددًا"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install Again"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar de nuevo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinstaller"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再インストール"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar novamente"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新安裝"
+          }
+        }
+      }
+    },
+    "detail.search.installedHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذه الحزمة مثبتة بالفعل."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This package is already installed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este paquete ya está instalado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce paquet est déjà installé."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このパッケージはすでにインストールされています。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este pacote já está instalado."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此包已安装。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此套件已安裝。"
+          }
+        }
+      }
+    },
+    "detail.search.loadingInstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ تحميل حالة Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading Homebrew status"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando estado de Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement de l’état Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew の状態を読み込み中"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregando status do Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载 Homebrew 状态"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在載入 Homebrew 狀態"
+          }
+        }
+      }
+    },
+    "detail.search.noMatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد حزم مثبتة مطابقة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching installed packages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay paquetes instalados coincidentes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun paquet installé correspondant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するインストール済みパッケージはありません"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum pacote instalado correspondente"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配的已安装包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有符合的已安裝套件"
+          }
+        }
+      }
+    },
+    "detail.search.notLoaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم تحميل الحزم المثبتة بعد"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed packages not loaded yet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los paquetes instalados aún no se han cargado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les paquets installés ne sont pas encore chargés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済みパッケージは未読み込みです"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pacotes instalados ainda não carregados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未加载已安装包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未載入已安裝套件"
+          }
+        }
+      }
+    },
+    "detail.search.onlinePlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث عن حزم"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search packages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar paquetes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des paquets"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージを検索"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar pacotes"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索软件包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋套件"
+          }
+        }
+      }
+    },
+    "detail.search.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث في الحزم المثبتة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search installed packages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar paquetes instalados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher les paquets installés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済みパッケージを検索"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar pacotes instalados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索已安装包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋已安裝套件"
+          }
+        }
+      }
+    },
+    "detail.search.searching": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ البحث في Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Searching Homebrew"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando en Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche dans Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew を検索中"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisando no Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在搜索 Homebrew"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在搜尋 Homebrew"
+          }
+        }
+      }
+    },
+    "detail.status.brewPathMissing": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew غير مهيأ"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew not configured"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew sin configurar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew non configuré"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew 未設定"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew não configurado"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未配置 brew"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未設定 brew"
+          }
+        }
+      }
+    },
+    "detail.status.installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مثبت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済み"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安裝"
+          }
+        }
+      }
+    },
+    "detail.status.outdated": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بحاجة لتحديث"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outdated"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactualizados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À mettre à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新あり"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desatualizados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可更新"
+          }
+        }
+      }
+    },
+    "detail.status.scanning": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاري فحص الحزم والتحديثات..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scanning packages and updates..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando paquetes y actualizaciones..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse des paquets et des mises à jour..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージとアップデートをスキャン中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando pacotes e atualizações..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在扫描包与更新..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在掃描包與更新..."
+          }
+        }
+      }
+    },
+    "detail.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة الحزم والتطبيقات والمستودعات بصريًا."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage packages, apps, and repositories visually."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestiona paquetes, apps y repositorios visualmente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérez visuellement les paquets, apps et dépôts."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージ、アプリ、リポジトリを視覚的に管理します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerencie pacotes, apps e repositórios visualmente."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可视化管理包、应用与软件源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "視覺化管理套件、App 與軟體源"
+          }
+        }
+      }
+    },
+    "detail.tabs.diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التشخيص"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "诊断"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診斷"
+          }
+        }
+      }
+    },
+    "detail.tabs.installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مثبت"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済み"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安裝"
+          }
+        }
+      }
+    },
+    "detail.tabs.picker": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "العرض"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualização"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "视图"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢視"
+          }
+        }
+      }
+    },
+    "detail.tabs.search": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بحث"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋"
+          }
+        }
+      }
+    },
+    "detail.tabs.taps": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المصادر"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "软件源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "軟體源"
+          }
+        }
+      }
+    },
+    "detail.taps.buttonAdd": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入"
+          }
+        }
+      }
+    },
+    "detail.taps.buttonUntap": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retirer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        }
+      }
+    },
+    "detail.taps.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد مصادر"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No taps yet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay taps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun tap"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap はありません"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum tap"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无软件源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫無軟體源"
+          }
+        }
+      }
+    },
+    "detail.taps.placeholderAdd": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user/repo أو رابط المستودع"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user/repo or repository URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user/repo o URL del repositorio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user/repo ou URL du dépôt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user/repo またはリポジトリ URL"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user/repo ou URL do repositório"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user/repo 或仓库 URL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user/repo 或儲存庫 URL"
+          }
+        }
+      }
+    },
+    "detail.taps.titleAdd": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة مصدر"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Tap"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar tap"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter un tap"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap を追加"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar tap"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加软件源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入軟體源"
+          }
+        }
+      }
+    },
+    "detail.taps.titleList": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المصادر المفعلة (%d)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled Taps (%d)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps habilitados (%d)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps activés (%d)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効な Tap（%d）"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taps ativados (%d)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已启用软件源（%d）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已啟用軟體源（%d）"
+          }
+        }
+      }
+    },
+    "detail.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مدير Homebrew"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew Manager"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestor de Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestionnaire Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 管理"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerenciador do Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 管理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 管理"
+          }
+        }
+      }
+    },
+    "log.command.cancelled": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] ألغى المستخدم العملية"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operation cancelled by user"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operación cancelada por el usuario"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Opération annulée par l’utilisateur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] ユーザーが操作をキャンセルしました"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operação cancelada pelo usuário"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 操作已被用户取消"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 操作已由使用者取消"
+          }
+        }
+      }
+    },
+    "log.command.completed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] اكتملت العملية"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operation completed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operación completada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Opération terminée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 操作が完了しました"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operação concluída"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 操作成功完成"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 操作成功完成"
+          }
+        }
+      }
+    },
+    "log.command.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] فشل الأمر: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Command failed: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Error al ejecutar comando: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Échec de la commande : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] コマンドに失敗しました: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Falha ao executar comando: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 执行命令出错：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 執行命令出錯：%@"
+          }
+        }
+      }
+    },
+    "log.command.failedStatus": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] فشلت العملية، الرمز: %d"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operation failed, exit code: %d"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operación fallida, código: %d"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Opération échouée, code : %d"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 操作に失敗しました。終了コード: %d"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Operação falhou, código: %d"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 操作失败，错误码：%d"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 操作失敗，錯誤碼：%d"
+          }
+        }
+      }
+    },
+    "log.details.loaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] تم تحميل بيانات الحزمة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Package metadata loaded"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Metadatos del paquete cargados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Métadonnées du paquet chargées"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] パッケージメタデータを読み込みました"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Metadados do pacote carregados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 包详细元数据加载完成"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 套件詳細中繼資料載入完成"
+          }
+        }
+      }
+    },
+    "log.details.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] جارٍ تحميل بيانات الحزمة..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Loading package metadata..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Cargando metadatos del paquete..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Chargement des métadonnées du paquet..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] パッケージメタデータを読み込み中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Carregando metadados do pacote..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 正在加载包详细元数据..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 正在載入套件詳細中繼資料..."
+          }
+        }
+      }
+    },
+    "log.details.parseFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] فشل تحليل بيانات الحزمة: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Failed to parse package metadata: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Error al analizar metadatos: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Échec de l’analyse des métadonnées : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] パッケージメタデータの解析に失敗しました: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Falha ao analisar metadados: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 解析详细元数据失败：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 解析詳細中繼資料失敗：%@"
+          }
+        }
+      }
+    },
+    "log.installed.loaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] تم تحميل %d حزمة مثبتة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Loaded %d installed packages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d paquetes instalados cargados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d paquets installés chargés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d 個のインストール済みパッケージを読み込みました"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d pacotes instalados carregados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 已加载 %d 个已安装包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 已載入 %d 個已安裝套件"
+          }
+        }
+      }
+    },
+    "log.installed.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] جارٍ تحميل الحزم المثبتة..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Loading installed packages..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Cargando paquetes instalados..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Chargement des paquets installés..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] インストール済みパッケージを読み込み中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Carregando pacotes instalados..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 正在获取已安装包列表..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 正在取得已安裝套件清單..."
+          }
+        }
+      }
+    },
+    "log.outdated.loaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] تم العثور على %d حزمة قديمة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Found %d outdated packages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Se encontraron %d paquetes desactualizados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d paquets obsolètes trouvés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d 個の古いパッケージが見つかりました"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d pacotes desatualizados encontrados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 获取到 %d 个待更新包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 取得 %d 個待更新套件"
+          }
+        }
+      }
+    },
+    "log.outdated.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] جارٍ تحميل الحزم القديمة..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Loading outdated packages..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Cargando paquetes desactualizados..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Chargement des paquets obsolètes..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 古いパッケージを読み込み中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Carregando pacotes desatualizados..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 正在获取待更新包列表..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 正在取得待更新套件清單..."
+          }
+        }
+      }
+    },
+    "log.outdated.parseFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] فشل تحليل الحزم القديمة: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Failed to parse outdated packages: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Error al analizar paquetes desactualizados: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Échec de l’analyse des paquets obsolètes : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 古いパッケージの解析に失敗しました: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Falha ao analisar pacotes desatualizados: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 解析待更新包失败：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 解析待更新套件失敗：%@"
+          }
+        }
+      }
+    },
+    "log.path.invalid": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] مسار Homebrew غير صالح. اختر ملف brew قابلًا للتنفيذ."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Invalid Homebrew path. Choose an executable brew file."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Ruta de Homebrew no válida. Elige un archivo brew ejecutable."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Chemin Homebrew invalide. Choisissez un fichier brew exécutable."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Homebrew パスが無効です。実行可能な brew ファイルを選択してください。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Caminho do Homebrew inválido. Escolha um arquivo brew executável."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Homebrew 路径无效，请选择可执行的 brew 文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Homebrew 路徑無效，請選擇可執行的 brew 檔案。"
+          }
+        }
+      }
+    },
+    "log.path.updated": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] تم تحديث مسار Homebrew."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Homebrew path updated."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Ruta de Homebrew actualizada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Chemin Homebrew mis à jour."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Homebrew パスを更新しました。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Caminho do Homebrew atualizado."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 已更新 Homebrew 路径。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 已更新 Homebrew 路徑。"
+          }
+        }
+      }
+    },
+    "log.scan.completed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] اكتمل الفحص."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Scan completed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Escaneo completado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Analyse terminée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] スキャンが完了しました。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Verificação concluída."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 扫描完成。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 掃描完成。"
+          }
+        }
+      }
+    },
+    "log.scan.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] فشل الفحص: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Scan failed: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Error al escanear: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Échec de l’analyse : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] スキャンに失敗しました: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Falha na verificação: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 扫描发生错误：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 掃描發生錯誤：%@"
+          }
+        }
+      }
+    },
+    "log.scan.started": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] بدأ فحص حالة Homebrew..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Started scanning Homebrew status..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Se inició el escaneo del estado de Homebrew..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Analyse de l’état Homebrew démarrée..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Homebrew の状態スキャンを開始しました..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Verificação do status do Homebrew iniciada..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 开始扫描 Homebrew 状态..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 開始掃描 Homebrew 狀態..."
+          }
+        }
+      }
+    },
+    "log.taps.loaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] تم تحميل %d مصدر"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Loaded %d taps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d taps cargados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d taps chargés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d 個の tap を読み込みました"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] %d taps carregados"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 获取到 %d 个软件源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 取得 %d 個軟體源"
+          }
+        }
+      }
+    },
+    "log.taps.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] جارٍ تحميل المصادر المفعلة..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Loading enabled taps..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Cargando taps habilitados..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Chargement des taps activés..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 有効な tap を読み込み中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] Carregando taps ativados..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 正在获取已启用的软件源..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[System] 正在取得已啟用的軟體源..."
+          }
+        }
+      }
+    },
+    "metadata.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة حزم Homebrew والمستودعات والتشخيصات."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Homebrew packages, repositories, and diagnostics."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestiona paquetes, repositorios y diagnósticos de Homebrew."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérez les paquets, dépôts et diagnostics Homebrew."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew パッケージ、リポジトリ、診断を管理します。"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerencie pacotes, repositórios e diagnósticos do Homebrew."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理 Homebrew 包、软件源与诊断"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理 Homebrew 套件、軟體源與診斷"
+          }
+        }
+      }
+    },
     "metadata.title": {
       "extractionState": "manual",
       "localizations": {
@@ -32,7 +5703,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew"
+            "value": "Homebrew 管理"
           }
         },
         "pt": {
@@ -55,267 +5726,744 @@
         }
       }
     },
-    "metadata.description": {
+    "operation.cleanup": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "إدارة حزم Homebrew والمستودعات وتشغيل تشخيصات النظام."
+            "value": "جارٍ تنظيف ذاكرة Homebrew المؤقتة..."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Manage Homebrew packages, repositories, and perform system diagnostics."
+            "value": "Cleaning Homebrew cache..."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Administrar paquetes de Homebrew, repositorios y realizar diagnósticos del sistema."
+            "value": "Limpiando caché de Homebrew..."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gérer les paquets Homebrew, les dépôts et effectuer des diagnostics système."
+            "value": "Nettoyage du cache Homebrew..."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew パッケージ、リポジトリの管理、およびシステム診断の実行。"
+            "value": "Homebrew キャッシュをクリーンアップ中..."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerenciar pacotes do Homebrew, repositórios e executar diagnósticos do sistema."
+            "value": "Limpando cache do Homebrew..."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "管理 Homebrew 包、软件仓库并执行系统诊断"
+            "value": "正在清理 Homebrew 缓存..."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "管理 Homebrew 包、軟體倉庫並執行系統診斷"
+            "value": "正在清理 Homebrew 快取..."
           }
         }
       }
     },
-    "panel.subtitle.notInstalled": {
+    "operation.doctor": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew غير مثبت"
+            "value": "جارٍ تشغيل تشخيص Homebrew..."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew not installed"
+            "value": "Running Homebrew diagnostics..."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew no instalado"
+            "value": "Ejecutando diagnóstico de Homebrew..."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew non installé"
+            "value": "Exécution du diagnostic Homebrew..."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew がインストールされていません"
+            "value": "Homebrew 診断を実行中..."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew não instalado"
+            "value": "Executando diagnóstico do Homebrew..."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew 未安装"
+            "value": "正在运行 Homebrew 诊断..."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew 未安裝"
+            "value": "正在執行 Homebrew 診斷..."
           }
         }
       }
     },
-    "panel.subtitle.scanning": {
+    "operation.install": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "جاري الفحص..."
+            "value": "جارٍ تثبيت %@..."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scanning..."
+            "value": "Installing %@..."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Escaneando..."
+            "value": "Instalando %@..."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Analyse en cours..."
+            "value": "Installation de %@..."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "スキャン中..."
+            "value": "%@ をインストール中..."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Escaneando..."
+            "value": "Instalando %@..."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在扫描..."
+            "value": "正在安装 %@..."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在掃描..."
+            "value": "正在安裝 %@..."
           }
         }
       }
     },
-    "panel.subtitle.upgradable": {
+    "operation.pin": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "%d تحديثات متاحة"
+            "value": "جارٍ تثبيت إصدار %@..."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%d updates available"
+            "value": "Pinning %@..."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%d actualizaciones disponibles"
+            "value": "Fijando %@..."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%d mises à jour disponibles"
+            "value": "Épinglage de %@..."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%d 個のアップデートが利用可能"
+            "value": "%@ を固定中..."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "%d atualizações disponíveis"
+            "value": "Fixando %@..."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%d 个包可升级"
+            "value": "正在锁定 %@..."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "%d 個包可升級"
+            "value": "正在鎖定 %@..."
           }
         }
       }
     },
-    "panel.subtitle.upToDate": {
+    "operation.scanAll": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "محدث بالكامل"
+            "value": "جارٍ فحص الحزم والتحديثات..."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Up to date"
+            "value": "Scanning packages and updates..."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Actualizado"
+            "value": "Escaneando paquetes y actualizaciones..."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "À jour"
+            "value": "Analyse des paquets et mises à jour..."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "すべて最新"
+            "value": "パッケージと更新をスキャン中..."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atualizado"
+            "value": "Verificando pacotes e atualizações..."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "一切最新"
+            "value": "正在扫描包与更新..."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "一切最新"
+            "value": "正在掃描套件與更新..."
+          }
+        }
+      }
+    },
+    "operation.tap": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ إضافة المصدر %@..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adding tap %@..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregando tap %@..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajout du tap %@..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap %@ を追加中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionando tap %@..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在启用软件源 %@..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在啟用軟體源 %@..."
+          }
+        }
+      }
+    },
+    "operation.uninstall": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ إزالة %@..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstalling %@..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalando %@..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désinstallation de %@..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ をアンインストール中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalando %@..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在卸载 %@..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在解除安裝 %@..."
+          }
+        }
+      }
+    },
+    "operation.unpin": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ إلغاء تثبيت إصدار %@..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unpinning %@..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dejando de fijar %@..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désépinglage de %@..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の固定を解除中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfixando %@..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在解锁 %@..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在解除鎖定 %@..."
+          }
+        }
+      }
+    },
+    "operation.untap": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ إزالة المصدر %@..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removing tap %@..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminando tap %@..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retrait du tap %@..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap %@ を削除中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removendo tap %@..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在移除软件源 %@..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在移除軟體源 %@..."
+          }
+        }
+      }
+    },
+    "operation.updateBrew": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ تحديث مصادر Homebrew..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updating Homebrew sources..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando fuentes de Homebrew..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour des sources Homebrew..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew ソースを更新中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizando fontes do Homebrew..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新 Homebrew 源..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新 Homebrew 軟體源..."
+          }
+        }
+      }
+    },
+    "operation.upgrade": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ ترقية %@..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrading %@..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando %@..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour de %@..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ をアップグレード中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizando %@..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新 %@..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新 %@..."
+          }
+        }
+      }
+    },
+    "operation.upgradeAll": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ ترقية كل الحزم..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrading all packages..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando todos los paquetes..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour de tous les paquets..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのパッケージを更新中..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizando todos os pacotes..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新所有包..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新所有套件..."
+          }
+        }
+      }
+    },
+    "panel.action.cleanup": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظيف الذاكرة المؤقتة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleanup Cache"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar caché"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyer le cache"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャッシュのクリーンアップ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar cache"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理缓存"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理快取"
+          }
+        }
+      }
+    },
+    "panel.action.manage": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestionar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerenciar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理"
           }
         }
       }
@@ -426,112 +6574,6 @@
         }
       }
     },
-    "panel.action.upgradeAll": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترقية الكل"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrade All"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar todo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tout mettre à jour"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一括アップデート"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atualizar tudo"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一键升级"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一鍵升級"
-          }
-        }
-      }
-    },
-    "panel.action.cleanup": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تنظيف الذاكرة المؤقتة"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cleanup Cache"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpiar caché"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nettoyer le cache"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャッシュのクリーンアップ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpar cache"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清理缓存"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清理快取"
-          }
-        }
-      }
-    },
     "panel.action.stop": {
       "extractionState": "manual",
       "localizations": {
@@ -585,3235 +6627,373 @@
         }
       }
     },
-    "detail.title": {
+    "panel.action.upgradeAll": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "مدير Homebrew"
+            "value": "ترقية الكل"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew Manager"
+            "value": "Upgrade All"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestor de Homebrew"
+            "value": "Actualizar todo"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestionnaire Homebrew"
+            "value": "Tout mettre à jour"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew マネージャー"
+            "value": "一括アップデート"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerenciador do Homebrew"
+            "value": "Atualizar tudo"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew 管理器"
+            "value": "一键升级"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew 管理器"
+            "value": "一鍵升級"
           }
         }
       }
     },
-    "detail.subtitle": {
+    "panel.error.brewPathRequired": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "إدارة أدوات سطر أوامر Homebrew وتطبيقات سطح المكتب ومستودعات المصادر بصريًا."
+            "value": "يجب إعداد مسار brew"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Manage Homebrew packages, applications, and repositories visually."
+            "value": "Configure the brew path"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Administre visualmente herramientas de línea de comandos, aplicaciones y repositorios de Homebrew."
+            "value": "Configura la ruta de brew"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gérez visuellement les outils en ligne de commande, les applications et les dépôts Homebrew."
+            "value": "Configurez le chemin brew"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Homebrew コマンドラインツール、デスクトップアプリ、およびリポジトリソースをビジュアルに管理します。"
+            "value": "brew パスの設定が必要です"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerencie visualmente ferramentas de linha de comando, aplicativos e repositórios do Homebrew."
+            "value": "Configure o caminho do brew"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "可视化管理电脑上的 Homebrew 命令行工具、桌面应用以及仓库源"
+            "value": "需要配置 brew 路径"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "視覺化管理電腦上的 Homebrew 命令列工具、桌面應用程式以及倉庫源"
+            "value": "需要設定 brew 路徑"
           }
         }
       }
     },
-    "detail.status.scanning": {
+    "panel.subtitle.manage": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "جاري فحص الحزم والتحديثات..."
+            "value": "إدارة الحزم والمصادر والتشخيصات"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scanning packages and updates..."
+            "value": "Manage packages, taps, and diagnostics"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buscando paquetes y actualizaciones..."
+            "value": "Gestionar paquetes, taps y diagnósticos"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Analyse des paquets et des mises à jour..."
+            "value": "Gérer les paquets, taps et diagnostics"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "パッケージとアップデートをスキャン中..."
+            "value": "パッケージ、tap、診断を管理"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buscando pacotes e atualizações..."
+            "value": "Gerenciar pacotes, taps e diagnósticos"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在扫描包与更新..."
+            "value": "管理包、软件源与诊断"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在掃描包與更新..."
+            "value": "管理套件、軟體源與診斷"
           }
         }
       }
     },
-    "detail.tabs.installed": {
+    "panel.subtitle.notInstalled": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "المثبتة"
+            "value": "Homebrew غير مثبت"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Installed"
+            "value": "Homebrew not installed"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalado"
+            "value": "Homebrew no instalado"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Installé"
+            "value": "Homebrew non installé"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "インストール済み"
+            "value": "Homebrew がインストールされていません"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instalado"
+            "value": "Homebrew não instalado"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已安装"
+            "value": "Homebrew 未安装"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "已安裝"
+            "value": "Homebrew 未安裝"
           }
         }
       }
     },
-    "detail.tabs.search": {
+    "panel.subtitle.scanning": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "بحث وتثبيت"
+            "value": "جاري الفحص..."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Search"
+            "value": "Scanning..."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buscar"
+            "value": "Escaneando..."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rechercher"
+            "value": "Analyse en cours..."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "検索とインストール"
+            "value": "スキャン中..."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buscar"
+            "value": "Escaneando..."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "搜索安装"
+            "value": "正在扫描..."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "搜尋安裝"
+            "value": "正在掃描..."
           }
         }
       }
     },
-    "detail.tabs.taps": {
+    "panel.subtitle.upToDate": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "المستودعات"
+            "value": "محدث بالكامل"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Taps"
+            "value": "Up to date"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Taps"
+            "value": "Actualizado"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Taps"
+            "value": "À jour"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "タップ源"
+            "value": "すべて最新"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Taps"
+            "value": "Atualizado"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "三方源"
+            "value": "一切最新"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "三方源"
+            "value": "一切最新"
           }
         }
       }
     },
-    "detail.tabs.diagnostics": {
+    "panel.subtitle.upgradable": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الصيانة والتشخيص"
+            "value": "%d تحديثات متاحة"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagnostics"
+            "value": "%d updates available"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagnósticos"
+            "value": "%d actualizaciones disponibles"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagnostics"
+            "value": "%d mises à jour disponibles"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "メンテナンスと診断"
+            "value": "%d 個のアップデートが利用可能"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagnósticos"
+            "value": "%d atualizações disponíveis"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "维护与诊断"
+            "value": "%d 个包可升级"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "維護與診斷"
-          }
-        }
-      }
-    },
-    "detail.filter.all": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الكل"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tout"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべて"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tudo"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全部"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全部"
-          }
-        }
-      }
-    },
-    "detail.filter.formula": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula"
-          }
-        }
-      }
-    },
-    "detail.filter.cask": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask"
-          }
-        }
-      }
-    },
-    "detail.search.placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "البحث في الحزم المثبتة..."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search installed packages..."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar paquetes instalados..."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechercher des paquets installés..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストール済みパッケージを検索..."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar pacotes instalados..."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索已安装的包..."
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜尋已安裝的包..."
-          }
-        }
-      }
-    },
-    "detail.search.onlinePlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "البحث عن صيغ أو تطبيقات عبر الإنترنت..."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search online formulae or casks..."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar fórmulas o casks en línea..."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechercher des formules ou casks en ligne..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オンラインパッケージまたはアプリを検索..."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar fórmulas ou casks online..."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索在线公式或应用..."
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜尋線上公式或應用程式..."
-          }
-        }
-      }
-    },
-    "detail.search.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بحث"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechercher"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検索"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜尋"
-          }
-        }
-      }
-    },
-    "detail.search.empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "أدخل الكلمات المفتاحية للبحث عبر سطر الأوامر."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter keywords to search on Homebrew"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingrese palabras clave para buscar en Homebrew"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entrez des mots-clés pour rechercher sur Homebrew"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーワードを入力してHomebrewを検索します"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insira palavras-chave para buscar no Homebrew"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "输入关键字并在命令行进行搜索"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輸入關鍵字並在命令列進行搜尋"
-          }
-        }
-      }
-    },
-    "detail.search.noMatch": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لا توجد حزم مثبتة مطابقة"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No matching installed packages"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se encontraron paquetes instalados coincidentes"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun paquet installé correspondant"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一致するインストール済みパッケージはありません"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhum pacote instalado correspondente"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无匹配的已安装包"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無匹配的已安裝包"
-          }
-        }
-      }
-    },
-    "detail.search.searching": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جاري البحث في Homebrew..."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Searching Homebrew..."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscando en Homebrew..."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recherche sur Homebrew..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrewを検索中..."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscando no Homebrew..."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在搜索 Homebrew..."
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在搜尋 Homebrew..."
-          }
-        }
-      }
-    },
-    "detail.search.fetchingDetail": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جاري جلب البيانات الوصفية التفصيلية..."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetching detailed metadata..."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obteniendo metadatos detallados..."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Récupération des métadonnées détaillées..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "詳細メタデータを取得中..."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obtendo metadados detalhados..."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在获取详细元数据..."
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在獲取詳細元數據..."
-          }
-        }
-      }
-    },
-    "detail.search.installedHint": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هذه الحزمة مثبتة بالفعل على النظام."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This package is already installed."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este paquete ya está instalado en el sistema."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ce paquet est déjà installé sur le système."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このパッケージはすでにシステムにインストールされています。"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este pacote já está instalado no sistema."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此包已在系统中安装。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此包已在系統中安裝。"
-          }
-        }
-      }
-    },
-    "detail.search.installAction": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تثبيت"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Install"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instalar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installer"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストール"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instalar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击安装 (Install)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "點擊安裝 (Install)"
-          }
-        }
-      }
-    },
-    "detail.search.installAgainAction": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تثبيت مجددًا"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Install Again"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instalar de nuevo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réinstaller"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再インストール"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instalar novamente"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再次安装"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再次安裝"
-          }
-        }
-      }
-    },
-    "detail.search.hasUpdate": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تحديث متاح"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update Available"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualización disponible"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mise à jour disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アップデートあり"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atualização disponível"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有更新"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有更新"
-          }
-        }
-      }
-    },
-    "detail.detail.selectionHint": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اختر حزمة مثبتة من اليسار لعرض التفاصيل."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select an installed package to view details."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccione un paquete instalado de la izquierda para ver los detalles."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélectionnez un paquet installé à gauche pour afficher les détails."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "詳細を表示するには、左側からインストール済みパッケージを選択してください。"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecione um pacote instalado à esquerda para ver os detalhes."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择左侧已安装的包以查看详情"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選擇左側已安裝的包以查看詳情"
-          }
-        }
-      }
-    },
-    "detail.detail.onlineHint": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حدد نتيجة بحث لتثبيت الحزمة."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select search result to install package."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccione el resultado de búsqueda para instalar el paquete."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélectionnez un résultat de recherche pour installer le paquet."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パッケージをインストールするには、検索結果を選択してください。"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecione o resultado da busca para instalar o pacote."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择搜索结果并安装包"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選擇搜尋結果並安裝包"
-          }
-        }
-      }
-    },
-    "detail.detail.type": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نوع البرنامج"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タイプ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipo"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "软件类型"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "軟體類型"
-          }
-        }
-      }
-    },
-    "detail.detail.typeFormula": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formula (سطر الأوامر)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Command-line Formula"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fórmula de línea de comandos"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formule en ligne de commande"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コマンドラインパッケージ (Formula)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fórmula de linha de comando"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "命令行包 (Formula)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "命令列包 (Formula)"
-          }
-        }
-      }
-    },
-    "detail.detail.typeCask": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cask (تطبيق سطح مكتب)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desktop Application (Cask)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicación de escritorio (Cask)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Application de bureau (Cask)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デスクトップアプリ (Cask)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicativo de desktop (Cask)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "桌面应用 (Cask)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "桌面應用程式 (Cask)"
-          }
-        }
-      }
-    },
-    "detail.detail.installedVer": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإصدار المثبت"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installed Version"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión instalada"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version installée"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストール済みバージョン"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão instalada"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已装版本"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已裝版本"
-          }
-        }
-      }
-    },
-    "detail.detail.latestVer": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "أحدث إصدار"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Latest Version"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Última versión"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dernière version"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最新バージョン"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Última versão"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最新版本"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最新版本"
-          }
-        }
-      }
-    },
-    "detail.detail.latestAvailableVer": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "أحدث إصدار متاح"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Latest Available Version"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Última versión disponible"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dernière version disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用可能な最新バージョン"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Última versão disponível"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最新可用版本"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最新可用版本"
-          }
-        }
-      }
-    },
-    "detail.detail.website": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الموقع الرسمي"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Website"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sitio web"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Site web"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ウェブサイト"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Site"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "官方网站"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "官方網站"
-          }
-        }
-      }
-    },
-    "detail.detail.pinned": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مثبت"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pinned"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fijado"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Épinglé"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ピン留め済み"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fixado"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已锁定"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已鎖定"
-          }
-        }
-      }
-    },
-    "detail.detail.dependencies": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يعتمد على الحزم (%d)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dependencies (%d)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depende de los paquetes (%d)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dépend des paquets (%d)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "依存パッケージ (%d)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depende dos pacotes (%d)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "依赖以下包 (%d)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "依賴以下包 (%d)"
-          }
-        }
-      }
-    },
-    "detail.detail.usedBy": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مستخدم بواسطة الحزم (%d)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Used by (%d)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usado por los paquetes (%d)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utilisé par les paquets (%d)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "被依存パッケージ (%d)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usado pelos pacotes (%d)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "被以下包使用 (%d)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "被以下包使用 (%d)"
-          }
-        }
-      }
-    },
-    "detail.detail.actionUpgrade": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترقية"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrade"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mettre à jour"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アップグレード"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atualizar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "升级"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "升級"
-          }
-        }
-      }
-    },
-    "detail.detail.actionPin": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تثبيت الإصدار"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pin Version"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fijar versión"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Épingler la version"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バージョンを固定"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fixar versão"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "锁定版本"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鎖定版本"
-          }
-        }
-      }
-    },
-    "detail.detail.actionUnpin": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إلغاء التثبيت"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unpin"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfijar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Déséplingler"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "固定を解除"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfixar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "解锁"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "解鎖"
-          }
-        }
-      }
-    },
-    "detail.detail.actionUninstall": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إلغاء التثبيت"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uninstall"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desinstalar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Désinstaller"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アンインストール"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desinstalar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "卸载"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "卸載"
-          }
-        }
-      }
-    },
-    "detail.taps.titleAdd": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إضافة مستودع (Tap)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Tap Repository"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Añadir repositorio (Tap)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajouter un dépôt (Tap)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タップリポジトリを追加 (Tap)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adicionar repositório (Tap)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加三方源 (Tap)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新增三方源 (Tap)"
-          }
-        }
-      }
-    },
-    "detail.taps.placeholderAdd": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "أدخل مسار المستودع (مثال: user/repo أو رابط المستودع)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter tap path (e.g., user/repo or repository URL)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingrese la ruta del tap (ej. user/repo o URL del repositorio)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saisissez le chemin du tap (ex. user/repo ou URL du dépôt)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リポジトリのパスを入力します (例: user/repo または URL)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insira o caminho do tap (ex: user/repo ou URL do repositório)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "输入源路径 (例如: user/repo 或仓库 URL)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輸入源路徑 (例如: user/repo 或倉庫 URL)"
-          }
-        }
-      }
-    },
-    "detail.taps.buttonAdd": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إضافة"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Añadir"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajouter"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "追加"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adicionar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新增"
-          }
-        }
-      }
-    },
-    "detail.taps.titleList": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "المستودعات النشطة (%d)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active Taps (%d)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taps activos (%d)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taps actifs (%d)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効なタップ源 (%d)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taps ativos (%d)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已启用的软件源 (%d)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已啟用的軟體源 (%d)"
-          }
-        }
-      }
-    },
-    "detail.taps.empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لا توجد مستودعات نشطة"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No active tap repositories"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No hay repositorios tap activos"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun dépôt tap actif"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効なタップリポジトリはありません"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhum repositório tap ativo"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无已启用三方源"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無已啟用三方源"
-          }
-        }
-      }
-    },
-    "detail.taps.buttonUntap": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إلغاء الاشتراك"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Untap"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desregistrar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Désinscrire"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "登録解除"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desregistrar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "注销"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "註銷"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.update.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تحديث مستودعات Homebrew (brew update)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update Repositories (brew update)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar repositorios (brew update)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mettre à jour les dépôts (brew update)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リポジトリリストを更新 (brew update)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atualizar repositórios (brew update)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新软件仓库列表 (brew update)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新軟體倉庫列表 (brew update)"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.update.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مزامنة أحدث قوائم الصيغ والتطبيقات من الخوادم البعيدة."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync the latest list of formulas and casks from remote servers."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sincronice la última lista de fórmulas y casks desde los servidores remotos."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Synchroniser la dernière liste des formules et casks depuis les serveurs distants."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リモートサーバーから最新の Homebrew フォーミュラとアプリリストを同期します。"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sincronize a lista mais recente de fórmulas e casks dos servidores remotos."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "从远程服务器同步最新的 Homebrew 公式与应用清单。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "從遠端伺服器同步最新的 Homebrew 公式與應用程式清單。"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.upgrade.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترقية جميع الحزم منتهية الصلاحية (brew upgrade)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrade All Outdated Packages (brew upgrade)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar todos los paquetes obsoletos (brew upgrade)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mettre à jour tous les paquets obsolètes (brew upgrade)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべての古いパッケージをアップグレード (brew upgrade)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atualizar todos os pacotes desatualizados (brew upgrade)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "升级所有过期软件包 (brew upgrade)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "升級所有過期套件 (brew upgrade)"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.upgrade.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترقية جميع الصيغ والتطبيقات القابلة للتحديث المكتشفة في النظام بضغطة واحدة."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrade all outdated formulas and casks currently detected on your system."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualice todas las fórmulas y casks obsoletas actualmente detectadas en su sistema."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mettre à jour toutes les formules et casks obsolètes actuellement détectés sur votre système."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システムで検出されたすべての古いフォーミュラとアプリを一括でアップグレードします。"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atualize todas as fórmulas e casks desatualizadas atualmente detectadas em seu sistema."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一键升级当前系统已检测到的所有可更新 Formula 与 Cask。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一鍵升級當前系統已檢測到的所有可更新 Formula 與 Cask。"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.doctor.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تشخيص صحة البيئة (brew doctor)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Health Diagnostics (brew doctor)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diagnóstico de salud del entorno (brew doctor)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diagnostic de santé de l'environnement (brew doctor)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "環境の健全性診断 (brew doctor)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diagnóstico de saúde do ambiente (brew doctor)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "环境健康诊断 (brew doctor)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "環境健康診斷 (brew doctor)"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.doctor.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تشخيص المشاكل المحتملة في متغيرات البيئة والأذونات ومسارات البناء."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diagnose potential issues with environment variables, permissions, and build paths."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diagnostique problemas potenciales con variables de entorno, permisos y rutas de compilación."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diagnostiquer les problèmes potentiels liés aux variables d'environnement, aux autorisations et aux chemins de build."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "環境変数、権限設定、およびビルドパスの潜在的な問題を診断します。"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diagnostique problemas potenciais com variáveis de ambiente, permissões e caminhos de compilação."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "诊断系统环境变量、权限设置和编译环境的潜在问题。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "診斷系統環境變數、權限設定和編譯環境的潛在問題。"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.cleanup.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تنظيف المخلفات والذاكرة المؤقتة الزائدة (brew cleanup)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cleanup Trash & Caches (brew cleanup)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpiar basura y cachés redundantes (brew cleanup)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nettoyer les fichiers inutiles et caches (brew cleanup)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不要なファイルとキャッシュをクリア (brew cleanup)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpar arquivos desnecessários e caches (brew cleanup)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清理垃圾与冗余缓存 (brew cleanup)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清理垃圾與冗餘快取 (brew cleanup)"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.cleanup.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إزالة التنزيلات والملفات المؤقتة القديمة لتحرير مساحة القرص."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove outdated local downloads and caches to reclaim disk space."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elimine las descargas y cachés locales obsoletas para recuperar espacio en disco."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer les téléchargements locaux et caches obsolètes pour libérer de l'espace disque."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "古いローカルダウンロードとキャッシュを削除して、ディスク容量を解放します。"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remova downloads locais e caches desatualizados para recuperar espaço em disco."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "删除过期的旧版本安装文件和下载包缓存，释放磁盘空间。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "刪除過期的舊版本安裝檔案和下載包快取，釋放磁碟空間。"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.buttonExecute": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تشغيل"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Run"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ejecutar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lancer"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "実行"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Executar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "执行"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "執行"
-          }
-        }
-      }
-    },
-    "detail.console.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سجل وحدة تحكم الأوامر"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Command Console Log"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registro de la consola de comandos"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Journal de la console de commande"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コマンドコンソールログ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log do console de comandos"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "命令行控制台日志"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "命令列主控台記錄"
-          }
-        }
-      }
-    },
-    "detail.console.buttonClear": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسح"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpiar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Effacer"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クリア"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清空"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清空"
-          }
-        }
-      }
-    },
-    "detail.console.buttonCancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إلغاء العملية"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Operation"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar operación"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Annuler l'opération"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "操作をキャンセル"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar operação"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取消操作"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取消操作"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.pathTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تكوين مسار Homebrew"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew Path Configuration"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuración de la ruta de Homebrew"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuration du chemin Homebrew"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew パス設定"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuração do caminho do Homebrew"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew 路径设置"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew 路徑設定"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.pathPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "المسار إلى ملف brew القابل للتنفيذ (مثال: /opt/homebrew/bin/brew)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Path to brew executable (e.g. /opt/homebrew/bin/brew)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ruta al ejecutable brew (ej. /opt/homebrew/bin/brew)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chemin vers l'exécutable brew (ex. /opt/homebrew/bin/brew)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "brew 実行可能ファイルのパス (例: /opt/homebrew/bin/brew)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Caminho para o executável brew (ex: /opt/homebrew/bin/brew)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "输入 brew 可执行文件路径 (例如: /opt/homebrew/bin/brew)"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輸入 brew 可執行檔案路徑 (例如: /opt/homebrew/bin/brew)"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.pathApply": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تطبيق"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apply"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appliquer"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "適用"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicar"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "应用"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "套用"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.pathNotFoundTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لم يتم اكتشاف Homebrew"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew Not Detected"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew no detectado"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew non détecté"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew が検出されませんでした"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew não detectado"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未检测到 Homebrew"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未檢測到 Homebrew"
-          }
-        }
-      }
-    },
-    "detail.diagnostics.pathNotFoundDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لم يتم العثور على Homebrew في أدلة النظام القياسية. يرجى التأكد من تثبيته أو توفير المسار المخصص إلى ملف brew القابل للتنفيذ أدناه:"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew was not found in standard system directories. Please ensure it is installed or provide the custom path to the 'brew' executable below:"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se encontró Homebrew en los directorios estándar del sistema. Asegúrese de que esté instalado o proporcione la ruta personalizada al ejecutable 'brew' a continuación:"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homebrew n'a pas été trouvé dans les répertoires système standard. Veuillez vous assurer qu'il est installé ou fournir le chemin personnalisé vers l'exécutable 'brew' ci-dessous :"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "標準のシステムディレクトリに Homebrew が見つかりませんでした。インストールされていることを確認するか、以下の 'brew' 実行可能ファイルへのカスタムパスを指定してください:"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O Homebrew não foi encontrado nos diretórios padrão do sistema. Certifique-se de que ele está instalado ou forneça o caminho personalizado para o executável 'brew' abaixo:"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在标准系统目录下未检测到 Homebrew 安装。请确保其已正确安装，或在下方指定 'brew' 可执行文件的自定义路径："
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在標準系統目錄下未檢測到 Homebrew 安裝。請確保其已正確安裝，或在下方指定 'brew' 可執行檔案的自定義路徑："
-          }
-        }
-      }
-    },
-    "detail.diagnostics.pathHelpTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مواقع التثبيت الشائعة:"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Common Installation Locations:"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ubicaciones de instalación comunes:"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emplacements d'installation courants :"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一般的なインストール場所:"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Locais de instalação comuns:"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "常见安装位置："
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "常見安裝位置："
+            "value": "%d 個包可升級"
           }
         }
       }

--- a/Plugins/Homebrew/Sources/HomebrewCommandRunner.swift
+++ b/Plugins/Homebrew/Sources/HomebrewCommandRunner.swift
@@ -58,13 +58,17 @@ public actor HomebrewCommandRunner: HomebrewCommandRunning {
 
         self.activeProcess = process
 
+        let group = DispatchGroup()
+
         // Attach readability handlers to stream output in real-time
         outputPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
             guard !data.isEmpty else { return }
             if let string = String(data: data, encoding: .utf8) {
+                group.enter()
                 Task { @MainActor in
                     onOutput(string)
+                    group.leave()
                 }
             }
         }
@@ -73,8 +77,10 @@ public actor HomebrewCommandRunner: HomebrewCommandRunning {
             let data = handle.availableData
             guard !data.isEmpty else { return }
             if let string = String(data: data, encoding: .utf8) {
+                group.enter()
                 Task { @MainActor in
                     onError(string)
+                    group.leave()
                 }
             }
         }
@@ -87,7 +93,15 @@ public actor HomebrewCommandRunner: HomebrewCommandRunning {
 
                 Task { [weak self] in
                     guard let self = self else { return }
-                    await self.clearProcess()
+                    
+                    // Wait for all pending UI output tasks to complete
+                    await withCheckedContinuation { (waitContinuation: CheckedContinuation<Void, Never>) in
+                        group.notify(queue: .global()) {
+                            waitContinuation.resume()
+                        }
+                    }
+                    
+                    await self.clearProcess(for: proc)
                     continuation.resume(returning: proc.terminationStatus)
                 }
             }
@@ -97,8 +111,9 @@ public actor HomebrewCommandRunner: HomebrewCommandRunning {
             } catch {
                 outputPipe.fileHandleForReading.readabilityHandler = nil
                 errorPipe.fileHandleForReading.readabilityHandler = nil
-                Task {
-                    self.clearProcess()
+                Task { [weak self] in
+                    guard let self = self else { return }
+                    await self.clearProcess(for: process)
                 }
                 continuation.resume(throwing: error)
             }
@@ -109,10 +124,11 @@ public actor HomebrewCommandRunner: HomebrewCommandRunning {
         if let process = activeProcess, process.isRunning {
             process.terminate()
         }
-        activeProcess = nil
     }
 
-    private func clearProcess() {
-        self.activeProcess = nil
+    private func clearProcess(for process: Process) {
+        if self.activeProcess === process {
+            self.activeProcess = nil
+        }
     }
 }

--- a/Plugins/Homebrew/Sources/HomebrewCommandRunner.swift
+++ b/Plugins/Homebrew/Sources/HomebrewCommandRunner.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+public protocol HomebrewCommandRunning: Sendable {
+    func run(
+        executable: String,
+        arguments: [String],
+        onOutput: @escaping @MainActor (String) -> Void,
+        onError: @escaping @MainActor (String) -> Void
+    ) async throws -> Int32
+    
+    func cancel() async
+}
+
+public actor HomebrewCommandRunner: HomebrewCommandRunning {
+    private var activeProcess: Process?
+
+    public init() {}
+
+    /// Runs a command asynchronously, streaming output and error chunks to the provided handlers.
+    /// Returns the termination status (exit code).
+    public func run(
+        executable: String,
+        arguments: [String],
+        onOutput: @escaping @MainActor (String) -> Void,
+        onError: @escaping @MainActor (String) -> Void
+    ) async throws -> Int32 {
+        if activeProcess != nil {
+            throw NSError(
+                domain: "HomebrewCommandRunner",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "A process is already running."]
+            )
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        
+        // Setup environment path, ensuring homebrew binaries are visible
+        var env = ProcessInfo.processInfo.environment
+        let path = env["PATH"] ?? ""
+        let brewPaths = ["/opt/homebrew/bin", "/usr/local/bin"]
+        var pathComponents = path.components(separatedBy: ":")
+        for p in brewPaths {
+            if !pathComponents.contains(p) {
+                pathComponents.insert(p, at: 0)
+            }
+        }
+        env["PATH"] = pathComponents.joined(separator: ":")
+        env["HOMEBREW_NO_EMOJI"] = "1"
+        env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+        process.environment = env
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        self.activeProcess = process
+
+        // Attach readability handlers to stream output in real-time
+        outputPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            if let string = String(data: data, encoding: .utf8) {
+                Task { @MainActor in
+                    onOutput(string)
+                }
+            }
+        }
+
+        errorPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            if let string = String(data: data, encoding: .utf8) {
+                Task { @MainActor in
+                    onError(string)
+                }
+            }
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            process.terminationHandler = { [weak self] proc in
+                // Clear readability handlers to prevent resource leaks
+                outputPipe.fileHandleForReading.readabilityHandler = nil
+                errorPipe.fileHandleForReading.readabilityHandler = nil
+
+                Task { [weak self] in
+                    guard let self = self else { return }
+                    await self.clearProcess()
+                    continuation.resume(returning: proc.terminationStatus)
+                }
+            }
+
+            do {
+                try process.run()
+            } catch {
+                outputPipe.fileHandleForReading.readabilityHandler = nil
+                errorPipe.fileHandleForReading.readabilityHandler = nil
+                Task {
+                    self.clearProcess()
+                }
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    public func cancel() {
+        if let process = activeProcess, process.isRunning {
+            process.terminate()
+        }
+        activeProcess = nil
+    }
+
+    private func clearProcess() {
+        self.activeProcess = nil
+    }
+}

--- a/Plugins/Homebrew/Sources/HomebrewCommandRunner.swift
+++ b/Plugins/Homebrew/Sources/HomebrewCommandRunner.swift
@@ -1,5 +1,77 @@
 import Foundation
 
+public enum HomebrewExecutableValidator {
+    public static let standardPaths = [
+        "/opt/homebrew/bin/brew",
+        "/usr/local/bin/brew",
+        "/opt/workbrew/bin/brew"
+    ]
+
+    public static func validatedPath(
+        for rawPath: String,
+        fileManager: FileManager = .default
+    ) -> String? {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        var candidate = (trimmed as NSString).expandingTildeInPath
+        if (candidate as NSString).lastPathComponent != "brew" {
+            candidate = (candidate as NSString).appendingPathComponent("brew")
+        }
+
+        let standardized = URL(fileURLWithPath: candidate).standardizedFileURL
+        guard isValidBrewExecutable(at: standardized.path, fileManager: fileManager) else {
+            return nil
+        }
+        return standardized.path
+    }
+
+    public static func isValidBrewExecutable(
+        at path: String,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        guard url.lastPathComponent == "brew",
+              url.deletingLastPathComponent().lastPathComponent == "bin" else {
+            return false
+        }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              fileManager.isExecutableFile(atPath: url.path) else {
+            return false
+        }
+
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        var resolvedIsDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: resolvedURL.path, isDirectory: &resolvedIsDirectory),
+              !resolvedIsDirectory.boolValue,
+              fileManager.isExecutableFile(atPath: resolvedURL.path) else {
+            return false
+        }
+
+        return looksLikeHomebrewExecutable(at: resolvedURL)
+            || looksLikeHomebrewExecutable(at: url)
+    }
+
+    private static func looksLikeHomebrewExecutable(at url: URL) -> Bool {
+        guard let fileHandle = try? FileHandle(forReadingFrom: url) else {
+            return false
+        }
+        defer { try? fileHandle.close() }
+
+        guard let data = try? fileHandle.read(upToCount: 16_384),
+              let sample = String(data: data, encoding: .utf8) else {
+            return false
+        }
+
+        return sample.contains("HOMEBREW")
+            || sample.contains("Homebrew")
+            || sample.contains("brew.rb")
+    }
+}
+
 public protocol HomebrewCommandRunning: Sendable {
     func run(
         executable: String,
@@ -33,7 +105,15 @@ public actor HomebrewCommandRunner: HomebrewCommandRunning {
         }
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
+        guard let validatedExecutable = HomebrewExecutableValidator.validatedPath(for: executable) else {
+            throw NSError(
+                domain: "HomebrewCommandRunner",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "The configured Homebrew executable is invalid."]
+            )
+        }
+
+        process.executableURL = URL(fileURLWithPath: validatedExecutable)
         
         // Setup environment path, ensuring homebrew binaries are visible
         var env = ProcessInfo.processInfo.environment

--- a/Plugins/Homebrew/Sources/HomebrewController.swift
+++ b/Plugins/Homebrew/Sources/HomebrewController.swift
@@ -27,88 +27,57 @@ public final class HomebrewController: ObservableObject {
     
     public init(runner: any HomebrewCommandRunning = HomebrewCommandRunner()) {
         self.runner = runner
+
         if let customPath = UserDefaults.standard.string(forKey: "mactools.homebrew.customPath"),
-           !customPath.isEmpty,
-           FileManager.default.fileExists(atPath: customPath) {
-            self.brewPath = customPath
-            self.isBrewAvailable = true
-        } else if let path = discoverBrewPath() {
+           !customPath.isEmpty {
+            if let validatedPath = HomebrewExecutableValidator.validatedPath(for: customPath) {
+                self.brewPath = validatedPath
+                self.isBrewAvailable = true
+                return
+            }
+            UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
+        }
+
+        if let path = discoverBrewPath() {
             self.brewPath = path
             self.isBrewAvailable = true
-        } else {
-            Task { [weak self] in
-                guard let self = self else { return }
-                if let path = await self.discoverBrewPathViaShell() {
-                    self.brewPath = path
-                    self.isBrewAvailable = true
-                    self.onStateChange?()
-                    if self.installedPackages.isEmpty {
-                        self.scanAll()
-                    }
-                }
-            }
         }
     }
     
     public func updateCustomPath(_ path: String) {
-        var trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
             if let path = discoverBrewPath() {
                 self.brewPath = path
                 self.isBrewAvailable = true
-                scanAll()
-                onStateChange?()
             } else {
                 self.brewPath = ""
                 self.isBrewAvailable = false
-                onStateChange?()
-                Task { [weak self] in
-                    guard let self = self else { return }
-                    if let path = await self.discoverBrewPathViaShell() {
-                        self.brewPath = path
-                        self.isBrewAvailable = true
-                        self.onStateChange?()
-                        if self.installedPackages.isEmpty {
-                            self.scanAll()
-                        }
-                    }
-                }
             }
+            onStateChange?()
             return
         }
-        
-        // Auto-append brew if pointing to directory containing brew
-        if (trimmed as NSString).lastPathComponent != "brew" {
-            let possiblePath = (trimmed as NSString).appendingPathComponent("brew")
-            if FileManager.default.fileExists(atPath: possiblePath) {
-                trimmed = possiblePath
-            }
+
+        guard let validatedPath = HomebrewExecutableValidator.validatedPath(for: trimmed) else {
+            appendLog("[System] Homebrew 路径无效，请选择可执行的 brew 文件。", isError: true)
+            onStateChange?()
+            return
         }
-        
-        UserDefaults.standard.set(trimmed, forKey: "mactools.homebrew.customPath")
-        self.brewPath = trimmed
-        self.isBrewAvailable = FileManager.default.fileExists(atPath: trimmed)
-        
-        if self.isBrewAvailable {
-            scanAll()
-        }
+
+        UserDefaults.standard.set(validatedPath, forKey: "mactools.homebrew.customPath")
+        self.brewPath = validatedPath
+        self.isBrewAvailable = true
+        appendLog("[System] 已更新 Homebrew 路径。")
         onStateChange?()
     }
     
     // MARK: - Path Discovery
     
     private func discoverBrewPath() -> String? {
-        let standardPaths = [
-            "/opt/homebrew/bin/brew",
-            "/usr/local/bin/brew",
-            "/opt/workbrew/bin/brew",
-            "/usr/bin/brew",
-            "/bin/brew"
-        ]
-        for path in standardPaths {
-            if FileManager.default.fileExists(atPath: path) {
-                return path
+        for path in HomebrewExecutableValidator.standardPaths {
+            if let validatedPath = HomebrewExecutableValidator.validatedPath(for: path) {
+                return validatedPath
             }
         }
         
@@ -117,55 +86,11 @@ public final class HomebrewController: ObservableObject {
             let dirs = envPath.components(separatedBy: ":")
             for dir in dirs {
                 let path = (dir as NSString).appendingPathComponent("brew")
-                if FileManager.default.fileExists(atPath: path) {
-                    return path
+                if let validatedPath = HomebrewExecutableValidator.validatedPath(for: path) {
+                    return validatedPath
                 }
             }
         }
-        
-        return nil
-    }
-    
-    private func discoverBrewPathViaShell() async -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = ["-l", "-c", "which brew"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        
-        let timeoutTask = Task {
-            try? await Task.sleep(for: .seconds(3.0))
-            if process.isRunning {
-                process.terminate()
-            }
-        }
-        
-        let exitCode: Int32 = await withCheckedContinuation { continuation in
-            process.terminationHandler = { proc in
-                continuation.resume(returning: proc.terminationStatus)
-            }
-            if !process.isRunning {
-                process.terminationHandler = nil
-                continuation.resume(returning: process.terminationStatus)
-            }
-        }
-        
-        timeoutTask.cancel()
-        
-        if exitCode == 0 {
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !path.isEmpty, path.contains("/") {
-                return path
-            }
-        }
-        
         return nil
     }
     

--- a/Plugins/Homebrew/Sources/HomebrewController.swift
+++ b/Plugins/Homebrew/Sources/HomebrewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import SwiftUI
+import MacToolsPluginKit
 
 @MainActor
 public final class HomebrewController: ObservableObject {
@@ -24,9 +25,14 @@ public final class HomebrewController: ObservableObject {
     public var onStateChange: (() -> Void)?
     
     let runner: any HomebrewCommandRunning
+    private let localization: PluginLocalization
     
-    public init(runner: any HomebrewCommandRunning = HomebrewCommandRunner()) {
+    public init(
+        runner: any HomebrewCommandRunning = HomebrewCommandRunner(),
+        localization: PluginLocalization = PluginLocalization(bundle: .main)
+    ) {
         self.runner = runner
+        self.localization = localization
 
         if let customPath = UserDefaults.standard.string(forKey: "mactools.homebrew.customPath"),
            !customPath.isEmpty {
@@ -60,7 +66,10 @@ public final class HomebrewController: ObservableObject {
         }
 
         guard let validatedPath = HomebrewExecutableValidator.validatedPath(for: trimmed) else {
-            appendLog("[System] Homebrew 路径无效，请选择可执行的 brew 文件。", isError: true)
+            appendLog(localization.string(
+                "log.path.invalid",
+                defaultValue: "[System] Homebrew 路径无效，请选择可执行的 brew 文件。"
+            ), isError: true)
             onStateChange?()
             return
         }
@@ -68,7 +77,7 @@ public final class HomebrewController: ObservableObject {
         UserDefaults.standard.set(validatedPath, forKey: "mactools.homebrew.customPath")
         self.brewPath = validatedPath
         self.isBrewAvailable = true
-        appendLog("[System] 已更新 Homebrew 路径。")
+        appendLog(localization.string("log.path.updated", defaultValue: "[System] 已更新 Homebrew 路径。"))
         onStateChange?()
     }
     
@@ -118,9 +127,9 @@ public final class HomebrewController: ObservableObject {
     public func scanAll() {
         guard isBrewAvailable, !isBusy else { return }
         isBusy = true
-        currentOperationName = "正在扫描包与更新..."
+        currentOperationName = localization.string("operation.scanAll", defaultValue: "正在扫描包与更新...")
         clearLogs()
-        appendLog("[System] 开始扫描 Homebrew 状态...")
+        appendLog(localization.string("log.scan.started", defaultValue: "[System] 开始扫描 Homebrew 状态..."))
         
         Task {
             do {
@@ -136,9 +145,13 @@ public final class HomebrewController: ObservableObject {
                 // 4. Load full package details in background (desc, homepage, etc.)
                 try await loadPackageDetails()
                 
-                appendLog("[System] 扫描完成！")
+                appendLog(localization.string("log.scan.completed", defaultValue: "[System] 扫描完成。"))
             } catch {
-                appendLog("[System] 扫描发生错误: \(error.localizedDescription)", isError: true)
+                appendLog(localization.format(
+                    "log.scan.failed",
+                    defaultValue: "[System] 扫描发生错误：%@",
+                    error.localizedDescription
+                ), isError: true)
             }
             
             isBusy = false
@@ -148,7 +161,7 @@ public final class HomebrewController: ObservableObject {
     }
     
     private func loadTaps() async throws {
-        appendLog("[System] 正在获取已启用的软件源 (Taps)...")
+        appendLog(localization.string("log.taps.loading", defaultValue: "[System] 正在获取已启用的软件源..."))
         let tempRunner = self.runner
         var outputLines: [String] = []
         
@@ -167,11 +180,11 @@ public final class HomebrewController: ObservableObject {
             .filter { !$0.isEmpty }
         
         taps = tapNames.map { BrewTap(name: $0) }
-        appendLog("[System] 获取到 \(taps.count) 个软件源")
+        appendLog(localization.format("log.taps.loaded", defaultValue: "[System] 获取到 %d 个软件源", taps.count))
     }
     
     private func loadInstalledPackagesFast() async throws {
-        appendLog("[System] 正在快速获取已安装包列表...")
+        appendLog(localization.string("log.installed.loading", defaultValue: "[System] 正在获取已安装包列表..."))
         let tempRunner = self.runner
         
         var formulaOutput = ""
@@ -229,11 +242,11 @@ public final class HomebrewController: ObservableObject {
         }
         
         self.installedPackages = tempPackages.sorted { $0.name.lowercased() < $1.name.lowercased() }
-        appendLog("[System] 快速加载已安装包: \(installedPackages.count) 个")
+        appendLog(localization.format("log.installed.loaded", defaultValue: "[System] 已加载 %d 个已安装包", installedPackages.count))
     }
     
     private func loadOutdatedPackages() async throws {
-        appendLog("[System] 正在获取待更新包列表...")
+        appendLog(localization.string("log.outdated.loading", defaultValue: "[System] 正在获取待更新包列表..."))
         let tempRunner = self.runner
         var jsonOutput = ""
         
@@ -323,14 +336,18 @@ public final class HomebrewController: ObservableObject {
                 )
             }
             
-            appendLog("[System] 获取到 \(outdatedPackages.count) 个待更新包")
+            appendLog(localization.format("log.outdated.loaded", defaultValue: "[System] 获取到 %d 个待更新包", outdatedPackages.count))
         } catch {
-            appendLog("[System] 解析待更新包失败: \(error.localizedDescription)", isError: true)
+            appendLog(localization.format(
+                "log.outdated.parseFailed",
+                defaultValue: "[System] 解析待更新包失败：%@",
+                error.localizedDescription
+            ), isError: true)
         }
     }
     
     private func loadPackageDetails() async throws {
-        appendLog("[System] 正在加载包详细元数据...")
+        appendLog(localization.string("log.details.loading", defaultValue: "[System] 正在加载包详细元数据..."))
         let tempRunner = self.runner
         var jsonOutput = ""
         
@@ -414,9 +431,13 @@ public final class HomebrewController: ObservableObject {
                 return pkg
             }
             
-            appendLog("[System] 包详细元数据加载完成")
+            appendLog(localization.string("log.details.loaded", defaultValue: "[System] 包详细元数据加载完成"))
         } catch {
-            appendLog("[System] 解析详细元数据失败: \(error.localizedDescription)", isError: true)
+            appendLog(localization.format(
+                "log.details.parseFailed",
+                defaultValue: "[System] 解析详细元数据失败：%@",
+                error.localizedDescription
+            ), isError: true)
         }
     }
     
@@ -504,7 +525,7 @@ public final class HomebrewController: ObservableObject {
     
     public func install(package: BrewPackage) {
         runAsyncCommand(
-            name: "正在安装 \(package.name)...",
+            name: localization.format("operation.install", defaultValue: "正在安装 %@...", package.name),
             args: ["install"] + (package.isCask ? ["--cask"] : []) + [package.name]
         ) { [weak self] success in
             if success {
@@ -515,7 +536,7 @@ public final class HomebrewController: ObservableObject {
     
     public func uninstall(package: BrewPackage) {
         runAsyncCommand(
-            name: "正在卸载 \(package.name)...",
+            name: localization.format("operation.uninstall", defaultValue: "正在卸载 %@...", package.name),
             args: ["uninstall"] + (package.isCask ? ["--cask"] : []) + [package.name]
         ) { [weak self] success in
             if success {
@@ -526,7 +547,7 @@ public final class HomebrewController: ObservableObject {
     
     public func upgrade(package: BrewPackage) {
         runAsyncCommand(
-            name: "正在更新 \(package.name)...",
+            name: localization.format("operation.upgrade", defaultValue: "正在更新 %@...", package.name),
             args: ["upgrade"] + (package.isCask ? ["--cask"] : []) + [package.name]
         ) { [weak self] success in
             if success {
@@ -537,7 +558,7 @@ public final class HomebrewController: ObservableObject {
     
     public func pin(package: BrewPackage) {
         runAsyncCommand(
-            name: "正在锁定 \(package.name)...",
+            name: localization.format("operation.pin", defaultValue: "正在锁定 %@...", package.name),
             args: ["pin", package.name]
         ) { [weak self] success in
             if success {
@@ -548,7 +569,7 @@ public final class HomebrewController: ObservableObject {
     
     public func unpin(package: BrewPackage) {
         runAsyncCommand(
-            name: "正在解锁 \(package.name)...",
+            name: localization.format("operation.unpin", defaultValue: "正在解锁 %@...", package.name),
             args: ["unpin", package.name]
         ) { [weak self] success in
             if success {
@@ -560,7 +581,7 @@ public final class HomebrewController: ObservableObject {
     // MARK: - Global Operations
     
     public func upgradeAll() {
-        runAsyncCommand(name: "正在更新所有包...", args: ["upgrade"]) { [weak self] success in
+        runAsyncCommand(name: localization.string("operation.upgradeAll", defaultValue: "正在更新所有包..."), args: ["upgrade"]) { [weak self] success in
             if success {
                 self?.scanAll()
             }
@@ -568,7 +589,7 @@ public final class HomebrewController: ObservableObject {
     }
     
     public func updateBrew() {
-        runAsyncCommand(name: "正在更新 Homebrew 源...", args: ["update"]) { [weak self] success in
+        runAsyncCommand(name: localization.string("operation.updateBrew", defaultValue: "正在更新 Homebrew 源..."), args: ["update"]) { [weak self] success in
             if success {
                 self?.scanAll()
             }
@@ -576,11 +597,11 @@ public final class HomebrewController: ObservableObject {
     }
     
     public func runDoctor() {
-        runAsyncCommand(name: "正在运行 Homebrew 诊断 (Doctor)...", args: ["doctor"]) { _ in }
+        runAsyncCommand(name: localization.string("operation.doctor", defaultValue: "正在运行 Homebrew 诊断..."), args: ["doctor"]) { _ in }
     }
     
     public func runCleanup() {
-        runAsyncCommand(name: "正在清理 Homebrew 缓存...", args: ["cleanup"]) { _ in }
+        runAsyncCommand(name: localization.string("operation.cleanup", defaultValue: "正在清理 Homebrew 缓存..."), args: ["cleanup"]) { _ in }
     }
     
     // MARK: - Tap Actions
@@ -588,7 +609,7 @@ public final class HomebrewController: ObservableObject {
     public func tapRepository(name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        runAsyncCommand(name: "正在启用软件源 \(trimmed)...", args: ["tap", trimmed]) { [weak self] success in
+        runAsyncCommand(name: localization.format("operation.tap", defaultValue: "正在启用软件源 %@...", trimmed), args: ["tap", trimmed]) { [weak self] success in
             if success {
                 self?.scanAll()
             }
@@ -596,7 +617,7 @@ public final class HomebrewController: ObservableObject {
     }
     
     public func untapRepository(tap: BrewTap) {
-        runAsyncCommand(name: "正在注销软件源 \(tap.name)...", args: ["untap", tap.name]) { [weak self] success in
+        runAsyncCommand(name: localization.format("operation.untap", defaultValue: "正在移除软件源 %@...", tap.name), args: ["untap", tap.name]) { [weak self] success in
             if success {
                 self?.scanAll()
             }
@@ -631,9 +652,18 @@ public final class HomebrewController: ObservableObject {
                 )
                 
                 success = (status == 0)
-                appendLog(success ? "[System] 操作成功完成" : "[System] 操作失败，错误码: \(status)", isError: !success)
+                appendLog(
+                    success
+                        ? localization.string("log.command.completed", defaultValue: "[System] 操作成功完成")
+                        : localization.format("log.command.failedStatus", defaultValue: "[System] 操作失败，错误码：%d", status),
+                    isError: !success
+                )
             } catch {
-                appendLog("[System] 执行命令出错: \(error.localizedDescription)", isError: true)
+                appendLog(localization.format(
+                    "log.command.failed",
+                    defaultValue: "[System] 执行命令出错：%@",
+                    error.localizedDescription
+                ), isError: true)
                 success = false
             }
             
@@ -647,7 +677,7 @@ public final class HomebrewController: ObservableObject {
     public func cancelCurrentOperation() {
         Task {
             await runner.cancel()
-            appendLog("[System] 操作已被用户取消", isError: true)
+            appendLog(localization.string("log.command.cancelled", defaultValue: "[System] 操作已被用户取消"), isError: true)
             isBusy = false
             currentOperationName = ""
             onStateChange?()

--- a/Plugins/Homebrew/Sources/HomebrewController.swift
+++ b/Plugins/Homebrew/Sources/HomebrewController.swift
@@ -428,6 +428,8 @@ public final class HomebrewController: ObservableObject {
             searchResults.removeAll()
             return
         }
+        guard !isSearching else { return }
+        guard searchQuery != trimmed || searchResults.isEmpty else { return }
         
         searchQuery = trimmed
         isSearching = true

--- a/Plugins/Homebrew/Sources/HomebrewController.swift
+++ b/Plugins/Homebrew/Sources/HomebrewController.swift
@@ -1,0 +1,675 @@
+import Foundation
+import Combine
+import SwiftUI
+
+@MainActor
+public final class HomebrewController: ObservableObject {
+    @Published public var isBrewAvailable = false
+    @Published public var brewPath = ""
+    
+    @Published public var installedPackages: [BrewPackage] = []
+    @Published public var outdatedPackages: [BrewPackage] = []
+    @Published public var taps: [BrewTap] = []
+    
+    // Search states
+    @Published public var searchQuery = ""
+    @Published public var searchResults: [BrewPackage] = []
+    @Published public var isSearching = false
+    
+    // Command & console states
+    @Published public var logs: [BrewCommandLog] = []
+    @Published public var isBusy = false
+    @Published public var currentOperationName = ""
+    
+    public var onStateChange: (() -> Void)?
+    
+    let runner: any HomebrewCommandRunning
+    
+    public init(runner: any HomebrewCommandRunning = HomebrewCommandRunner()) {
+        self.runner = runner
+        if let customPath = UserDefaults.standard.string(forKey: "mactools.homebrew.customPath"),
+           !customPath.isEmpty,
+           FileManager.default.fileExists(atPath: customPath) {
+            self.brewPath = customPath
+            self.isBrewAvailable = true
+        } else if let path = discoverBrewPath() {
+            self.brewPath = path
+            self.isBrewAvailable = true
+        }
+    }
+    
+    public func updateCustomPath(_ path: String) {
+        var trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
+            if let path = discoverBrewPath() {
+                self.brewPath = path
+                self.isBrewAvailable = true
+                scanAll()
+            } else {
+                self.brewPath = ""
+                self.isBrewAvailable = false
+            }
+            onStateChange?()
+            return
+        }
+        
+        // Auto-append brew if pointing to directory containing brew
+        if (trimmed as NSString).lastPathComponent != "brew" {
+            let possiblePath = (trimmed as NSString).appendingPathComponent("brew")
+            if FileManager.default.fileExists(atPath: possiblePath) {
+                trimmed = possiblePath
+            }
+        }
+        
+        UserDefaults.standard.set(trimmed, forKey: "mactools.homebrew.customPath")
+        self.brewPath = trimmed
+        self.isBrewAvailable = FileManager.default.fileExists(atPath: trimmed)
+        
+        if self.isBrewAvailable {
+            scanAll()
+        }
+        onStateChange?()
+    }
+    
+    // MARK: - Path Discovery
+    
+    private func discoverBrewPath() -> String? {
+        let standardPaths = [
+            "/opt/homebrew/bin/brew",
+            "/usr/local/bin/brew",
+            "/opt/workbrew/bin/brew",
+            "/usr/bin/brew",
+            "/bin/brew"
+        ]
+        for path in standardPaths {
+            if FileManager.default.fileExists(atPath: path) {
+                return path
+            }
+        }
+        
+        // Check current ProcessInfo PATH
+        if let envPath = ProcessInfo.processInfo.environment["PATH"] {
+            let dirs = envPath.components(separatedBy: ":")
+            for dir in dirs {
+                let path = (dir as NSString).appendingPathComponent("brew")
+                if FileManager.default.fileExists(atPath: path) {
+                    return path
+                }
+            }
+        }
+        
+        // Fallback: try finding via zsh login shell
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-l", "-c", "which brew"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !path.isEmpty, path.contains("/") {
+                return path
+            }
+        } catch {}
+        return nil
+    }
+    
+    // MARK: - Logs Management
+    
+    public func clearLogs() {
+        logs.removeAll()
+    }
+    
+    private func appendLog(_ text: String, isError: Bool = false) {
+        let lines = text.components(separatedBy: .newlines)
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .newlines)
+            if !trimmed.isEmpty {
+                logs.append(BrewCommandLog(text: trimmed, isError: isError))
+            }
+        }
+        if logs.count > 1000 {
+            logs.removeFirst(logs.count - 1000)
+        }
+    }
+    
+    // MARK: - Scanning Packages
+    
+    public func scanAll() {
+        guard isBrewAvailable, !isBusy else { return }
+        isBusy = true
+        currentOperationName = "正在扫描包与更新..."
+        clearLogs()
+        appendLog("[System] 开始扫描 Homebrew 状态...")
+        
+        Task {
+            do {
+                // 1. Load active Taps
+                try await loadTaps()
+                
+                // 2. Load installed packages (fast list first)
+                try await loadInstalledPackagesFast()
+                
+                // 3. Load outdated packages
+                try await loadOutdatedPackages()
+                
+                // 4. Load full package details in background (desc, homepage, etc.)
+                try await loadPackageDetails()
+                
+                appendLog("[System] 扫描完成！")
+            } catch {
+                appendLog("[System] 扫描发生错误: \(error.localizedDescription)", isError: true)
+            }
+            
+            isBusy = false
+            currentOperationName = ""
+            onStateChange?()
+        }
+    }
+    
+    private func loadTaps() async throws {
+        appendLog("[System] 正在获取已启用的软件源 (Taps)...")
+        let tempRunner = self.runner
+        var outputLines: [String] = []
+        
+        _ = try await tempRunner.run(
+            executable: brewPath,
+            arguments: ["tap"],
+            onOutput: { text in
+                outputLines.append(text)
+            },
+            onError: { _ in }
+        )
+        
+        let rawOutput = outputLines.joined()
+        let tapNames = rawOutput.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        
+        taps = tapNames.map { BrewTap(name: $0) }
+        appendLog("[System] 获取到 \(taps.count) 个软件源")
+    }
+    
+    private func loadInstalledPackagesFast() async throws {
+        appendLog("[System] 正在快速获取已安装包列表...")
+        let tempRunner = self.runner
+        
+        var formulaOutput = ""
+        _ = try await tempRunner.run(
+            executable: brewPath,
+            arguments: ["list", "--formula", "--versions"],
+            onOutput: { formulaOutput += $0 },
+            onError: { _ in }
+        )
+        
+        var caskOutput = ""
+        _ = try await tempRunner.run(
+            executable: brewPath,
+            arguments: ["list", "--cask", "--versions"],
+            onOutput: { caskOutput += $0 },
+            onError: { _ in }
+        )
+        
+        var tempPackages: [BrewPackage] = []
+        
+        // Parse Formulae
+        for line in formulaOutput.components(separatedBy: .newlines) {
+            let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+            guard parts.count >= 2 else { continue }
+            let name = parts[0]
+            let version = parts[1]
+            tempPackages.append(BrewPackage(
+                name: name,
+                version: version,
+                latestVersion: version,
+                isCask: false,
+                desc: "",
+                homepage: "",
+                isOutdated: false,
+                isPinned: false
+            ))
+        }
+        
+        // Parse Casks
+        for line in caskOutput.components(separatedBy: .newlines) {
+            let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+            guard parts.count >= 2 else { continue }
+            let name = parts[0]
+            let version = parts[1]
+            tempPackages.append(BrewPackage(
+                name: name,
+                version: version,
+                latestVersion: version,
+                isCask: true,
+                desc: "",
+                homepage: "",
+                isOutdated: false,
+                isPinned: false
+            ))
+        }
+        
+        self.installedPackages = tempPackages.sorted { $0.name.lowercased() < $1.name.lowercased() }
+        appendLog("[System] 快速加载已安装包: \(installedPackages.count) 个")
+    }
+    
+    private func loadOutdatedPackages() async throws {
+        appendLog("[System] 正在获取待更新包列表...")
+        let tempRunner = self.runner
+        var jsonOutput = ""
+        
+        _ = try await tempRunner.run(
+            executable: brewPath,
+            arguments: ["outdated", "--json=v2"],
+            onOutput: { jsonOutput += $0 },
+            onError: { _ in }
+        )
+        
+        guard let data = jsonOutput.data(using: .utf8) else { return }
+        
+        struct OutdatedResponse: Codable {
+            let formulae: [OutdatedFormulaInfo]
+            let casks: [OutdatedCaskInfo]
+        }
+        struct OutdatedFormulaInfo: Codable {
+            let name: String
+            let installed_versions: [String]
+            let current_version: String
+            let pinned: Bool
+        }
+        struct OutdatedCaskInfo: Codable {
+            let name: String
+            let installed_versions: [String]
+            let current_version: String
+        }
+        
+        do {
+            let response = try JSONDecoder().decode(OutdatedResponse.self, from: data)
+            
+            var tempOutdated: [BrewPackage] = []
+            var outdatedNames = Set<String>()
+            var latestVersions: [String: String] = [:]
+            var pinnedStatus: [String: Bool] = [:]
+            
+            for item in response.formulae {
+                outdatedNames.insert(item.name)
+                latestVersions[item.name] = item.current_version
+                pinnedStatus[item.name] = item.pinned
+                
+                tempOutdated.append(BrewPackage(
+                    name: item.name,
+                    version: item.installed_versions.first ?? "",
+                    latestVersion: item.current_version,
+                    isCask: false,
+                    desc: "",
+                    homepage: "",
+                    isOutdated: true,
+                    isPinned: item.pinned
+                ))
+            }
+            
+            for item in response.casks {
+                outdatedNames.insert(item.name)
+                latestVersions[item.name] = item.current_version
+                
+                tempOutdated.append(BrewPackage(
+                    name: item.name,
+                    version: item.installed_versions.first ?? "",
+                    latestVersion: item.current_version,
+                    isCask: true,
+                    desc: "",
+                    homepage: "",
+                    isOutdated: true,
+                    isPinned: false
+                ))
+            }
+            
+            self.outdatedPackages = tempOutdated.sorted { $0.name.lowercased() < $1.name.lowercased() }
+            
+            // Update outdated flag and latestVersion in installedPackages
+            self.installedPackages = self.installedPackages.map { pkg in
+                let isOutdated = outdatedNames.contains(pkg.name)
+                let latestVer = latestVersions[pkg.name] ?? pkg.version
+                let isPinned = pinnedStatus[pkg.name] ?? pkg.isPinned
+                return BrewPackage(
+                    name: pkg.name,
+                    version: pkg.version,
+                    latestVersion: latestVer,
+                    isCask: pkg.isCask,
+                    desc: pkg.desc,
+                    homepage: pkg.homepage,
+                    isOutdated: isOutdated,
+                    isPinned: isPinned,
+                    dependencies: pkg.dependencies
+                )
+            }
+            
+            appendLog("[System] 获取到 \(outdatedPackages.count) 个待更新包")
+        } catch {
+            appendLog("[System] 解析待更新包失败: \(error.localizedDescription)", isError: true)
+        }
+    }
+    
+    private func loadPackageDetails() async throws {
+        appendLog("[System] 正在加载包详细元数据...")
+        let tempRunner = self.runner
+        var jsonOutput = ""
+        
+        _ = try await tempRunner.run(
+            executable: brewPath,
+            arguments: ["info", "--json=v2", "--installed"],
+            onOutput: { jsonOutput += $0 },
+            onError: { _ in }
+        )
+        
+        guard let data = jsonOutput.data(using: .utf8) else { return }
+        
+        struct BrewInfoResponse: Codable {
+            let formulae: [FormulaInfo]
+            let casks: [CaskInfo]
+        }
+        struct FormulaInfo: Codable {
+            let name: String
+            let desc: String?
+            let homepage: String?
+            let dependencies: [String]?
+        }
+        struct CaskInfo: Codable {
+            let token: String
+            let name: [String]?
+            let desc: String?
+            let homepage: String?
+        }
+        
+        do {
+            let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+            
+            var details: [String: (desc: String, homepage: String, deps: [String])] = [:]
+            for item in response.formulae {
+                details[item.name] = (
+                    desc: item.desc ?? "",
+                    homepage: item.homepage ?? "",
+                    deps: item.dependencies ?? []
+                )
+            }
+            for item in response.casks {
+                details[item.token] = (
+                    desc: item.desc ?? (item.name?.first ?? ""),
+                    homepage: item.homepage ?? "",
+                    deps: []
+                )
+            }
+            
+            // Map details back to installedPackages and outdatedPackages
+            self.installedPackages = self.installedPackages.map { pkg in
+                if let detail = details[pkg.name] {
+                    return BrewPackage(
+                        name: pkg.name,
+                        version: pkg.version,
+                        latestVersion: pkg.latestVersion,
+                        isCask: pkg.isCask,
+                        desc: detail.desc,
+                        homepage: detail.homepage,
+                        isOutdated: pkg.isOutdated,
+                        isPinned: pkg.isPinned,
+                        dependencies: detail.deps
+                    )
+                }
+                return pkg
+            }
+            
+            self.outdatedPackages = self.outdatedPackages.map { pkg in
+                if let detail = details[pkg.name] {
+                    return BrewPackage(
+                        name: pkg.name,
+                        version: pkg.version,
+                        latestVersion: pkg.latestVersion,
+                        isCask: pkg.isCask,
+                        desc: detail.desc,
+                        homepage: detail.homepage,
+                        isOutdated: pkg.isOutdated,
+                        isPinned: pkg.isPinned,
+                        dependencies: detail.deps
+                    )
+                }
+                return pkg
+            }
+            
+            appendLog("[System] 包详细元数据加载完成")
+        } catch {
+            appendLog("[System] 解析详细元数据失败: \(error.localizedDescription)", isError: true)
+        }
+    }
+    
+    // MARK: - Search
+    
+    public func search(query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            searchResults.removeAll()
+            return
+        }
+        
+        searchQuery = trimmed
+        isSearching = true
+        searchResults.removeAll()
+        
+        Task {
+            do {
+                let tempRunner = self.runner
+                
+                // Search formulae
+                var formulaOutput = ""
+                _ = try await tempRunner.run(
+                    executable: brewPath,
+                    arguments: ["search", "--formula", trimmed],
+                    onOutput: { formulaOutput += $0 },
+                    onError: { _ in }
+                )
+                
+                // Search casks
+                var caskOutput = ""
+                _ = try await tempRunner.run(
+                    executable: brewPath,
+                    arguments: ["search", "--cask", trimmed],
+                    onOutput: { caskOutput += $0 },
+                    onError: { _ in }
+                )
+                
+                var results: [BrewPackage] = []
+                
+                let formulae = formulaOutput.components(separatedBy: .newlines)
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                
+                let casks = caskOutput.components(separatedBy: .newlines)
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                
+                for f in formulae {
+                    results.append(BrewPackage(
+                        name: f,
+                        version: "",
+                        latestVersion: "",
+                        isCask: false,
+                        desc: "",
+                        homepage: "",
+                        isOutdated: false,
+                        isPinned: false
+                    ))
+                }
+                
+                for c in casks {
+                    results.append(BrewPackage(
+                        name: c,
+                        version: "",
+                        latestVersion: "",
+                        isCask: true,
+                        desc: "",
+                        homepage: "",
+                        isOutdated: false,
+                        isPinned: false
+                    ))
+                }
+                
+                self.searchResults = results.sorted { $0.name.lowercased() < $1.name.lowercased() }
+            } catch {}
+            
+            isSearching = false
+        }
+    }
+    
+    // MARK: - Package Actions
+    
+    public func install(package: BrewPackage) {
+        runAsyncCommand(
+            name: "正在安装 \(package.name)...",
+            args: [package.isCask ? "--cask" : nil, "install", package.name].compactMap { $0 }
+        ) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    public func uninstall(package: BrewPackage) {
+        runAsyncCommand(
+            name: "正在卸载 \(package.name)...",
+            args: [package.isCask ? "--cask" : nil, "uninstall", package.name].compactMap { $0 }
+        ) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    public func upgrade(package: BrewPackage) {
+        runAsyncCommand(
+            name: "正在更新 \(package.name)...",
+            args: [package.isCask ? "--cask" : nil, "upgrade", package.name].compactMap { $0 }
+        ) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    public func pin(package: BrewPackage) {
+        runAsyncCommand(
+            name: "正在锁定 \(package.name)...",
+            args: ["pin", package.name]
+        ) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    public func unpin(package: BrewPackage) {
+        runAsyncCommand(
+            name: "正在解锁 \(package.name)...",
+            args: ["unpin", package.name]
+        ) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    // MARK: - Global Operations
+    
+    public func upgradeAll() {
+        runAsyncCommand(name: "正在更新所有包...", args: ["upgrade"]) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    public func updateBrew() {
+        runAsyncCommand(name: "正在更新 Homebrew 源...", args: ["update"]) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    public func runDoctor() {
+        runAsyncCommand(name: "正在运行 Homebrew 诊断 (Doctor)...", args: ["doctor"]) { _ in }
+    }
+    
+    public func runCleanup() {
+        runAsyncCommand(name: "正在清理 Homebrew 缓存...", args: ["cleanup"]) { _ in }
+    }
+    
+    // MARK: - Tap Actions
+    
+    public func tapRepository(name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        runAsyncCommand(name: "正在启用软件源 \(trimmed)...", args: ["tap", trimmed]) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    public func untapRepository(tap: BrewTap) {
+        runAsyncCommand(name: "正在注销软件源 \(tap.name)...", args: ["untap", tap.name]) { [weak self] success in
+            if success {
+                self?.scanAll()
+            }
+        }
+    }
+    
+    // MARK: - Process Execution
+    
+    private func runAsyncCommand(
+        name: String,
+        args: [String],
+        completion: @escaping @MainActor (Bool) -> Void
+    ) {
+        guard isBrewAvailable, !isBusy else { return }
+        isBusy = true
+        currentOperationName = name
+        clearLogs()
+        appendLog("[Command] brew \(args.joined(separator: " "))")
+        
+        Task {
+            do {
+                let status = try await runner.run(
+                    executable: brewPath,
+                    arguments: args,
+                    onOutput: { [weak self] text in
+                        self?.appendLog(text)
+                    },
+                    onError: { [weak self] text in
+                        self?.appendLog(text, isError: true)
+                    }
+                )
+                
+                let success = (status == 0)
+                appendLog(success ? "[System] 操作成功完成" : "[System] 操作失败，错误码: \(status)", isError: !success)
+                completion(success)
+            } catch {
+                appendLog("[System] 执行命令出错: \(error.localizedDescription)", isError: true)
+                completion(false)
+            }
+            isBusy = false
+            currentOperationName = ""
+            onStateChange?()
+        }
+    }
+    
+    public func cancelCurrentOperation() {
+        Task {
+            await runner.cancel()
+            appendLog("[System] 操作已被用户取消", isError: true)
+            isBusy = false
+            currentOperationName = ""
+            onStateChange?()
+        }
+    }
+}

--- a/Plugins/Homebrew/Sources/HomebrewController.swift
+++ b/Plugins/Homebrew/Sources/HomebrewController.swift
@@ -35,6 +35,18 @@ public final class HomebrewController: ObservableObject {
         } else if let path = discoverBrewPath() {
             self.brewPath = path
             self.isBrewAvailable = true
+        } else {
+            Task { [weak self] in
+                guard let self = self else { return }
+                if let path = await self.discoverBrewPathViaShell() {
+                    self.brewPath = path
+                    self.isBrewAvailable = true
+                    self.onStateChange?()
+                    if self.installedPackages.isEmpty {
+                        self.scanAll()
+                    }
+                }
+            }
         }
     }
     
@@ -46,11 +58,23 @@ public final class HomebrewController: ObservableObject {
                 self.brewPath = path
                 self.isBrewAvailable = true
                 scanAll()
+                onStateChange?()
             } else {
                 self.brewPath = ""
                 self.isBrewAvailable = false
+                onStateChange?()
+                Task { [weak self] in
+                    guard let self = self else { return }
+                    if let path = await self.discoverBrewPathViaShell() {
+                        self.brewPath = path
+                        self.isBrewAvailable = true
+                        self.onStateChange?()
+                        if self.installedPackages.isEmpty {
+                            self.scanAll()
+                        }
+                    }
+                }
             }
-            onStateChange?()
             return
         }
         
@@ -99,21 +123,49 @@ public final class HomebrewController: ObservableObject {
             }
         }
         
-        // Fallback: try finding via zsh login shell
+        return nil
+    }
+    
+    private func discoverBrewPathViaShell() async -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-l", "-c", "which brew"]
         let pipe = Pipe()
         process.standardOutput = pipe
+        
         do {
             try process.run()
-            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+        
+        let timeoutTask = Task {
+            try? await Task.sleep(for: .seconds(3.0))
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+        
+        let exitCode: Int32 = await withCheckedContinuation { continuation in
+            process.terminationHandler = { proc in
+                continuation.resume(returning: proc.terminationStatus)
+            }
+            if !process.isRunning {
+                process.terminationHandler = nil
+                continuation.resume(returning: process.terminationStatus)
+            }
+        }
+        
+        timeoutTask.cancel()
+        
+        if exitCode == 0 {
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty, path.contains("/") {
                 return path
             }
-        } catch {}
+        }
+        
         return nil
     }
     
@@ -526,7 +578,7 @@ public final class HomebrewController: ObservableObject {
     public func install(package: BrewPackage) {
         runAsyncCommand(
             name: "正在安装 \(package.name)...",
-            args: [package.isCask ? "--cask" : nil, "install", package.name].compactMap { $0 }
+            args: ["install"] + (package.isCask ? ["--cask"] : []) + [package.name]
         ) { [weak self] success in
             if success {
                 self?.scanAll()
@@ -537,7 +589,7 @@ public final class HomebrewController: ObservableObject {
     public func uninstall(package: BrewPackage) {
         runAsyncCommand(
             name: "正在卸载 \(package.name)...",
-            args: [package.isCask ? "--cask" : nil, "uninstall", package.name].compactMap { $0 }
+            args: ["uninstall"] + (package.isCask ? ["--cask"] : []) + [package.name]
         ) { [weak self] success in
             if success {
                 self?.scanAll()
@@ -548,7 +600,7 @@ public final class HomebrewController: ObservableObject {
     public func upgrade(package: BrewPackage) {
         runAsyncCommand(
             name: "正在更新 \(package.name)...",
-            args: [package.isCask ? "--cask" : nil, "upgrade", package.name].compactMap { $0 }
+            args: ["upgrade"] + (package.isCask ? ["--cask"] : []) + [package.name]
         ) { [weak self] success in
             if success {
                 self?.scanAll()
@@ -638,6 +690,7 @@ public final class HomebrewController: ObservableObject {
         appendLog("[Command] brew \(args.joined(separator: " "))")
         
         Task {
+            let success: Bool
             do {
                 let status = try await runner.run(
                     executable: brewPath,
@@ -650,16 +703,17 @@ public final class HomebrewController: ObservableObject {
                     }
                 )
                 
-                let success = (status == 0)
+                success = (status == 0)
                 appendLog(success ? "[System] 操作成功完成" : "[System] 操作失败，错误码: \(status)", isError: !success)
-                completion(success)
             } catch {
                 appendLog("[System] 执行命令出错: \(error.localizedDescription)", isError: true)
-                completion(false)
+                success = false
             }
+            
             isBusy = false
             currentOperationName = ""
             onStateChange?()
+            completion(success)
         }
     }
     

--- a/Plugins/Homebrew/Sources/HomebrewDetailView.swift
+++ b/Plugins/Homebrew/Sources/HomebrewDetailView.swift
@@ -1,0 +1,996 @@
+import SwiftUI
+import MacToolsPluginKit
+
+struct HomebrewDetailView: View {
+    @ObservedObject var controller: HomebrewController
+    private let localization: PluginLocalization
+    private let showsHeader: Bool
+    private let contentPadding: CGFloat
+    private let minimumContentHeight: CGFloat
+    
+    @State private var activeTab: BrewTabSection = .installed
+    @State private var installedFilter: BrewPackageFilter = .all
+    @State private var localSearchText = ""
+    @State private var onlineSearchText = ""
+    @State private var newTapName = ""
+    
+    @State private var selectedInstalledPkg: BrewPackage?
+    @State private var selectedSearchPkg: BrewPackage?
+    @State private var onlinePackageDetail: BrewPackage?
+    @State private var isFetchingOnlineDetail = false
+    @State private var customBrewPath = ""
+    
+    enum BrewTabSection: String, CaseIterable, Identifiable {
+        case installed
+        case search
+        case taps
+        case diagnostics
+        
+        var id: String { rawValue }
+        
+        func title(localization: PluginLocalization) -> String {
+            switch self {
+            case .installed: return localization.string("detail.tabs.installed", defaultValue: "Installed")
+            case .search: return localization.string("detail.tabs.search", defaultValue: "Search")
+            case .taps: return localization.string("detail.tabs.taps", defaultValue: "Taps")
+            case .diagnostics: return localization.string("detail.tabs.diagnostics", defaultValue: "Diagnostics")
+            }
+        }
+        
+        var icon: String {
+            switch self {
+            case .installed: return "shippingbox.fill"
+            case .search: return "magnifyingglass"
+            case .taps: return "square.stack.3d.up.fill"
+            case .diagnostics: return "wrench.and.screwdriver.fill"
+            }
+        }
+    }
+    
+    enum BrewPackageFilter: String, CaseIterable, Identifiable {
+        case all
+        case formula
+        case cask
+        
+        var id: String { rawValue }
+        
+        func title(localization: PluginLocalization) -> String {
+            switch self {
+            case .all: return localization.string("detail.filter.all", defaultValue: "All")
+            case .formula: return localization.string("detail.filter.formula", defaultValue: "Formula")
+            case .cask: return localization.string("detail.filter.cask", defaultValue: "Cask")
+            }
+        }
+    }
+    
+    init(
+        controller: HomebrewController,
+        localization: PluginLocalization = PluginLocalization(bundle: .main),
+        showsHeader: Bool = true,
+        contentPadding: CGFloat = 16,
+        minimumContentHeight: CGFloat = 450
+    ) {
+        self.controller = controller
+        self.localization = localization
+        self.showsHeader = showsHeader
+        self.contentPadding = contentPadding
+        self.minimumContentHeight = minimumContentHeight
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if showsHeader {
+                header
+                    .padding(.horizontal, contentPadding)
+                    .padding(.top, contentPadding)
+            }
+            
+            if !controller.isBrewAvailable {
+                pathNotFoundView
+            } else {
+                // Tab Selector
+                tabBar
+                    .padding(.horizontal, contentPadding)
+                    .padding(.vertical, 8)
+                
+                Divider()
+                
+                // Main Content Area
+                GeometryReader { geo in
+                    VStack(spacing: 0) {
+                        Group {
+                            switch activeTab {
+                            case .installed:
+                                installedTabContent
+                            case .search:
+                                searchTabContent
+                            case .taps:
+                                tapsTabContent
+                            case .diagnostics:
+                                diagnosticsTabContent
+                            }
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        
+                        // Console Output Drawer
+                        if !controller.logs.isEmpty {
+                            consoleDrawer
+                                .frame(height: 140)
+                                .transition(.move(edge: .bottom))
+                        }
+                    }
+                }
+            }
+        }
+        .frame(minHeight: minimumContentHeight)
+        .onAppear {
+            customBrewPath = controller.brewPath
+            if controller.isBrewAvailable && controller.installedPackages.isEmpty && !controller.isBusy {
+                controller.scanAll()
+            }
+        }
+        .onChange(of: controller.brewPath) { _, newPath in
+            customBrewPath = newPath
+        }
+    }
+    
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(localization.string("detail.title", defaultValue: "Homebrew Manager"))
+                    .font(PluginSettingsTheme.Typography.pageTitle)
+                Text(localization.string("detail.subtitle", defaultValue: "Manage Homebrew packages, applications, and repositories visually"))
+                    .font(PluginSettingsTheme.Typography.pageDescription)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            
+            if controller.isBusy {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(controller.currentOperationName)
+                        .font(PluginSettingsTheme.Typography.rowDescription)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .pluginSettingsCardBackground(.recessed)
+            }
+        }
+    }
+    
+    private var tabBar: some View {
+        HStack(spacing: 8) {
+            ForEach(BrewTabSection.allCases) { section in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        activeTab = section
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: section.icon)
+                        Text(section.title(localization: localization))
+                    }
+                    .font(.body.weight(activeTab == section ? .semibold : .regular))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(activeTab == section ? Color.accentColor.opacity(0.15) : Color.clear)
+                    )
+                    .foregroundStyle(activeTab == section ? Color.accentColor : Color.primary)
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer()
+        }
+    }
+    
+    // MARK: - Tab Contents
+    
+    private var installedTabContent: some View {
+        HStack(spacing: 12) {
+            // Left List Column
+            VStack(spacing: 8) {
+                // Search & Filter
+                HStack(spacing: 8) {
+                    TextField(localization.string("detail.search.placeholder", defaultValue: "Search installed packages..."), text: $localSearchText)
+                        .textFieldStyle(.roundedBorder)
+                        .controlSize(.regular)
+                    
+                    Picker("", selection: $installedFilter) {
+                        ForEach(BrewPackageFilter.allCases) { filter in
+                            Text(filter.title(localization: localization)).tag(filter)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 100)
+                }
+                .padding(.horizontal, 4)
+                
+                // Package List
+                let filtered = controller.installedPackages.filter { pkg in
+                    let matchesText = localSearchText.isEmpty || pkg.name.localizedCaseInsensitiveContains(localSearchText) || pkg.desc.localizedCaseInsensitiveContains(localSearchText)
+                    let matchesFilter = (installedFilter == .all) ||
+                        (installedFilter == .formula && !pkg.isCask) ||
+                        (installedFilter == .cask && pkg.isCask)
+                    return matchesText && matchesFilter
+                }
+                
+                if filtered.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "shippingbox")
+                            .font(.system(size: 24))
+                            .foregroundStyle(.secondary)
+                        Text(localization.string("detail.search.noMatch", defaultValue: "No matching installed packages"))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .pluginSettingsCardBackground(.recessed)
+                } else {
+                    List(filtered, selection: $selectedInstalledPkg) { pkg in
+                        HStack {
+                            Image(systemName: pkg.isCask ? "macwindow" : "terminal")
+                                .foregroundStyle(pkg.isCask ? .blue : .green)
+                                .font(.system(size: 13))
+                            
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(pkg.name)
+                                    .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
+                                if !pkg.desc.isEmpty {
+                                    Text(pkg.desc)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                            Spacer()
+                            
+                            if pkg.isOutdated {
+                                Text(localization.string("detail.search.hasUpdate", defaultValue: "Update Available"))
+                                    .font(PluginSettingsTheme.Typography.statusBadge)
+                                    .padding(.horizontal, 5)
+                                    .padding(.vertical, 1)
+                                    .background(Color.orange.opacity(0.15), in: Capsule())
+                                    .foregroundStyle(.orange)
+                            }
+                            
+                            Text(pkg.version)
+                                .font(PluginSettingsTheme.Typography.monospacedValue)
+                                .foregroundStyle(.secondary)
+                        }
+                        .tag(pkg)
+                        .padding(.vertical, 2)
+                    }
+                    .listStyle(.inset)
+                    .pluginSettingsCardBackground(.recessed)
+                }
+            }
+            .frame(width: 320)
+            
+            // Right Detail Column
+            VStack {
+                if let pkg = selectedInstalledPkg {
+                    packageDetailView(for: pkg)
+                } else {
+                    VStack(spacing: 8) {
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 32))
+                            .foregroundStyle(.secondary)
+                        Text(localization.string("detail.detail.selectionHint", defaultValue: "Select an installed package to view details"))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .pluginSettingsCardBackground(.host)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.horizontal, contentPadding)
+        .padding(.bottom, contentPadding)
+    }
+    
+    private var searchTabContent: some View {
+        HStack(spacing: 12) {
+            // Left List Column
+            VStack(spacing: 8) {
+                // Search bar
+                HStack {
+                    TextField(localization.string("detail.search.onlinePlaceholder", defaultValue: "Search online formulae or casks..."), text: $onlineSearchText, onCommit: {
+                        controller.search(query: onlineSearchText)
+                    })
+                    .textFieldStyle(.roundedBorder)
+                    .controlSize(.regular)
+                    
+                    Button(localization.string("detail.search.button", defaultValue: "Search")) {
+                        controller.search(query: onlineSearchText)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(onlineSearchText.isEmpty || controller.isSearching)
+                }
+                .padding(.horizontal, 4)
+                
+                if controller.isSearching {
+                    VStack {
+                        ProgressView()
+                        Text(localization.string("detail.search.searching", defaultValue: "Searching Homebrew..."))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 8)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .pluginSettingsCardBackground(.recessed)
+                } else if controller.searchResults.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 24))
+                            .foregroundStyle(.secondary)
+                        Text(localization.string("detail.search.empty", defaultValue: "Enter keywords to search on Homebrew"))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .pluginSettingsCardBackground(.recessed)
+                } else {
+                    List(controller.searchResults, selection: $selectedSearchPkg) { pkg in
+                        HStack {
+                            Image(systemName: pkg.isCask ? "macwindow" : "terminal")
+                                .foregroundStyle(pkg.isCask ? .blue : .green)
+                            Text(pkg.name)
+                                .font(PluginSettingsTheme.Typography.rowTitle)
+                            Spacer()
+                            Text(pkg.isCask ? "Cask" : "Formula")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .tag(pkg)
+                        .padding(.vertical, 2)
+                    }
+                    .listStyle(.inset)
+                    .pluginSettingsCardBackground(.recessed)
+                    .onChange(of: selectedSearchPkg) { _, newPkg in
+                        if let pkg = newPkg {
+                            fetchOnlinePackageDetail(pkg)
+                        }
+                    }
+                }
+            }
+            .frame(width: 320)
+            
+            // Right Detail Column
+            VStack {
+                if isFetchingOnlineDetail {
+                    VStack {
+                        ProgressView()
+                        Text(localization.string("detail.search.fetchingDetail", defaultValue: "Fetching detailed metadata..."))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 8)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .pluginSettingsCardBackground(.host)
+                } else if let pkg = onlinePackageDetail {
+                    onlinePackageDetailView(for: pkg)
+                } else {
+                    VStack(spacing: 8) {
+                        Image(systemName: "plus.circle")
+                            .font(.system(size: 32))
+                            .foregroundStyle(.secondary)
+                        Text(localization.string("detail.detail.onlineHint", defaultValue: "Select search result to install package"))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .pluginSettingsCardBackground(.host)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.horizontal, contentPadding)
+        .padding(.bottom, contentPadding)
+    }
+    
+    private var tapsTabContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Add Tap Card
+            VStack(alignment: .leading, spacing: 8) {
+                Text(localization.string("detail.taps.titleAdd", defaultValue: "Add Tap Repository"))
+                    .font(PluginSettingsTheme.Typography.sectionTitle)
+                    .foregroundStyle(.secondary)
+                
+                HStack {
+                    TextField(localization.string("detail.taps.placeholderAdd", defaultValue: "Enter tap path (e.g., user/repo or repository URL)"), text: $newTapName)
+                        .textFieldStyle(.roundedBorder)
+                        .controlSize(.regular)
+                    
+                    Button(localization.string("detail.taps.buttonAdd", defaultValue: "Add")) {
+                        controller.tapRepository(name: newTapName)
+                        newTapName = ""
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(newTapName.isEmpty || controller.isBusy)
+                }
+            }
+            .padding(12)
+            .pluginSettingsCardBackground(.host)
+            
+            // Active Taps List
+            VStack(alignment: .leading, spacing: 8) {
+                Text(String(format: localization.string("detail.taps.titleList", defaultValue: "Active Taps (%d)"), controller.taps.count))
+                    .font(PluginSettingsTheme.Typography.sectionTitle)
+                    .foregroundStyle(.secondary)
+                
+                if controller.taps.isEmpty {
+                    Text(localization.string("detail.taps.empty", defaultValue: "No active tap repositories"))
+                        .font(PluginSettingsTheme.Typography.rowDescription)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, minHeight: 60)
+                } else {
+                    ScrollView {
+                        VStack(spacing: 6) {
+                            ForEach(controller.taps) { tap in
+                                HStack {
+                                    Image(systemName: "square.stack.3d.up")
+                                        .foregroundStyle(.secondary)
+                                    Text(tap.name)
+                                        .font(PluginSettingsTheme.Typography.rowTitle)
+                                    Spacer()
+                                    
+                                    Button(localization.string("detail.taps.buttonUntap", defaultValue: "Untap")) {
+                                        controller.untapRepository(tap: tap)
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.small)
+                                    .disabled(controller.isBusy)
+                                }
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 6)
+                                .background(Color.primary.opacity(0.02))
+                                .cornerRadius(6)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: .infinity)
+                }
+            }
+            .padding(12)
+            .pluginSettingsCardBackground(.host)
+        }
+        .padding(.horizontal, contentPadding)
+        .padding(.bottom, contentPadding)
+    }
+    
+    private var diagnosticsTabContent: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                // Path Config Card
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(localization.string("detail.diagnostics.pathTitle", defaultValue: "Homebrew Path Configuration"))
+                        .font(PluginSettingsTheme.Typography.sectionTitle)
+                        .foregroundStyle(.secondary)
+                    
+                    HStack {
+                        TextField(localization.string("detail.diagnostics.pathPlaceholder", defaultValue: "Path to brew executable (e.g. /opt/homebrew/bin/brew)"), text: $customBrewPath)
+                            .textFieldStyle(.roundedBorder)
+                            .controlSize(.regular)
+                        
+                        Button(localization.string("detail.diagnostics.pathApply", defaultValue: "Apply")) {
+                            controller.updateCustomPath(customBrewPath)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(customBrewPath == controller.brewPath || customBrewPath.isEmpty)
+                    }
+                }
+                .padding(12)
+                .pluginSettingsCardBackground(.host)
+
+                diagnosticRow(
+                    title: localization.string("detail.diagnostics.update.title", defaultValue: "Update Repositories (brew update)"),
+                    description: localization.string("detail.diagnostics.update.desc", defaultValue: "Sync the latest list of formulas and casks from remote servers."),
+                    icon: "arrow.clockwise.circle.fill",
+                    color: .blue,
+                    action: { controller.updateBrew() }
+                )
+                
+                diagnosticRow(
+                    title: localization.string("detail.diagnostics.upgrade.title", defaultValue: "Upgrade All Outdated Packages (brew upgrade)"),
+                    description: localization.string("detail.diagnostics.upgrade.desc", defaultValue: "Upgrade all outdated formulas and casks currently detected on your system."),
+                    icon: "arrow.up.circle.fill",
+                    color: .orange,
+                    action: { controller.upgradeAll() }
+                )
+                
+                diagnosticRow(
+                    title: localization.string("detail.diagnostics.doctor.title", defaultValue: "Health Diagnostics (brew doctor)"),
+                    description: localization.string("detail.diagnostics.doctor.desc", defaultValue: "Diagnose potential issues with environment variables, permissions, and build paths."),
+                    icon: "heart.text.square.fill",
+                    color: .green,
+                    action: { controller.runDoctor() }
+                )
+                
+                diagnosticRow(
+                    title: localization.string("detail.diagnostics.cleanup.title", defaultValue: "Cleanup Trash & Caches (brew cleanup)"),
+                    description: localization.string("detail.diagnostics.cleanup.desc", defaultValue: "Remove outdated local downloads and caches to reclaim disk space."),
+                    icon: "trash.circle.fill",
+                    color: .red,
+                    action: { controller.runCleanup() }
+                )
+            }
+            .padding(.bottom, 8)
+        }
+        .padding(.horizontal, contentPadding)
+        .padding(.bottom, contentPadding)
+    }
+
+    private var pathNotFoundView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.orange)
+            
+            Text(localization.string("detail.diagnostics.pathNotFoundTitle", defaultValue: "Homebrew Not Detected"))
+                .font(PluginSettingsTheme.Typography.pageTitle)
+            
+            Text(localization.string("detail.diagnostics.pathNotFoundDesc", defaultValue: "Homebrew was not found in standard system directories. Please ensure it is installed or provide the custom path to the 'brew' executable below:"))
+                .font(PluginSettingsTheme.Typography.rowDescription)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 480)
+            
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    TextField(localization.string("detail.diagnostics.pathPlaceholder", defaultValue: "Path to brew executable (e.g. /opt/homebrew/bin/brew)"), text: $customBrewPath)
+                        .textFieldStyle(.roundedBorder)
+                        .controlSize(.regular)
+                    
+                    Button(localization.string("detail.diagnostics.pathApply", defaultValue: "Apply")) {
+                        controller.updateCustomPath(customBrewPath)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(customBrewPath.isEmpty)
+                }
+            }
+            .frame(maxWidth: 480)
+            
+            VStack(alignment: .leading, spacing: 6) {
+                Text(localization.string("detail.diagnostics.pathHelpTitle", defaultValue: "Common Installation Locations:"))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text("• Apple Silicon Mac: /opt/homebrew/bin/brew")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("• Intel Mac: /usr/local/bin/brew")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 12)
+            Spacer()
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .pluginSettingsCardBackground(.host)
+    }
+    
+    private func diagnosticRow(
+        title: String,
+        description: String,
+        icon: String,
+        color: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 28))
+                .foregroundStyle(color)
+                .frame(width: 36)
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
+                Text(description)
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            
+            Button(localization.string("detail.diagnostics.buttonExecute", defaultValue: "Execute")) {
+                action()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+            .disabled(controller.isBusy)
+        }
+        .padding(12)
+        .pluginSettingsCardBackground(.host)
+    }
+    
+    // MARK: - Component Views
+    
+    private func packageDetailView(for pkg: BrewPackage) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Image(systemName: pkg.isCask ? "macwindow" : "terminal")
+                    .font(.system(size: 20))
+                    .foregroundStyle(pkg.isCask ? .blue : .green)
+                
+                Text(pkg.name)
+                    .font(PluginSettingsTheme.Typography.pageTitle)
+                Spacer()
+                
+                if pkg.isPinned {
+                    Label(localization.string("detail.detail.pinned", defaultValue: "Pinned"), systemImage: "pin.fill")
+                        .font(PluginSettingsTheme.Typography.statusBadge)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.yellow.opacity(0.15))
+                        .foregroundStyle(.yellow)
+                        .cornerRadius(4)
+                }
+            }
+            
+            if !pkg.desc.isEmpty {
+                Text(pkg.desc)
+                    .font(PluginSettingsTheme.Typography.rowTitle)
+                    .foregroundStyle(.secondary)
+            }
+            
+            VStack(spacing: 8) {
+                infoRow(label: localization.string("detail.detail.type", defaultValue: "Type"), value: pkg.isCask ? localization.string("detail.detail.typeCask", defaultValue: "GUI App (Cask)") : localization.string("detail.detail.typeFormula", defaultValue: "CLI Package (Formula)"))
+                infoRow(label: localization.string("detail.detail.installedVer", defaultValue: "Installed"), value: pkg.version)
+                infoRow(label: localization.string("detail.detail.latestVer", defaultValue: "Latest"), value: pkg.latestVersion)
+                if !pkg.homepage.isEmpty {
+                    HStack {
+                        Text(localization.string("detail.detail.website", defaultValue: "Homepage")).font(PluginSettingsTheme.Typography.rowDescription).foregroundStyle(.secondary)
+                        Spacer()
+                        Link(pkg.homepage, destination: URL(string: pkg.homepage)!)
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            .padding(10)
+            .pluginSettingsCardBackground(.recessed)
+            
+            if !pkg.dependencies.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(String(format: localization.string("detail.detail.dependencies", defaultValue: "Dependencies (%d)"), pkg.dependencies.count))
+                        .font(PluginSettingsTheme.Typography.sectionTitle)
+                        .foregroundStyle(.secondary)
+                    
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ForEach(pkg.dependencies, id: \.self) { dep in
+                                Button {
+                                    navigateToPackage(name: dep)
+                                } label: {
+                                    Text(dep)
+                                        .font(PluginSettingsTheme.Typography.monospacedValue)
+                                        .padding(.horizontal, 6)
+                                        .padding(.vertical, 2)
+                                        .background(Color.primary.opacity(0.05))
+                                        .cornerRadius(4)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                }
+            }
+
+            let usedBy = pkg.requiredBy(in: controller.installedPackages)
+            if !usedBy.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(String(format: localization.string("detail.detail.usedBy", defaultValue: "Required By (%d)"), usedBy.count))
+                        .font(PluginSettingsTheme.Typography.sectionTitle)
+                        .foregroundStyle(.secondary)
+                    
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ForEach(usedBy, id: \.self) { parent in
+                                Button {
+                                    navigateToPackage(name: parent)
+                                } label: {
+                                    Text(parent)
+                                        .font(PluginSettingsTheme.Typography.monospacedValue)
+                                        .padding(.horizontal, 6)
+                                        .padding(.vertical, 2)
+                                        .background(Color.primary.opacity(0.05))
+                                        .cornerRadius(4)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                }
+            }
+            
+            Spacer()
+            
+            // Actions
+            HStack(spacing: 10) {
+                if pkg.isOutdated {
+                    Button {
+                        controller.upgrade(package: pkg)
+                    } label: {
+                        Label(localization.string("detail.detail.actionUpgrade", defaultValue: "Upgrade"), systemImage: "arrow.up.circle")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                    .disabled(controller.isBusy)
+                }
+                
+                if !pkg.isPinned {
+                    Button {
+                        if pkg.isPinned {
+                            controller.unpin(package: pkg)
+                        } else {
+                            controller.pin(package: pkg)
+                        }
+                    } label: {
+                        Label(pkg.isPinned ? localization.string("detail.detail.actionUnpin", defaultValue: "Unpin") : localization.string("detail.detail.actionPin", defaultValue: "Pin Version"), systemImage: pkg.isPinned ? "pin.slash" : "pin")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+                    .disabled(controller.isBusy)
+                } else {
+                    Button {
+                        if pkg.isPinned {
+                            controller.unpin(package: pkg)
+                        } else {
+                            controller.pin(package: pkg)
+                        }
+                    } label: {
+                        Label(pkg.isPinned ? localization.string("detail.detail.actionUnpin", defaultValue: "Unpin") : localization.string("detail.detail.actionPin", defaultValue: "Pin Version"), systemImage: pkg.isPinned ? "pin.slash" : "pin")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+                    .disabled(controller.isBusy)
+                }
+                
+                Button(role: .destructive) {
+                    controller.uninstall(package: pkg)
+                } label: {
+                    Label(localization.string("detail.detail.actionUninstall", defaultValue: "Uninstall"), systemImage: "trash")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+                .disabled(controller.isBusy)
+            }
+        }
+        .padding(14)
+        .pluginSettingsCardBackground(.host)
+    }
+    
+    private func onlinePackageDetailView(for pkg: BrewPackage) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Image(systemName: pkg.isCask ? "macwindow" : "terminal")
+                    .font(.system(size: 20))
+                    .foregroundStyle(pkg.isCask ? .blue : .green)
+                
+                Text(pkg.name)
+                    .font(PluginSettingsTheme.Typography.pageTitle)
+                Spacer()
+            }
+            
+            if !pkg.desc.isEmpty {
+                Text(pkg.desc)
+                    .font(PluginSettingsTheme.Typography.rowTitle)
+                    .foregroundStyle(.secondary)
+            }
+            
+            VStack(spacing: 8) {
+                infoRow(label: localization.string("detail.detail.type", defaultValue: "Type"), value: pkg.isCask ? "Cask" : "Formula")
+                infoRow(label: localization.string("detail.detail.latestAvailableVer", defaultValue: "Latest Available"), value: pkg.latestVersion)
+                if !pkg.homepage.isEmpty {
+                    HStack {
+                        Text(localization.string("detail.detail.website", defaultValue: "Homepage")).font(PluginSettingsTheme.Typography.rowDescription).foregroundStyle(.secondary)
+                        Spacer()
+                        Link(pkg.homepage, destination: URL(string: pkg.homepage)!)
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            .padding(10)
+            .pluginSettingsCardBackground(.recessed)
+            
+            Spacer()
+            
+            // Actions
+            let alreadyInstalled = controller.installedPackages.contains { $0.name == pkg.name }
+            
+            Button {
+                controller.install(package: pkg)
+            } label: {
+                Label(alreadyInstalled ? localization.string("detail.search.installAgainAction", defaultValue: "Install Again") : localization.string("detail.search.installAction", defaultValue: "Install"), systemImage: "plus.circle")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(controller.isBusy)
+            
+            if alreadyInstalled {
+                Text(localization.string("detail.search.installedHint", defaultValue: "This package is already installed on your system."))
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+        .padding(14)
+        .pluginSettingsCardBackground(.host)
+    }
+    
+    private func infoRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(PluginSettingsTheme.Typography.rowDescription)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(PluginSettingsTheme.Typography.rowDescription)
+        }
+    }
+    
+    // MARK: - Console Output Drawer
+    
+    private var consoleDrawer: some View {
+        VStack(spacing: 0) {
+            Divider()
+            
+            // Terminal Header
+            HStack {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(controller.isBusy ? Color.green : Color.gray)
+                        .frame(width: 8, height: 8)
+                        .opacity(controller.isBusy ? 0.8 : 0.4)
+                    
+                    Text(localization.string("detail.console.title", defaultValue: "Terminal Console Logs"))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                
+                Button(localization.string("detail.console.buttonClear", defaultValue: "Clear")) {
+                    controller.clearLogs()
+                }
+                .buttonStyle(.plain)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.primary.opacity(0.05))
+                .cornerRadius(4)
+                
+                if controller.isBusy {
+                    Button(localization.string("detail.console.buttonCancel", defaultValue: "Cancel Operation")) {
+                        controller.cancelCurrentOperation()
+                    }
+                    .buttonStyle(.plain)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.red.opacity(0.1))
+                    .cornerRadius(4)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Color.primary.opacity(0.02))
+            
+            // Scrollable Console
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(controller.logs.suffix(150)) { log in
+                            Text(log.text)
+                                .font(PluginSettingsTheme.Typography.monospacedValue)
+                                .foregroundStyle(log.isError ? Color.red : Color.green)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .id(log.id)
+                        }
+                    }
+                    .padding(8)
+                }
+                .background(Color(nsColor: .textBackgroundColor).opacity(0.95))
+                .onChange(of: controller.logs.count) { _, _ in
+                    if let last = controller.logs.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func fetchOnlinePackageDetail(_ pkg: BrewPackage) {
+        isFetchingOnlineDetail = true
+        onlinePackageDetail = nil
+        
+        Task {
+            do {
+                let tempRunner = controller.runner
+                var jsonOutput = ""
+                
+                _ = try await tempRunner.run(
+                    executable: controller.brewPath,
+                    arguments: ["info", "--json=v2", pkg.name],
+                    onOutput: { jsonOutput += $0 },
+                    onError: { _ in }
+                )
+                
+                guard let data = jsonOutput.data(using: .utf8) else {
+                    isFetchingOnlineDetail = false
+                    return
+                }
+                
+                struct BrewInfoResponse: Codable {
+                    let formulae: [FormulaInfo]
+                    let casks: [CaskInfo]
+                }
+                struct FormulaInfo: Codable {
+                    let name: String
+                    let desc: String?
+                    let homepage: String?
+                    let versions: StableVersion?
+                }
+                struct StableVersion: Codable {
+                    let stable: String?
+                }
+                struct CaskInfo: Codable {
+                    let token: String
+                    let name: [String]?
+                    let desc: String?
+                    let homepage: String?
+                    let version: String?
+                }
+                
+                let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+                
+                if pkg.isCask, let cask = response.casks.first {
+                    onlinePackageDetail = BrewPackage(
+                        name: cask.token,
+                        version: "",
+                        latestVersion: cask.version ?? "",
+                        isCask: true,
+                        desc: cask.desc ?? (cask.name?.first ?? ""),
+                        homepage: cask.homepage ?? "",
+                        isOutdated: false,
+                        isPinned: false
+                    )
+                } else if let formula = response.formulae.first {
+                    onlinePackageDetail = BrewPackage(
+                        name: formula.name,
+                        version: "",
+                        latestVersion: formula.versions?.stable ?? "",
+                        isCask: false,
+                        desc: formula.desc ?? "",
+                        homepage: formula.homepage ?? "",
+                        isOutdated: false,
+                        isPinned: false
+                    )
+                }
+            } catch {}
+            
+            isFetchingOnlineDetail = false
+        }
+    }
+    
+    private func navigateToPackage(name: String) {
+        if let found = controller.installedPackages.first(where: { $0.name == name }) {
+            activeTab = .installed
+            selectedInstalledPkg = found
+        } else {
+            activeTab = .search
+            onlineSearchText = name
+            controller.search(query: name)
+        }
+    }
+}

--- a/Plugins/Homebrew/Sources/HomebrewDetailView.swift
+++ b/Plugins/Homebrew/Sources/HomebrewDetailView.swift
@@ -32,10 +32,10 @@ struct HomebrewDetailView: View {
         
         func title(localization: PluginLocalization) -> String {
             switch self {
-            case .installed: return "已安装"
-            case .search: return "搜索"
-            case .taps: return "软件源"
-            case .diagnostics: return "诊断"
+            case .installed: return localization.string("detail.tabs.installed", defaultValue: "已安装")
+            case .search: return localization.string("detail.tabs.search", defaultValue: "搜索")
+            case .taps: return localization.string("detail.tabs.taps", defaultValue: "软件源")
+            case .diagnostics: return localization.string("detail.tabs.diagnostics", defaultValue: "诊断")
             }
         }
         
@@ -58,9 +58,9 @@ struct HomebrewDetailView: View {
         
         func title(localization: PluginLocalization) -> String {
             switch self {
-            case .all: return "全部"
-            case .formula: return "Formula"
-            case .cask: return "Cask"
+            case .all: return localization.string("detail.filter.all", defaultValue: "全部")
+            case .formula: return localization.string("detail.filter.formula", defaultValue: "Formula")
+            case .cask: return localization.string("detail.filter.cask", defaultValue: "Cask")
             }
         }
     }
@@ -196,7 +196,7 @@ struct HomebrewDetailView: View {
     private var tabBar: some View {
         HStack {
             Spacer(minLength: 0)
-            Picker("视图", selection: $activeTab) {
+            Picker(localization.string("detail.tabs.picker", defaultValue: "视图"), selection: $activeTab) {
                 ForEach(BrewTabSection.allCases) { section in
                     Label(section.title(localization: localization), systemImage: section.icon)
                         .tag(section)
@@ -214,13 +214,13 @@ struct HomebrewDetailView: View {
     private var statusSummaryBar: some View {
         HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
             statusMetric(
-                title: "已安装",
+                title: localization.string("detail.status.installed", defaultValue: "已安装"),
                 value: "\(controller.installedPackages.count)",
                 systemImage: "shippingbox.fill",
                 color: Color(nsColor: .secondaryLabelColor)
             )
             statusMetric(
-                title: "可更新",
+                title: localization.string("detail.status.outdated", defaultValue: "可更新"),
                 value: "\(controller.outdatedPackages.count)",
                 systemImage: "arrow.up.circle.fill",
                 color: controller.outdatedPackages.isEmpty
@@ -234,7 +234,9 @@ struct HomebrewDetailView: View {
                 Image(systemName: "terminal")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Text(controller.brewPath.isEmpty ? "未配置 brew" : controller.brewPath)
+                Text(controller.brewPath.isEmpty
+                     ? localization.string("detail.status.brewPathMissing", defaultValue: "未配置 brew")
+                     : controller.brewPath)
                     .font(PluginSettingsTheme.Typography.monospacedValue)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -276,7 +278,7 @@ struct HomebrewDetailView: View {
         .buttonStyle(.bordered)
         .controlSize(.small)
         .disabled(!controller.isBrewAvailable || controller.isBusy)
-        .help("刷新 Homebrew 状态")
+        .help(localization.string("detail.refresh.help", defaultValue: "刷新 Homebrew 状态"))
     }
 
     private func sectionHeader(title: String, icon: String) -> some View {
@@ -327,7 +329,7 @@ struct HomebrewDetailView: View {
 
     private var installedToolbar: some View {
         HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-            TextField("搜索已安装包", text: $localSearchText)
+            TextField(localization.string("detail.search.placeholder", defaultValue: "搜索已安装包"), text: $localSearchText)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
 
@@ -341,7 +343,7 @@ struct HomebrewDetailView: View {
             .controlSize(.small)
             .frame(width: 96)
 
-            refreshButton(title: "刷新")
+            refreshButton(title: localization.string("detail.refresh.button", defaultValue: "刷新"))
         }
         .pluginSettingsListRowPadding(interactive: true)
     }
@@ -375,7 +377,7 @@ struct HomebrewDetailView: View {
             Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
 
             if pkg.isOutdated {
-                Text("可更新")
+                Text(localization.string("detail.search.hasUpdate", defaultValue: "可更新"))
                     .font(PluginSettingsTheme.Typography.statusBadge)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
@@ -398,7 +400,7 @@ struct HomebrewDetailView: View {
             } else {
                 emptyState(
                     icon: "info.circle",
-                    title: "选择一个包查看详情"
+                    title: localization.string("detail.detail.selectionHint", defaultValue: "选择一个包查看详情")
                 )
                 .pluginSettingsCardBackground(.host)
             }
@@ -411,8 +413,10 @@ struct HomebrewDetailView: View {
         return emptyState(
             icon: controller.isBusy ? "arrow.clockwise" : "shippingbox",
             title: controller.isBusy
-                ? "正在加载 Homebrew 状态"
-                : (isUnfiltered ? "尚未加载已安装包" : "没有匹配的已安装包")
+                ? localization.string("detail.search.loadingInstalled", defaultValue: "正在加载 Homebrew 状态")
+                : (isUnfiltered
+                   ? localization.string("detail.search.notLoaded", defaultValue: "尚未加载已安装包")
+                   : localization.string("detail.search.noMatch", defaultValue: "没有匹配的已安装包"))
         )
     }
 
@@ -437,7 +441,7 @@ struct HomebrewDetailView: View {
 
     private var searchToolbar: some View {
         HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-            TextField("搜索软件包", text: $onlineSearchText)
+            TextField(localization.string("detail.search.onlinePlaceholder", defaultValue: "搜索软件包"), text: $onlineSearchText)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
                 .onSubmit {
@@ -447,7 +451,7 @@ struct HomebrewDetailView: View {
             Button {
                 runOnlineSearch()
             } label: {
-                Label("搜索", systemImage: "magnifyingglass")
+                Label(localization.string("detail.search.button", defaultValue: "搜索"), systemImage: "magnifyingglass")
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
@@ -459,9 +463,9 @@ struct HomebrewDetailView: View {
     @ViewBuilder
     private var searchResultsContent: some View {
         if controller.isSearching {
-            emptyState(icon: "arrow.clockwise", title: "正在搜索 Homebrew")
+            emptyState(icon: "arrow.clockwise", title: localization.string("detail.search.searching", defaultValue: "正在搜索 Homebrew"))
         } else if controller.searchResults.isEmpty {
-            emptyState(icon: "magnifyingglass", title: "输入关键词搜索软件包")
+            emptyState(icon: "magnifyingglass", title: localization.string("detail.search.empty", defaultValue: "输入关键词搜索软件包"))
         } else {
             List(controller.searchResults, selection: $selectedSearchPkg) { pkg in
                 HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
@@ -471,7 +475,9 @@ struct HomebrewDetailView: View {
                         .font(PluginSettingsTheme.Typography.rowTitle)
                         .lineLimit(1)
                     Spacer()
-                    Text(pkg.isCask ? "Cask" : "Formula")
+                    Text(pkg.isCask
+                         ? localization.string("detail.filter.cask", defaultValue: "Cask")
+                         : localization.string("detail.filter.formula", defaultValue: "Formula"))
                         .font(PluginSettingsTheme.Typography.statusBadge)
                         .foregroundStyle(.secondary)
                 }
@@ -491,12 +497,12 @@ struct HomebrewDetailView: View {
     @ViewBuilder
     private var searchDetailPane: some View {
         if isFetchingOnlineDetail {
-            emptyState(icon: "arrow.clockwise", title: "正在加载包详情")
+            emptyState(icon: "arrow.clockwise", title: localization.string("detail.search.fetchingDetail", defaultValue: "正在加载包详情"))
                 .pluginSettingsCardBackground(.host)
         } else if let pkg = onlinePackageDetail {
             onlinePackageDetailView(for: pkg)
         } else {
-            emptyState(icon: "plus.circle", title: "选择搜索结果后安装")
+            emptyState(icon: "plus.circle", title: localization.string("detail.detail.onlineHint", defaultValue: "选择搜索结果后安装"))
                 .pluginSettingsCardBackground(.host)
         }
     }
@@ -504,10 +510,10 @@ struct HomebrewDetailView: View {
     private var tapsTabContent: some View {
         VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.section) {
             VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
-                sectionHeader(title: "添加软件源", icon: "plus.circle")
+                sectionHeader(title: localization.string("detail.taps.titleAdd", defaultValue: "添加软件源"), icon: "plus.circle")
 
                 HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-                    TextField("user/repo 或仓库 URL", text: $newTapName)
+                    TextField(localization.string("detail.taps.placeholderAdd", defaultValue: "user/repo 或仓库 URL"), text: $newTapName)
                         .textFieldStyle(.roundedBorder)
                         .controlSize(.small)
 
@@ -516,7 +522,7 @@ struct HomebrewDetailView: View {
                         guard !trimmed.isEmpty else { return }
                         pendingAction = .tap(trimmed)
                     } label: {
-                        Label("添加", systemImage: "plus")
+                        Label(localization.string("detail.taps.buttonAdd", defaultValue: "添加"), systemImage: "plus")
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
@@ -527,7 +533,10 @@ struct HomebrewDetailView: View {
             }
 
             VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
-                sectionHeader(title: "已启用软件源（\(controller.taps.count)）", icon: "square.stack.3d.up")
+                sectionHeader(
+                    title: localization.format("detail.taps.titleList", defaultValue: "已启用软件源（%d）", controller.taps.count),
+                    icon: "square.stack.3d.up"
+                )
                 tapListCard
             }
             .frame(maxHeight: .infinity, alignment: .top)
@@ -544,7 +553,7 @@ struct HomebrewDetailView: View {
                 HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
                     Image(systemName: "square.stack.3d.up")
                         .pluginSettingsRowIconStyle()
-                    Text("暂无软件源")
+                    Text(localization.string("detail.taps.empty", defaultValue: "暂无软件源"))
                         .font(PluginSettingsTheme.Typography.rowDescription)
                         .foregroundStyle(.secondary)
                     Spacer()
@@ -582,7 +591,7 @@ struct HomebrewDetailView: View {
             Button(role: .destructive) {
                 pendingAction = .untap(tap)
             } label: {
-                Label("移除", systemImage: "minus.circle")
+                Label(localization.string("detail.taps.buttonUntap", defaultValue: "移除"), systemImage: "minus.circle")
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
@@ -595,17 +604,17 @@ struct HomebrewDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.section) {
                 VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
-                    sectionHeader(title: "brew 路径", icon: "terminal")
+                    sectionHeader(title: localization.string("detail.diagnostics.pathTitle", defaultValue: "brew 路径"), icon: "terminal")
 
                     HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-                        TextField("例如 /opt/homebrew/bin/brew", text: $customBrewPath)
+                        TextField(localization.string("detail.diagnostics.pathPlaceholder", defaultValue: "例如 /opt/homebrew/bin/brew"), text: $customBrewPath)
                             .textFieldStyle(.roundedBorder)
                             .controlSize(.small)
 
                         Button {
                             controller.updateCustomPath(customBrewPath)
                         } label: {
-                            Label("应用", systemImage: "checkmark")
+                            Label(localization.string("detail.diagnostics.pathApply", defaultValue: "应用"), systemImage: "checkmark")
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
@@ -616,36 +625,36 @@ struct HomebrewDetailView: View {
                 }
 
                 VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
-                    sectionHeader(title: "维护操作", icon: "wrench.and.screwdriver")
+                    sectionHeader(title: localization.string("detail.diagnostics.maintenance.title", defaultValue: "维护操作"), icon: "wrench.and.screwdriver")
 
                     VStack(spacing: 0) {
                         diagnosticRow(
-                            title: "更新软件源",
-                            description: "同步 Homebrew formula 和 cask 列表。",
+                            title: localization.string("detail.diagnostics.update.title", defaultValue: "更新软件源"),
+                            description: localization.string("detail.diagnostics.update.desc", defaultValue: "同步 Homebrew formula 和 cask 列表。"),
                             icon: "arrow.clockwise.circle.fill",
                             color: .blue,
                             action: { controller.updateBrew() }
                         )
                         PluginSettingsListDivider()
                         diagnosticRow(
-                            title: "更新所有包",
-                            description: "更新当前检测到的过期包。",
+                            title: localization.string("detail.diagnostics.upgrade.title", defaultValue: "更新所有包"),
+                            description: localization.string("detail.diagnostics.upgrade.desc", defaultValue: "更新当前检测到的过期包。"),
                             icon: "arrow.up.circle.fill",
                             color: .orange,
                             action: { pendingAction = .upgradeAll }
                         )
                         PluginSettingsListDivider()
                         diagnosticRow(
-                            title: "运行诊断",
-                            description: "检查环境变量、权限和构建路径。",
+                            title: localization.string("detail.diagnostics.doctor.title", defaultValue: "运行诊断"),
+                            description: localization.string("detail.diagnostics.doctor.desc", defaultValue: "检查环境变量、权限和构建路径。"),
                             icon: "heart.text.square.fill",
                             color: .green,
                             action: { controller.runDoctor() }
                         )
                         PluginSettingsListDivider()
                         diagnosticRow(
-                            title: "清理缓存",
-                            description: "移除旧版本下载和缓存。",
+                            title: localization.string("detail.diagnostics.cleanup.title", defaultValue: "清理缓存"),
+                            description: localization.string("detail.diagnostics.cleanup.desc", defaultValue: "移除旧版本下载和缓存。"),
                             icon: "trash.circle.fill",
                             color: .red,
                             action: { pendingAction = .cleanup }
@@ -667,10 +676,10 @@ struct HomebrewDetailView: View {
                 .font(.system(size: PluginSettingsTheme.Size.pageIcon))
                 .foregroundStyle(.orange)
             
-            Text("未检测到 Homebrew")
+            Text(localization.string("detail.diagnostics.pathNotFoundTitle", defaultValue: "未检测到 Homebrew"))
                 .font(PluginSettingsTheme.Typography.pageTitle)
             
-            Text("请确认已安装 Homebrew，或手动指定 brew 可执行文件路径。")
+            Text(localization.string("detail.diagnostics.pathNotFoundDesc", defaultValue: "请确认已安装 Homebrew，或手动指定 brew 可执行文件路径。"))
                 .font(PluginSettingsTheme.Typography.rowDescription)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -678,14 +687,14 @@ struct HomebrewDetailView: View {
             
             VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
                 HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-                    TextField("例如 /opt/homebrew/bin/brew", text: $customBrewPath)
+                    TextField(localization.string("detail.diagnostics.pathPlaceholder", defaultValue: "例如 /opt/homebrew/bin/brew"), text: $customBrewPath)
                         .textFieldStyle(.roundedBorder)
                         .controlSize(.small)
                     
                     Button {
                         controller.updateCustomPath(customBrewPath)
                     } label: {
-                        Label("应用", systemImage: "checkmark")
+                        Label(localization.string("detail.diagnostics.pathApply", defaultValue: "应用"), systemImage: "checkmark")
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
@@ -695,7 +704,7 @@ struct HomebrewDetailView: View {
             .frame(maxWidth: 480)
             
             VStack(alignment: .leading, spacing: 6) {
-                Text("常见安装位置")
+                Text(localization.string("detail.diagnostics.pathHelpTitle", defaultValue: "常见安装位置"))
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Text("Apple Silicon Mac: /opt/homebrew/bin/brew")
@@ -736,7 +745,7 @@ struct HomebrewDetailView: View {
             Button {
                 action()
             } label: {
-                Label("执行", systemImage: "play")
+                Label(localization.string("detail.diagnostics.buttonExecute", defaultValue: "执行"), systemImage: "play")
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
@@ -801,7 +810,7 @@ struct HomebrewDetailView: View {
             
             if !pkg.dependencies.isEmpty {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(String(format: localization.string("detail.detail.dependencies", defaultValue: "Dependencies (%d)"), pkg.dependencies.count))
+                    Text(localization.format("detail.detail.dependencies", defaultValue: "Dependencies (%d)", pkg.dependencies.count))
                         .font(PluginSettingsTheme.Typography.sectionTitle)
                         .foregroundStyle(.secondary)
                     
@@ -828,7 +837,7 @@ struct HomebrewDetailView: View {
             let usedBy = pkg.requiredBy(in: controller.installedPackages)
             if !usedBy.isEmpty {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(String(format: localization.string("detail.detail.usedBy", defaultValue: "Required By (%d)"), usedBy.count))
+                    Text(localization.format("detail.detail.usedBy", defaultValue: "Required By (%d)", usedBy.count))
                         .font(PluginSettingsTheme.Typography.sectionTitle)
                         .foregroundStyle(.secondary)
                     
@@ -928,7 +937,12 @@ struct HomebrewDetailView: View {
             }
             
             VStack(spacing: 8) {
-                infoRow(label: localization.string("detail.detail.type", defaultValue: "Type"), value: pkg.isCask ? localization.string("detail.filter.cask", defaultValue: "Cask") : localization.string("detail.filter.formula", defaultValue: "Formula"))
+                infoRow(
+                    label: localization.string("detail.detail.type", defaultValue: "Type"),
+                    value: pkg.isCask
+                        ? localization.string("detail.filter.cask", defaultValue: "Cask")
+                        : localization.string("detail.filter.formula", defaultValue: "Formula")
+                )
                 infoRow(label: localization.string("detail.detail.latestAvailableVer", defaultValue: "Latest Available"), value: pkg.latestVersion)
                 if !pkg.homepage.isEmpty {
                     HStack {

--- a/Plugins/Homebrew/Sources/HomebrewDetailView.swift
+++ b/Plugins/Homebrew/Sources/HomebrewDetailView.swift
@@ -342,7 +342,7 @@ struct HomebrewDetailView: View {
                             Text(pkg.name)
                                 .font(PluginSettingsTheme.Typography.rowTitle)
                             Spacer()
-                            Text(pkg.isCask ? "Cask" : "Formula")
+                            Text(pkg.isCask ? localization.string("detail.filter.cask", defaultValue: "Cask") : localization.string("detail.filter.formula", defaultValue: "Formula"))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -481,7 +481,7 @@ struct HomebrewDetailView: View {
                             controller.updateCustomPath(customBrewPath)
                         }
                         .buttonStyle(.bordered)
-                        .disabled(customBrewPath == controller.brewPath || customBrewPath.isEmpty)
+                        .disabled(customBrewPath == controller.brewPath)
                     }
                 }
                 .padding(12)
@@ -551,7 +551,7 @@ struct HomebrewDetailView: View {
                         controller.updateCustomPath(customBrewPath)
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(customBrewPath.isEmpty)
+                    .disabled(customBrewPath == controller.brewPath)
                 }
             }
             .frame(maxWidth: 480)
@@ -560,10 +560,10 @@ struct HomebrewDetailView: View {
                 Text(localization.string("detail.diagnostics.pathHelpTitle", defaultValue: "Common Installation Locations:"))
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Text("• Apple Silicon Mac: /opt/homebrew/bin/brew")
+                Text(localization.string("detail.diagnostics.pathHelpAppleSilicon", defaultValue: "• Apple Silicon Mac: /opt/homebrew/bin/brew"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Text("• Intel Mac: /usr/local/bin/brew")
+                Text(localization.string("detail.diagnostics.pathHelpIntel", defaultValue: "• Intel Mac: /usr/local/bin/brew"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -646,9 +646,16 @@ struct HomebrewDetailView: View {
                     HStack {
                         Text(localization.string("detail.detail.website", defaultValue: "Homepage")).font(PluginSettingsTheme.Typography.rowDescription).foregroundStyle(.secondary)
                         Spacer()
-                        Link(pkg.homepage, destination: URL(string: pkg.homepage)!)
-                            .font(PluginSettingsTheme.Typography.rowDescription)
-                            .lineLimit(1)
+                        if let url = URL(string: pkg.homepage) {
+                            Link(pkg.homepage, destination: url)
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .lineLimit(1)
+                        } else {
+                            Text(pkg.homepage)
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .lineLimit(1)
+                                .textSelection(.enabled)
+                        }
                     }
                 }
             }
@@ -784,15 +791,22 @@ struct HomebrewDetailView: View {
             }
             
             VStack(spacing: 8) {
-                infoRow(label: localization.string("detail.detail.type", defaultValue: "Type"), value: pkg.isCask ? "Cask" : "Formula")
+                infoRow(label: localization.string("detail.detail.type", defaultValue: "Type"), value: pkg.isCask ? localization.string("detail.filter.cask", defaultValue: "Cask") : localization.string("detail.filter.formula", defaultValue: "Formula"))
                 infoRow(label: localization.string("detail.detail.latestAvailableVer", defaultValue: "Latest Available"), value: pkg.latestVersion)
                 if !pkg.homepage.isEmpty {
                     HStack {
                         Text(localization.string("detail.detail.website", defaultValue: "Homepage")).font(PluginSettingsTheme.Typography.rowDescription).foregroundStyle(.secondary)
                         Spacer()
-                        Link(pkg.homepage, destination: URL(string: pkg.homepage)!)
-                            .font(PluginSettingsTheme.Typography.rowDescription)
-                            .lineLimit(1)
+                        if let url = URL(string: pkg.homepage) {
+                            Link(pkg.homepage, destination: url)
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .lineLimit(1)
+                        } else {
+                            Text(pkg.homepage)
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .lineLimit(1)
+                                .textSelection(.enabled)
+                        }
                     }
                 }
             }
@@ -911,10 +925,17 @@ struct HomebrewDetailView: View {
     // MARK: - Helper Methods
     
     private func fetchOnlinePackageDetail(_ pkg: BrewPackage) {
+        let requestedName = pkg.name
+        let requestedIsCask = pkg.isCask
         isFetchingOnlineDetail = true
         onlinePackageDetail = nil
         
         Task {
+            defer {
+                if selectedSearchPkg?.name == requestedName && selectedSearchPkg?.isCask == requestedIsCask {
+                    isFetchingOnlineDetail = false
+                }
+            }
             do {
                 let tempRunner = controller.runner
                 var jsonOutput = ""
@@ -926,8 +947,9 @@ struct HomebrewDetailView: View {
                     onError: { _ in }
                 )
                 
+                guard selectedSearchPkg?.name == requestedName && selectedSearchPkg?.isCask == requestedIsCask else { return }
+                
                 guard let data = jsonOutput.data(using: .utf8) else {
-                    isFetchingOnlineDetail = false
                     return
                 }
                 
@@ -954,6 +976,8 @@ struct HomebrewDetailView: View {
                 
                 let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
                 
+                guard selectedSearchPkg?.name == requestedName && selectedSearchPkg?.isCask == requestedIsCask else { return }
+                
                 if pkg.isCask, let cask = response.casks.first {
                     onlinePackageDetail = BrewPackage(
                         name: cask.token,
@@ -978,8 +1002,6 @@ struct HomebrewDetailView: View {
                     )
                 }
             } catch {}
-            
-            isFetchingOnlineDetail = false
         }
     }
     

--- a/Plugins/Homebrew/Sources/HomebrewDetailView.swift
+++ b/Plugins/Homebrew/Sources/HomebrewDetailView.swift
@@ -20,6 +20,7 @@ struct HomebrewDetailView: View {
     @State private var isFetchingOnlineDetail = false
     @State private var customBrewPath = ""
     @State private var pendingAction: HomebrewPendingAction?
+    @State private var didRequestInitialScan = false
     
     enum BrewTabSection: String, CaseIterable, Identifiable {
         case installed
@@ -31,10 +32,10 @@ struct HomebrewDetailView: View {
         
         func title(localization: PluginLocalization) -> String {
             switch self {
-            case .installed: return localization.string("detail.tabs.installed", defaultValue: "Installed")
-            case .search: return localization.string("detail.tabs.search", defaultValue: "Search")
-            case .taps: return localization.string("detail.tabs.taps", defaultValue: "Taps")
-            case .diagnostics: return localization.string("detail.tabs.diagnostics", defaultValue: "Diagnostics")
+            case .installed: return "已安装"
+            case .search: return "搜索"
+            case .taps: return "软件源"
+            case .diagnostics: return "诊断"
             }
         }
         
@@ -57,9 +58,9 @@ struct HomebrewDetailView: View {
         
         func title(localization: PluginLocalization) -> String {
             switch self {
-            case .all: return localization.string("detail.filter.all", defaultValue: "All")
-            case .formula: return localization.string("detail.filter.formula", defaultValue: "Formula")
-            case .cask: return localization.string("detail.filter.cask", defaultValue: "Cask")
+            case .all: return "全部"
+            case .formula: return "Formula"
+            case .cask: return "Cask"
             }
         }
     }
@@ -89,15 +90,17 @@ struct HomebrewDetailView: View {
             if !controller.isBrewAvailable {
                 pathNotFoundView
             } else {
-                // Tab Selector
-                tabBar
-                    .padding(.horizontal, contentPadding)
-                    .padding(.vertical, 8)
+                VStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+                    tabBar
+                    statusSummaryBar
+                }
+                .padding(.horizontal, contentPadding)
+                .padding(.vertical, PluginSettingsTheme.Spacing.sectionHeaderContent)
                 
                 Divider()
                 
                 // Main Content Area
-                GeometryReader { geo in
+                GeometryReader { _ in
                     VStack(spacing: 0) {
                         Group {
                             switch activeTab {
@@ -126,9 +129,18 @@ struct HomebrewDetailView: View {
         .frame(minHeight: minimumContentHeight)
         .onAppear {
             customBrewPath = controller.brewPath
+            requestInitialScanIfNeeded()
         }
         .onChange(of: controller.brewPath) { _, newPath in
             customBrewPath = newPath
+        }
+        .onChange(of: controller.isBrewAvailable) { _, _ in
+            requestInitialScanIfNeeded()
+        }
+        .onChange(of: controller.isBusy) { _, isBusy in
+            if !isBusy {
+                requestInitialScanIfNeeded()
+            }
         }
         .confirmationDialog(
             pendingAction?.title(localization: localization)
@@ -182,417 +194,521 @@ struct HomebrewDetailView: View {
     }
     
     private var tabBar: some View {
-        HStack(spacing: 8) {
-            ForEach(BrewTabSection.allCases) { section in
-                Button {
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        activeTab = section
-                    }
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: section.icon)
-                        Text(section.title(localization: localization))
-                    }
-                    .font(.body.weight(activeTab == section ? .semibold : .regular))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(activeTab == section ? Color.accentColor.opacity(0.15) : Color.clear)
-                    )
-                    .foregroundStyle(activeTab == section ? Color.accentColor : Color.primary)
+        HStack {
+            Spacer(minLength: 0)
+            Picker("视图", selection: $activeTab) {
+                ForEach(BrewTabSection.allCases) { section in
+                    Label(section.title(localization: localization), systemImage: section.icon)
+                        .tag(section)
                 }
-                .buttonStyle(.plain)
             }
-            Spacer()
+            .pickerStyle(.segmented)
+            .controlSize(.large)
+            .labelsHidden()
+            .frame(minWidth: 500, idealWidth: 560, maxWidth: 620)
+            Spacer(minLength: 0)
         }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var statusSummaryBar: some View {
+        HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            statusMetric(
+                title: "已安装",
+                value: "\(controller.installedPackages.count)",
+                systemImage: "shippingbox.fill",
+                color: Color(nsColor: .secondaryLabelColor)
+            )
+            statusMetric(
+                title: "可更新",
+                value: "\(controller.outdatedPackages.count)",
+                systemImage: "arrow.up.circle.fill",
+                color: controller.outdatedPackages.isEmpty
+                    ? Color(nsColor: .secondaryLabelColor)
+                    : .orange
+            )
+
+            Spacer(minLength: 12)
+
+            HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                Image(systemName: "terminal")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(controller.brewPath.isEmpty ? "未配置 brew" : controller.brewPath)
+                    .font(PluginSettingsTheme.Typography.monospacedValue)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+            .frame(minWidth: 160, maxWidth: 360, alignment: .trailing)
+        }
+        .padding(.horizontal, PluginSettingsTheme.Spacing.rowHorizontal)
+        .padding(.vertical, PluginSettingsTheme.Spacing.rowVertical)
+        .pluginSettingsCardBackground(.recessed)
+    }
+
+    private func statusMetric(
+        title: String,
+        value: String,
+        systemImage: String,
+        color: Color
+    ) -> some View {
+        HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+            Image(systemName: systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(color)
+            Text(title)
+                .font(PluginSettingsTheme.Typography.rowDescription)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(PluginSettingsTheme.Typography.monospacedValue)
+                .foregroundStyle(.primary)
+        }
+    }
+
+    private func refreshButton(title: String) -> some View {
+        Button {
+            controller.scanAll()
+        } label: {
+            Label(title, systemImage: "arrow.clockwise")
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(!controller.isBrewAvailable || controller.isBusy)
+        .help("刷新 Homebrew 状态")
+    }
+
+    private func sectionHeader(title: String, icon: String) -> some View {
+        Label(title, systemImage: icon)
+            .font(PluginSettingsTheme.Typography.sectionTitle)
+            .foregroundStyle(.secondary)
     }
     
     // MARK: - Tab Contents
     
     private var installedTabContent: some View {
-        HStack(spacing: 12) {
-            // Left List Column
-            VStack(spacing: 8) {
-                // Search & Filter
-                HStack(spacing: 8) {
-                    TextField(localization.string("detail.search.placeholder", defaultValue: "Search installed packages..."), text: $localSearchText)
-                        .textFieldStyle(.roundedBorder)
-                        .controlSize(.regular)
-                    
-                    Picker("", selection: $installedFilter) {
-                        ForEach(BrewPackageFilter.allCases) { filter in
-                            Text(filter.title(localization: localization)).tag(filter)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .frame(width: 100)
-                }
-                .padding(.horizontal, 4)
-                
-                // Package List
-                let filtered = controller.installedPackages.filter { pkg in
-                    let matchesText = localSearchText.isEmpty || pkg.name.localizedCaseInsensitiveContains(localSearchText) || pkg.desc.localizedCaseInsensitiveContains(localSearchText)
-                    let matchesFilter = (installedFilter == .all) ||
-                        (installedFilter == .formula && !pkg.isCask) ||
-                        (installedFilter == .cask && pkg.isCask)
-                    return matchesText && matchesFilter
-                }
-                
+        let filtered = filteredInstalledPackages
+
+        return HStack(alignment: .top, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+            VStack(spacing: 0) {
+                installedToolbar
+                PluginSettingsListDivider(leadingInset: 0, trailingInset: 0)
+
                 if filtered.isEmpty {
-                    VStack(spacing: 8) {
-                        Image(systemName: "shippingbox")
-                            .font(.system(size: 24))
-                            .foregroundStyle(.secondary)
-                        Text(localization.string("detail.search.noMatch", defaultValue: "No matching installed packages"))
-                            .font(PluginSettingsTheme.Typography.rowDescription)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .pluginSettingsCardBackground(.recessed)
+                    installedEmptyState
                 } else {
-                    List(filtered, selection: $selectedInstalledPkg) { pkg in
-                        HStack {
-                            Image(systemName: pkg.isCask ? "macwindow" : "terminal")
-                                .foregroundStyle(pkg.isCask ? .blue : .green)
-                                .font(.system(size: 13))
-                            
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(pkg.name)
-                                    .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
-                                if !pkg.desc.isEmpty {
-                                    Text(pkg.desc)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-                                }
-                            }
-                            Spacer()
-                            
-                            if pkg.isOutdated {
-                                Text(localization.string("detail.search.hasUpdate", defaultValue: "Update Available"))
-                                    .font(PluginSettingsTheme.Typography.statusBadge)
-                                    .padding(.horizontal, 5)
-                                    .padding(.vertical, 1)
-                                    .background(Color.orange.opacity(0.15), in: Capsule())
-                                    .foregroundStyle(.orange)
-                            }
-                            
-                            Text(pkg.version)
-                                .font(PluginSettingsTheme.Typography.monospacedValue)
-                                .foregroundStyle(.secondary)
-                        }
-                        .tag(pkg)
-                        .padding(.vertical, 2)
-                    }
-                    .listStyle(.inset)
-                    .pluginSettingsCardBackground(.recessed)
+                    installedPackageList(filtered)
                 }
             }
-            .frame(width: 320)
-            
-            // Right Detail Column
-            VStack {
-                if let pkg = selectedInstalledPkg {
-                    packageDetailView(for: pkg)
-                } else {
-                    VStack(spacing: 8) {
-                        Image(systemName: "info.circle")
-                            .font(.system(size: 32))
-                            .foregroundStyle(.secondary)
-                        Text(localization.string("detail.detail.selectionHint", defaultValue: "Select an installed package to view details"))
-                            .font(PluginSettingsTheme.Typography.rowDescription)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .pluginSettingsCardBackground(.host)
-                }
-            }
-            .frame(maxWidth: .infinity)
+            .pluginSettingsCardBackground(.host)
+            .frame(width: 340)
+            .frame(maxHeight: .infinity)
+
+            installedDetailPane
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .padding(.top, PluginSettingsTheme.Spacing.sectionHeaderContent)
         .padding(.horizontal, contentPadding)
         .padding(.bottom, contentPadding)
     }
-    
-    private var searchTabContent: some View {
-        HStack(spacing: 12) {
-            // Left List Column
-            VStack(spacing: 8) {
-                // Search bar
-                HStack {
-                    TextField(localization.string("detail.search.onlinePlaceholder", defaultValue: "Search online formulae or casks..."), text: $onlineSearchText, onCommit: {
-                        controller.search(query: onlineSearchText)
-                    })
-                    .textFieldStyle(.roundedBorder)
-                    .controlSize(.regular)
-                    
-                    Button(localization.string("detail.search.button", defaultValue: "Search")) {
-                        controller.search(query: onlineSearchText)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(onlineSearchText.isEmpty || controller.isSearching)
-                }
-                .padding(.horizontal, 4)
-                
-                if controller.isSearching {
-                    VStack {
-                        ProgressView()
-                        Text(localization.string("detail.search.searching", defaultValue: "Searching Homebrew..."))
-                            .font(PluginSettingsTheme.Typography.rowDescription)
-                            .foregroundStyle(.secondary)
-                            .padding(.top, 8)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .pluginSettingsCardBackground(.recessed)
-                } else if controller.searchResults.isEmpty {
-                    VStack(spacing: 8) {
-                        Image(systemName: "magnifyingglass")
-                            .font(.system(size: 24))
-                            .foregroundStyle(.secondary)
-                        Text(localization.string("detail.search.empty", defaultValue: "Enter keywords to search on Homebrew"))
-                            .font(PluginSettingsTheme.Typography.rowDescription)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .pluginSettingsCardBackground(.recessed)
-                } else {
-                    List(controller.searchResults, selection: $selectedSearchPkg) { pkg in
-                        HStack {
-                            Image(systemName: pkg.isCask ? "macwindow" : "terminal")
-                                .foregroundStyle(pkg.isCask ? .blue : .green)
-                            Text(pkg.name)
-                                .font(PluginSettingsTheme.Typography.rowTitle)
-                            Spacer()
-                            Text(pkg.isCask ? localization.string("detail.filter.cask", defaultValue: "Cask") : localization.string("detail.filter.formula", defaultValue: "Formula"))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .tag(pkg)
-                        .padding(.vertical, 2)
-                    }
-                    .listStyle(.inset)
-                    .pluginSettingsCardBackground(.recessed)
-                    .onChange(of: selectedSearchPkg) { _, newPkg in
-                        if let pkg = newPkg {
-                            fetchOnlinePackageDetail(pkg)
-                        }
-                    }
-                }
-            }
-            .frame(width: 320)
-            
-            // Right Detail Column
-            VStack {
-                if isFetchingOnlineDetail {
-                    VStack {
-                        ProgressView()
-                        Text(localization.string("detail.search.fetchingDetail", defaultValue: "Fetching detailed metadata..."))
-                            .font(PluginSettingsTheme.Typography.rowDescription)
-                            .foregroundStyle(.secondary)
-                            .padding(.top, 8)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .pluginSettingsCardBackground(.host)
-                } else if let pkg = onlinePackageDetail {
-                    onlinePackageDetailView(for: pkg)
-                } else {
-                    VStack(spacing: 8) {
-                        Image(systemName: "plus.circle")
-                            .font(.system(size: 32))
-                            .foregroundStyle(.secondary)
-                        Text(localization.string("detail.detail.onlineHint", defaultValue: "Select search result to install package"))
-                            .font(PluginSettingsTheme.Typography.rowDescription)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .pluginSettingsCardBackground(.host)
-                }
-            }
-            .frame(maxWidth: .infinity)
+
+    private var filteredInstalledPackages: [BrewPackage] {
+        controller.installedPackages.filter { pkg in
+            let matchesText = localSearchText.isEmpty
+                || pkg.name.localizedCaseInsensitiveContains(localSearchText)
+                || pkg.desc.localizedCaseInsensitiveContains(localSearchText)
+            let matchesFilter = installedFilter == .all
+                || (installedFilter == .formula && !pkg.isCask)
+                || (installedFilter == .cask && pkg.isCask)
+            return matchesText && matchesFilter
         }
+    }
+
+    private var installedToolbar: some View {
+        HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            TextField("搜索已安装包", text: $localSearchText)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+
+            Picker("", selection: $installedFilter) {
+                ForEach(BrewPackageFilter.allCases) { filter in
+                    Text(filter.title(localization: localization)).tag(filter)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .controlSize(.small)
+            .frame(width: 96)
+
+            refreshButton(title: "刷新")
+        }
+        .pluginSettingsListRowPadding(interactive: true)
+    }
+
+    private func installedPackageList(_ packages: [BrewPackage]) -> some View {
+        List(packages, selection: $selectedInstalledPkg) { pkg in
+            installedPackageRow(pkg)
+                .tag(pkg)
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    private func installedPackageRow(_ pkg: BrewPackage) -> some View {
+        HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            Image(systemName: pkg.isCask ? "macwindow" : "terminal")
+                .pluginSettingsRowIconStyle(pkg.isCask ? Color.blue : Color.green)
+
+            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+                Text(pkg.name)
+                    .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
+                    .lineLimit(1)
+                if !pkg.desc.isEmpty {
+                    Text(pkg.desc)
+                        .font(PluginSettingsTheme.Typography.rowDescription)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
+
+            if pkg.isOutdated {
+                Text("可更新")
+                    .font(PluginSettingsTheme.Typography.statusBadge)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.orange.opacity(0.15), in: Capsule())
+                    .foregroundStyle(.orange)
+            }
+
+            Text(pkg.version)
+                .font(PluginSettingsTheme.Typography.monospacedValue)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.vertical, 3)
+    }
+
+    private var installedDetailPane: some View {
+        Group {
+            if let pkg = selectedInstalledPkg {
+                packageDetailView(for: pkg)
+            } else {
+                emptyState(
+                    icon: "info.circle",
+                    title: "选择一个包查看详情"
+                )
+                .pluginSettingsCardBackground(.host)
+            }
+        }
+    }
+
+    private var installedEmptyState: some View {
+        let isUnfiltered = localSearchText.isEmpty && installedFilter == .all
+
+        return emptyState(
+            icon: controller.isBusy ? "arrow.clockwise" : "shippingbox",
+            title: controller.isBusy
+                ? "正在加载 Homebrew 状态"
+                : (isUnfiltered ? "尚未加载已安装包" : "没有匹配的已安装包")
+        )
+    }
+
+    private var searchTabContent: some View {
+        HStack(alignment: .top, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+            VStack(spacing: 0) {
+                searchToolbar
+                PluginSettingsListDivider(leadingInset: 0, trailingInset: 0)
+                searchResultsContent
+            }
+            .pluginSettingsCardBackground(.host)
+            .frame(width: 340)
+            .frame(maxHeight: .infinity)
+
+            searchDetailPane
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(.top, PluginSettingsTheme.Spacing.sectionHeaderContent)
         .padding(.horizontal, contentPadding)
         .padding(.bottom, contentPadding)
+    }
+
+    private var searchToolbar: some View {
+        HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            TextField("搜索软件包", text: $onlineSearchText)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .onSubmit {
+                    runOnlineSearch()
+                }
+
+            Button {
+                runOnlineSearch()
+            } label: {
+                Label("搜索", systemImage: "magnifyingglass")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .disabled(onlineSearchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || controller.isSearching)
+        }
+        .pluginSettingsListRowPadding(interactive: true)
+    }
+
+    @ViewBuilder
+    private var searchResultsContent: some View {
+        if controller.isSearching {
+            emptyState(icon: "arrow.clockwise", title: "正在搜索 Homebrew")
+        } else if controller.searchResults.isEmpty {
+            emptyState(icon: "magnifyingglass", title: "输入关键词搜索软件包")
+        } else {
+            List(controller.searchResults, selection: $selectedSearchPkg) { pkg in
+                HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                    Image(systemName: pkg.isCask ? "macwindow" : "terminal")
+                        .pluginSettingsRowIconStyle(pkg.isCask ? Color.blue : Color.green)
+                    Text(pkg.name)
+                        .font(PluginSettingsTheme.Typography.rowTitle)
+                        .lineLimit(1)
+                    Spacer()
+                    Text(pkg.isCask ? "Cask" : "Formula")
+                        .font(PluginSettingsTheme.Typography.statusBadge)
+                        .foregroundStyle(.secondary)
+                }
+                .tag(pkg)
+                .padding(.vertical, 3)
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .onChange(of: selectedSearchPkg) { _, newPkg in
+                if let pkg = newPkg {
+                    fetchOnlinePackageDetail(pkg)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var searchDetailPane: some View {
+        if isFetchingOnlineDetail {
+            emptyState(icon: "arrow.clockwise", title: "正在加载包详情")
+                .pluginSettingsCardBackground(.host)
+        } else if let pkg = onlinePackageDetail {
+            onlinePackageDetailView(for: pkg)
+        } else {
+            emptyState(icon: "plus.circle", title: "选择搜索结果后安装")
+                .pluginSettingsCardBackground(.host)
+        }
     }
     
     private var tapsTabContent: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Add Tap Card
-            VStack(alignment: .leading, spacing: 8) {
-                Text(localization.string("detail.taps.titleAdd", defaultValue: "Add Tap Repository"))
-                    .font(PluginSettingsTheme.Typography.sectionTitle)
-                    .foregroundStyle(.secondary)
-                
-                HStack {
-                    TextField(localization.string("detail.taps.placeholderAdd", defaultValue: "Enter tap path (e.g., user/repo or repository URL)"), text: $newTapName)
+        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.section) {
+            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+                sectionHeader(title: "添加软件源", icon: "plus.circle")
+
+                HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                    TextField("user/repo 或仓库 URL", text: $newTapName)
                         .textFieldStyle(.roundedBorder)
-                        .controlSize(.regular)
-                    
-                    Button(localization.string("detail.taps.buttonAdd", defaultValue: "Add")) {
+                        .controlSize(.small)
+
+                    Button {
                         let trimmed = newTapName.trimmingCharacters(in: .whitespacesAndNewlines)
                         guard !trimmed.isEmpty else { return }
                         pendingAction = .tap(trimmed)
+                    } label: {
+                        Label("添加", systemImage: "plus")
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(newTapName.isEmpty || controller.isBusy)
+                    .controlSize(.small)
+                    .disabled(newTapName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || controller.isBusy)
                 }
+                .pluginSettingsListRowPadding(interactive: true)
+                .pluginSettingsCardBackground(.host)
             }
-            .padding(12)
-            .pluginSettingsCardBackground(.host)
-            
-            // Active Taps List
-            VStack(alignment: .leading, spacing: 8) {
-                Text(String(format: localization.string("detail.taps.titleList", defaultValue: "Active Taps (%d)"), controller.taps.count))
-                    .font(PluginSettingsTheme.Typography.sectionTitle)
-                    .foregroundStyle(.secondary)
-                
-                if controller.taps.isEmpty {
-                    Text(localization.string("detail.taps.empty", defaultValue: "No active tap repositories"))
+
+            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+                sectionHeader(title: "已启用软件源（\(controller.taps.count)）", icon: "square.stack.3d.up")
+                tapListCard
+            }
+            .frame(maxHeight: .infinity, alignment: .top)
+        }
+        .padding(.top, PluginSettingsTheme.Spacing.sectionHeaderContent)
+        .padding(.horizontal, contentPadding)
+        .padding(.bottom, contentPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var tapListCard: some View {
+        VStack(spacing: 0) {
+            if controller.taps.isEmpty {
+                HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                    Image(systemName: "square.stack.3d.up")
+                        .pluginSettingsRowIconStyle()
+                    Text("暂无软件源")
                         .font(PluginSettingsTheme.Typography.rowDescription)
                         .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, minHeight: 60)
-                } else {
-                    ScrollView {
-                        VStack(spacing: 6) {
-                            ForEach(controller.taps) { tap in
-                                HStack {
-                                    Image(systemName: "square.stack.3d.up")
-                                        .foregroundStyle(.secondary)
-                                    Text(tap.name)
-                                        .font(PluginSettingsTheme.Typography.rowTitle)
-                                    Spacer()
-                                    
-                                    Button(localization.string("detail.taps.buttonUntap", defaultValue: "Untap")) {
-                                        pendingAction = .untap(tap)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
-                                    .disabled(controller.isBusy)
-                                }
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 6)
-                                .background(Color.primary.opacity(0.02))
-                                .cornerRadius(6)
+                    Spacer()
+                }
+                .pluginSettingsListRowPadding()
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(controller.taps) { tap in
+                            tapRow(tap)
+                            if tap.id != controller.taps.last?.id {
+                                PluginSettingsListDivider()
                             }
                         }
                     }
-                    .frame(maxHeight: .infinity)
                 }
+                .scrollIndicators(.automatic)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .padding(12)
-            .pluginSettingsCardBackground(.host)
         }
-        .padding(.horizontal, contentPadding)
-        .padding(.bottom, contentPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .pluginSettingsCardBackground(.host)
     }
-    
+
+    private func tapRow(_ tap: BrewTap) -> some View {
+        HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            Image(systemName: "square.stack.3d.up")
+                .pluginSettingsRowIconStyle()
+            Text(tap.name)
+                .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
+
+            Button(role: .destructive) {
+                pendingAction = .untap(tap)
+            } label: {
+                Label("移除", systemImage: "minus.circle")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(controller.isBusy)
+        }
+        .pluginSettingsListRowPadding(interactive: true)
+    }
+
     private var diagnosticsTabContent: some View {
         ScrollView {
-            VStack(spacing: 12) {
-                // Path Config Card
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(localization.string("detail.diagnostics.pathTitle", defaultValue: "Homebrew Path Configuration"))
-                        .font(PluginSettingsTheme.Typography.sectionTitle)
-                        .foregroundStyle(.secondary)
-                    
-                    HStack {
-                        TextField(localization.string("detail.diagnostics.pathPlaceholder", defaultValue: "Path to brew executable (e.g. /opt/homebrew/bin/brew)"), text: $customBrewPath)
+            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.section) {
+                VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+                    sectionHeader(title: "brew 路径", icon: "terminal")
+
+                    HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                        TextField("例如 /opt/homebrew/bin/brew", text: $customBrewPath)
                             .textFieldStyle(.roundedBorder)
-                            .controlSize(.regular)
-                        
-                        Button(localization.string("detail.diagnostics.pathApply", defaultValue: "Apply")) {
+                            .controlSize(.small)
+
+                        Button {
                             controller.updateCustomPath(customBrewPath)
+                        } label: {
+                            Label("应用", systemImage: "checkmark")
                         }
                         .buttonStyle(.bordered)
-                        .disabled(customBrewPath == controller.brewPath)
+                        .controlSize(.small)
+                        .disabled(customBrewPath == controller.brewPath || customBrewPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
+                    .pluginSettingsListRowPadding(interactive: true)
+                    .pluginSettingsCardBackground(.host)
                 }
-                .padding(12)
-                .pluginSettingsCardBackground(.host)
 
-                diagnosticRow(
-                    title: localization.string("detail.diagnostics.update.title", defaultValue: "Update Repositories (brew update)"),
-                    description: localization.string("detail.diagnostics.update.desc", defaultValue: "Sync the latest list of formulas and casks from remote servers."),
-                    icon: "arrow.clockwise.circle.fill",
-                    color: .blue,
-                    action: { controller.updateBrew() }
-                )
-                
-                diagnosticRow(
-                    title: localization.string("detail.diagnostics.upgrade.title", defaultValue: "Upgrade All Outdated Packages (brew upgrade)"),
-                    description: localization.string("detail.diagnostics.upgrade.desc", defaultValue: "Upgrade all outdated formulas and casks currently detected on your system."),
-                    icon: "arrow.up.circle.fill",
-                    color: .orange,
-                    action: { pendingAction = .upgradeAll }
-                )
-                
-                diagnosticRow(
-                    title: localization.string("detail.diagnostics.doctor.title", defaultValue: "Health Diagnostics (brew doctor)"),
-                    description: localization.string("detail.diagnostics.doctor.desc", defaultValue: "Diagnose potential issues with environment variables, permissions, and build paths."),
-                    icon: "heart.text.square.fill",
-                    color: .green,
-                    action: { controller.runDoctor() }
-                )
-                
-                diagnosticRow(
-                    title: localization.string("detail.diagnostics.cleanup.title", defaultValue: "Cleanup Trash & Caches (brew cleanup)"),
-                    description: localization.string("detail.diagnostics.cleanup.desc", defaultValue: "Remove outdated local downloads and caches to reclaim disk space."),
-                    icon: "trash.circle.fill",
-                    color: .red,
-                    action: { pendingAction = .cleanup }
-                )
+                VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+                    sectionHeader(title: "维护操作", icon: "wrench.and.screwdriver")
+
+                    VStack(spacing: 0) {
+                        diagnosticRow(
+                            title: "更新软件源",
+                            description: "同步 Homebrew formula 和 cask 列表。",
+                            icon: "arrow.clockwise.circle.fill",
+                            color: .blue,
+                            action: { controller.updateBrew() }
+                        )
+                        PluginSettingsListDivider()
+                        diagnosticRow(
+                            title: "更新所有包",
+                            description: "更新当前检测到的过期包。",
+                            icon: "arrow.up.circle.fill",
+                            color: .orange,
+                            action: { pendingAction = .upgradeAll }
+                        )
+                        PluginSettingsListDivider()
+                        diagnosticRow(
+                            title: "运行诊断",
+                            description: "检查环境变量、权限和构建路径。",
+                            icon: "heart.text.square.fill",
+                            color: .green,
+                            action: { controller.runDoctor() }
+                        )
+                        PluginSettingsListDivider()
+                        diagnosticRow(
+                            title: "清理缓存",
+                            description: "移除旧版本下载和缓存。",
+                            icon: "trash.circle.fill",
+                            color: .red,
+                            action: { pendingAction = .cleanup }
+                        )
+                    }
+                    .pluginSettingsCardBackground(.host)
+                }
             }
-            .padding(.bottom, 8)
+            .padding(.top, PluginSettingsTheme.Spacing.sectionHeaderContent)
+            .padding(.bottom, contentPadding)
         }
         .padding(.horizontal, contentPadding)
-        .padding(.bottom, contentPadding)
     }
 
     private var pathNotFoundView: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: PluginSettingsTheme.Spacing.section) {
             Spacer()
             Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 48))
+                .font(.system(size: PluginSettingsTheme.Size.pageIcon))
                 .foregroundStyle(.orange)
             
-            Text(localization.string("detail.diagnostics.pathNotFoundTitle", defaultValue: "Homebrew Not Detected"))
+            Text("未检测到 Homebrew")
                 .font(PluginSettingsTheme.Typography.pageTitle)
             
-            Text(localization.string("detail.diagnostics.pathNotFoundDesc", defaultValue: "Homebrew was not found in standard system directories. Please ensure it is installed or provide the custom path to the 'brew' executable below:"))
+            Text("请确认已安装 Homebrew，或手动指定 brew 可执行文件路径。")
                 .font(PluginSettingsTheme.Typography.rowDescription)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 480)
             
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    TextField(localization.string("detail.diagnostics.pathPlaceholder", defaultValue: "Path to brew executable (e.g. /opt/homebrew/bin/brew)"), text: $customBrewPath)
+            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+                HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                    TextField("例如 /opt/homebrew/bin/brew", text: $customBrewPath)
                         .textFieldStyle(.roundedBorder)
-                        .controlSize(.regular)
+                        .controlSize(.small)
                     
-                    Button(localization.string("detail.diagnostics.pathApply", defaultValue: "Apply")) {
+                    Button {
                         controller.updateCustomPath(customBrewPath)
+                    } label: {
+                        Label("应用", systemImage: "checkmark")
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(customBrewPath == controller.brewPath)
+                    .controlSize(.small)
+                    .disabled(customBrewPath.isEmpty)
                 }
             }
             .frame(maxWidth: 480)
             
             VStack(alignment: .leading, spacing: 6) {
-                Text(localization.string("detail.diagnostics.pathHelpTitle", defaultValue: "Common Installation Locations:"))
+                Text("常见安装位置")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Text(localization.string("detail.diagnostics.pathHelpAppleSilicon", defaultValue: "• Apple Silicon Mac: /opt/homebrew/bin/brew"))
+                Text("Apple Silicon Mac: /opt/homebrew/bin/brew")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Text(localization.string("detail.diagnostics.pathHelpIntel", defaultValue: "• Intel Mac: /usr/local/bin/brew"))
+                Text("Intel Mac: /usr/local/bin/brew")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
             .padding(.top, 12)
             Spacer()
         }
-        .padding(24)
+        .padding(PluginSettingsTheme.Spacing.pagePadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .pluginSettingsCardBackground(.host)
     }
@@ -604,30 +720,29 @@ struct HomebrewDetailView: View {
         color: Color,
         action: @escaping () -> Void
     ) -> some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
             Image(systemName: icon)
-                .font(.system(size: 28))
-                .foregroundStyle(color)
-                .frame(width: 36)
+                .pluginSettingsRowIconStyle(color, visualScale: 1.1)
             
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
                 Text(title)
                     .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
                 Text(description)
                     .font(PluginSettingsTheme.Typography.rowDescription)
                     .foregroundStyle(.secondary)
             }
-            Spacer()
+            Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
             
-            Button(localization.string("detail.diagnostics.buttonExecute", defaultValue: "Execute")) {
+            Button {
                 action()
+            } label: {
+                Label("执行", systemImage: "play")
             }
             .buttonStyle(.bordered)
-            .controlSize(.regular)
+            .controlSize(.small)
             .disabled(controller.isBusy)
         }
-        .padding(12)
-        .pluginSettingsCardBackground(.host)
+        .pluginSettingsListRowPadding(interactive: true)
     }
     
     // MARK: - Component Views
@@ -945,6 +1060,38 @@ struct HomebrewDetailView: View {
     }
     
     // MARK: - Helper Methods
+
+    private func requestInitialScanIfNeeded() {
+        guard !didRequestInitialScan else { return }
+        guard controller.isBrewAvailable, !controller.isBusy else { return }
+        guard controller.installedPackages.isEmpty,
+              controller.outdatedPackages.isEmpty,
+              controller.taps.isEmpty else {
+            return
+        }
+
+        didRequestInitialScan = true
+        controller.scanAll()
+    }
+
+    private func emptyState(icon: String, title: String) -> some View {
+        VStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+            if icon == "arrow.clockwise" {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Image(systemName: icon)
+                    .font(.system(size: PluginSettingsTheme.Size.emptyStateIcon))
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(title)
+                .font(PluginSettingsTheme.Typography.pageDescription)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
     
     private func fetchOnlinePackageDetail(_ pkg: BrewPackage) {
         let requestedName = pkg.name
@@ -1034,8 +1181,16 @@ struct HomebrewDetailView: View {
         } else {
             activeTab = .search
             onlineSearchText = name
-            controller.search(query: name)
+            runOnlineSearch()
         }
+    }
+
+    private func runOnlineSearch() {
+        let trimmed = onlineSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        selectedSearchPkg = nil
+        onlinePackageDetail = nil
+        controller.search(query: trimmed)
     }
 
     private func perform(_ action: HomebrewPendingAction) {

--- a/Plugins/Homebrew/Sources/HomebrewDetailView.swift
+++ b/Plugins/Homebrew/Sources/HomebrewDetailView.swift
@@ -19,6 +19,7 @@ struct HomebrewDetailView: View {
     @State private var onlinePackageDetail: BrewPackage?
     @State private var isFetchingOnlineDetail = false
     @State private var customBrewPath = ""
+    @State private var pendingAction: HomebrewPendingAction?
     
     enum BrewTabSection: String, CaseIterable, Identifiable {
         case installed
@@ -125,12 +126,32 @@ struct HomebrewDetailView: View {
         .frame(minHeight: minimumContentHeight)
         .onAppear {
             customBrewPath = controller.brewPath
-            if controller.isBrewAvailable && controller.installedPackages.isEmpty && !controller.isBusy {
-                controller.scanAll()
-            }
         }
         .onChange(of: controller.brewPath) { _, newPath in
             customBrewPath = newPath
+        }
+        .confirmationDialog(
+            pendingAction?.title(localization: localization)
+                ?? localization.string("detail.confirm.defaultTitle", defaultValue: "确认操作"),
+            isPresented: Binding(
+                get: { pendingAction != nil },
+                set: { if !$0 { pendingAction = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let pendingAction {
+                Button(pendingAction.buttonTitle(localization: localization), role: pendingAction.role) {
+                    perform(pendingAction)
+                    self.pendingAction = nil
+                }
+            }
+            Button(localization.string("detail.confirm.cancel", defaultValue: "取消"), role: .cancel) {
+                pendingAction = nil
+            }
+        } message: {
+            if let pendingAction {
+                Text(pendingAction.message(localization: localization))
+            }
         }
     }
     
@@ -407,8 +428,9 @@ struct HomebrewDetailView: View {
                         .controlSize(.regular)
                     
                     Button(localization.string("detail.taps.buttonAdd", defaultValue: "Add")) {
-                        controller.tapRepository(name: newTapName)
-                        newTapName = ""
+                        let trimmed = newTapName.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        pendingAction = .tap(trimmed)
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(newTapName.isEmpty || controller.isBusy)
@@ -440,7 +462,7 @@ struct HomebrewDetailView: View {
                                     Spacer()
                                     
                                     Button(localization.string("detail.taps.buttonUntap", defaultValue: "Untap")) {
-                                        controller.untapRepository(tap: tap)
+                                        pendingAction = .untap(tap)
                                     }
                                     .buttonStyle(.bordered)
                                     .controlSize(.small)
@@ -500,7 +522,7 @@ struct HomebrewDetailView: View {
                     description: localization.string("detail.diagnostics.upgrade.desc", defaultValue: "Upgrade all outdated formulas and casks currently detected on your system."),
                     icon: "arrow.up.circle.fill",
                     color: .orange,
-                    action: { controller.upgradeAll() }
+                    action: { pendingAction = .upgradeAll }
                 )
                 
                 diagnosticRow(
@@ -516,7 +538,7 @@ struct HomebrewDetailView: View {
                     description: localization.string("detail.diagnostics.cleanup.desc", defaultValue: "Remove outdated local downloads and caches to reclaim disk space."),
                     icon: "trash.circle.fill",
                     color: .red,
-                    action: { controller.runCleanup() }
+                    action: { pendingAction = .cleanup }
                 )
             }
             .padding(.bottom, 8)
@@ -646,8 +668,8 @@ struct HomebrewDetailView: View {
                     HStack {
                         Text(localization.string("detail.detail.website", defaultValue: "Homepage")).font(PluginSettingsTheme.Typography.rowDescription).foregroundStyle(.secondary)
                         Spacer()
-                        if let url = URL(string: pkg.homepage) {
-                            Link(pkg.homepage, destination: url)
+                        if let homepageURL = validatedHomepageURL(pkg.homepage) {
+                            Link(pkg.homepage, destination: homepageURL)
                                 .font(PluginSettingsTheme.Typography.rowDescription)
                                 .lineLimit(1)
                         } else {
@@ -759,7 +781,7 @@ struct HomebrewDetailView: View {
                 }
                 
                 Button(role: .destructive) {
-                    controller.uninstall(package: pkg)
+                    pendingAction = .uninstall(pkg)
                 } label: {
                     Label(localization.string("detail.detail.actionUninstall", defaultValue: "Uninstall"), systemImage: "trash")
                 }
@@ -797,8 +819,8 @@ struct HomebrewDetailView: View {
                     HStack {
                         Text(localization.string("detail.detail.website", defaultValue: "Homepage")).font(PluginSettingsTheme.Typography.rowDescription).foregroundStyle(.secondary)
                         Spacer()
-                        if let url = URL(string: pkg.homepage) {
-                            Link(pkg.homepage, destination: url)
+                        if let homepageURL = validatedHomepageURL(pkg.homepage) {
+                            Link(pkg.homepage, destination: homepageURL)
                                 .font(PluginSettingsTheme.Typography.rowDescription)
                                 .lineLimit(1)
                         } else {
@@ -1013,6 +1035,138 @@ struct HomebrewDetailView: View {
             activeTab = .search
             onlineSearchText = name
             controller.search(query: name)
+        }
+    }
+
+    private func perform(_ action: HomebrewPendingAction) {
+        switch action {
+        case .upgradeAll:
+            controller.upgradeAll()
+        case .cleanup:
+            controller.runCleanup()
+        case let .uninstall(package):
+            controller.uninstall(package: package)
+        case let .tap(name):
+            controller.tapRepository(name: name)
+            newTapName = ""
+        case let .untap(tap):
+            controller.untapRepository(tap: tap)
+        }
+    }
+
+    private func validatedHomepageURL(_ value: String) -> URL? {
+        guard let components = URLComponents(string: value),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              let url = components.url else {
+            return nil
+        }
+        return url
+    }
+}
+
+private enum HomebrewPendingAction: Identifiable {
+    case upgradeAll
+    case cleanup
+    case uninstall(BrewPackage)
+    case tap(String)
+    case untap(BrewTap)
+
+    var id: String {
+        switch self {
+        case .upgradeAll:
+            return "upgrade-all"
+        case .cleanup:
+            return "cleanup"
+        case let .uninstall(package):
+            return "uninstall-\(package.name)"
+        case let .tap(name):
+            return "tap-\(name)"
+        case let .untap(tap):
+            return "untap-\(tap.name)"
+        }
+    }
+
+    var role: ButtonRole? {
+        switch self {
+        case .cleanup,
+             .uninstall,
+             .untap:
+            return .destructive
+        case .upgradeAll,
+             .tap:
+            return nil
+        }
+    }
+
+    func title(localization: PluginLocalization) -> String {
+        switch self {
+        case .upgradeAll:
+            return localization.string("detail.confirm.upgradeAll.title", defaultValue: "确认更新所有包？")
+        case .cleanup:
+            return localization.string("detail.confirm.cleanup.title", defaultValue: "确认清理 Homebrew 缓存？")
+        case let .uninstall(package):
+            return localization.format(
+                "detail.confirm.uninstall.title",
+                defaultValue: "确认卸载 %@？",
+                package.name
+            )
+        case .tap:
+            return localization.string("detail.confirm.tap.title", defaultValue: "确认添加软件源？")
+        case let .untap(tap):
+            return localization.format(
+                "detail.confirm.untap.title",
+                defaultValue: "确认移除 %@？",
+                tap.name
+            )
+        }
+    }
+
+    func message(localization: PluginLocalization) -> String {
+        switch self {
+        case .upgradeAll:
+            return localization.string(
+                "detail.confirm.upgradeAll.message",
+                defaultValue: "将执行 brew upgrade，更新所有可升级的 Homebrew 包。此操作可能修改已安装软件。"
+            )
+        case .cleanup:
+            return localization.string(
+                "detail.confirm.cleanup.message",
+                defaultValue: "将执行 brew cleanup，删除 Homebrew 旧版本和下载缓存。"
+            )
+        case let .uninstall(package):
+            return localization.format(
+                "detail.confirm.uninstall.message",
+                defaultValue: "将执行 brew uninstall %@。如果其他包依赖它，相关功能可能受到影响。",
+                package.name
+            )
+        case let .tap(name):
+            return localization.format(
+                "detail.confirm.tap.message",
+                defaultValue: "将执行 brew tap %@，Homebrew 会从该软件源获取配方和 cask 信息。",
+                name
+            )
+        case let .untap(tap):
+            return localization.format(
+                "detail.confirm.untap.message",
+                defaultValue: "将执行 brew untap %@。依赖该软件源的包可能无法继续更新。",
+                tap.name
+            )
+        }
+    }
+
+    func buttonTitle(localization: PluginLocalization) -> String {
+        switch self {
+        case .upgradeAll:
+            return localization.string("detail.confirm.upgradeAll.button", defaultValue: "更新全部")
+        case .cleanup:
+            return localization.string("detail.confirm.cleanup.button", defaultValue: "清理")
+        case .uninstall:
+            return localization.string("detail.confirm.uninstall.button", defaultValue: "卸载")
+        case .tap:
+            return localization.string("detail.confirm.tap.button", defaultValue: "添加")
+        case .untap:
+            return localization.string("detail.confirm.untap.button", defaultValue: "移除")
         }
     }
 }

--- a/Plugins/Homebrew/Sources/HomebrewModels.swift
+++ b/Plugins/Homebrew/Sources/HomebrewModels.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+public struct BrewPackage: Identifiable, Hashable, Sendable, Codable {
+    public var id: String { name }
+    public let name: String
+    public let version: String
+    public let latestVersion: String
+    public let isCask: Bool
+    public let desc: String
+    public let homepage: String
+    public let isOutdated: Bool
+    public let isPinned: Bool
+    public let dependencies: [String]
+
+    public init(
+        name: String,
+        version: String,
+        latestVersion: String,
+        isCask: Bool,
+        desc: String,
+        homepage: String,
+        isOutdated: Bool,
+        isPinned: Bool,
+        dependencies: [String] = []
+    ) {
+        self.name = name
+        self.version = version
+        self.latestVersion = latestVersion
+        self.isCask = isCask
+        self.desc = desc
+        self.homepage = homepage
+        self.isOutdated = isOutdated
+        self.isPinned = isPinned
+        self.dependencies = dependencies
+    }
+
+    public func requiredBy(in packages: [BrewPackage]) -> [String] {
+        packages.filter { $0.dependencies.contains(self.name) }.map { $0.name }
+    }
+}
+
+public struct BrewTap: Identifiable, Hashable, Sendable, Codable {
+    public var id: String { name }
+    public let name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}
+
+public struct BrewCommandLog: Identifiable, Sendable {
+    public let id = UUID()
+    public let text: String
+    public let isError: Bool
+
+    public init(text: String, isError: Bool = false) {
+        self.text = text
+        self.isError = isError
+    }
+}

--- a/Plugins/Homebrew/Sources/HomebrewModels.swift
+++ b/Plugins/Homebrew/Sources/HomebrewModels.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public struct BrewPackage: Identifiable, Hashable, Sendable, Codable {
-    public var id: String { name }
+    public var id: String { "\(isCask ? "cask" : "formula"):\(name)" }
     public let name: String
     public let version: String
     public let latestVersion: String

--- a/Plugins/Homebrew/Sources/HomebrewPlugin.swift
+++ b/Plugins/Homebrew/Sources/HomebrewPlugin.swift
@@ -24,6 +24,46 @@ private struct HomebrewPluginProvider: PluginProvider {
 }
 
 @MainActor
+private protocol HomebrewConfirmationPresenting: AnyObject {
+    func confirm(
+        title: String,
+        message: String,
+        confirmTitle: String,
+        isDestructive: Bool,
+        onConfirm: @escaping @MainActor () -> Void
+    )
+}
+
+@MainActor
+private final class HomebrewAlertConfirmationPresenter: HomebrewConfirmationPresenting {
+    private let localization: PluginLocalization
+
+    init(localization: PluginLocalization) {
+        self.localization = localization
+    }
+
+    func confirm(
+        title: String,
+        message: String,
+        confirmTitle: String,
+        isDestructive: Bool,
+        onConfirm: @escaping @MainActor () -> Void
+    ) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = isDestructive ? .warning : .informational
+        alert.addButton(withTitle: confirmTitle)
+        alert.addButton(withTitle: localization.string("confirm.cancel", defaultValue: "取消"))
+
+        NSApp.activate(ignoringOtherApps: true)
+        if alert.runModal() == .alertFirstButtonReturn {
+            onConfirm()
+        }
+    }
+}
+
+@MainActor
 public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
     public enum ControlID {
         static let scan = "homebrew-scan"
@@ -45,6 +85,7 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
 
     private let controller: HomebrewController
     private let localization: PluginLocalization
+    private let confirmationPresenter: HomebrewConfirmationPresenting
     private var isExpanded = false
 
     public init(
@@ -53,6 +94,7 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
     ) {
         self.controller = controller
         self.localization = localization
+        self.confirmationPresenter = HomebrewAlertConfirmationPresenter(localization: localization)
         
         self.metadata = PluginMetadata(
             id: "homebrew",
@@ -69,10 +111,7 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
     }
 
     public func activate(context: PluginRuntimeContext) {
-        // Auto scan on launch to populate initial count
-        if controller.isBrewAvailable && controller.installedPackages.isEmpty {
-            controller.scanAll()
-        }
+        onStateChange?()
     }
 
     public func deactivate(reason: PluginDeactivationReason) {
@@ -81,7 +120,7 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
     }
 
     public func refresh() {
-        controller.scanAll()
+        onStateChange?()
     }
 
     public var primaryPanelState: PluginPanelState {
@@ -150,6 +189,9 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
         if outdatedCount > 0 {
             return String(format: localization.string("panel.subtitle.upgradable", defaultValue: "%d package(s) upgradable"), outdatedCount)
         }
+        if controller.installedPackages.isEmpty {
+            return localization.string("panel.subtitle.ready", defaultValue: "Ready to check")
+        }
         return localization.string("panel.subtitle.upToDate", defaultValue: "All packages up to date")
     }
 
@@ -158,13 +200,41 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
         case ControlID.scan:
             controller.scanAll()
         case ControlID.upgradeAll:
-            controller.upgradeAll()
+            confirmUpgradeAll()
         case ControlID.cleanup:
-            controller.runCleanup()
+            confirmCleanup()
         case ControlID.stop:
             controller.cancelCurrentOperation()
         default:
             break
+        }
+    }
+
+    private func confirmUpgradeAll() {
+        confirmationPresenter.confirm(
+            title: localization.string("confirm.upgradeAll.title", defaultValue: "确认更新所有包？"),
+            message: localization.string(
+                "confirm.upgradeAll.message",
+                defaultValue: "将执行 brew upgrade，更新所有可升级的 Homebrew 包。此操作可能修改已安装软件。"
+            ),
+            confirmTitle: localization.string("confirm.upgradeAll.button", defaultValue: "更新全部"),
+            isDestructive: false
+        ) { [weak self] in
+            self?.controller.upgradeAll()
+        }
+    }
+
+    private func confirmCleanup() {
+        confirmationPresenter.confirm(
+            title: localization.string("confirm.cleanup.title", defaultValue: "确认清理 Homebrew 缓存？"),
+            message: localization.string(
+                "confirm.cleanup.message",
+                defaultValue: "将执行 brew cleanup，删除 Homebrew 旧版本和下载缓存。"
+            ),
+            confirmTitle: localization.string("confirm.cleanup.button", defaultValue: "清理"),
+            isDestructive: true
+        ) { [weak self] in
+            self?.controller.runCleanup()
         }
     }
 

--- a/Plugins/Homebrew/Sources/HomebrewPlugin.swift
+++ b/Plugins/Homebrew/Sources/HomebrewPlugin.swift
@@ -76,6 +76,7 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
     }
 
     public func deactivate(reason: PluginDeactivationReason) {
+        guard reason.requiresStateCleanup else { return }
         controller.cancelCurrentOperation()
     }
 

--- a/Plugins/Homebrew/Sources/HomebrewPlugin.swift
+++ b/Plugins/Homebrew/Sources/HomebrewPlugin.swift
@@ -24,69 +24,26 @@ private struct HomebrewPluginProvider: PluginProvider {
 }
 
 @MainActor
-private protocol HomebrewConfirmationPresenting: AnyObject {
-    func confirm(
-        title: String,
-        message: String,
-        confirmTitle: String,
-        isDestructive: Bool,
-        onConfirm: @escaping @MainActor () -> Void
-    )
-}
-
-@MainActor
-private final class HomebrewAlertConfirmationPresenter: HomebrewConfirmationPresenting {
-    private let localization: PluginLocalization
-
-    init(localization: PluginLocalization) {
-        self.localization = localization
-    }
-
-    func confirm(
-        title: String,
-        message: String,
-        confirmTitle: String,
-        isDestructive: Bool,
-        onConfirm: @escaping @MainActor () -> Void
-    ) {
-        let alert = NSAlert()
-        alert.messageText = title
-        alert.informativeText = message
-        alert.alertStyle = isDestructive ? .warning : .informational
-        alert.addButton(withTitle: confirmTitle)
-        alert.addButton(withTitle: localization.string("confirm.cancel", defaultValue: "取消"))
-
-        NSApp.activate(ignoringOtherApps: true)
-        if alert.runModal() == .alertFirstButtonReturn {
-            onConfirm()
-        }
-    }
-}
-
-@MainActor
-public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
+public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginConfigurationPresenting {
     public enum ControlID {
-        static let scan = "homebrew-scan"
-        static let upgradeAll = "homebrew-upgrade-all"
-        static let cleanup = "homebrew-cleanup"
-        static let stop = "homebrew-stop"
+        static let manage = "execute"
     }
 
     public let metadata: PluginMetadata
 
     public let primaryPanelDescriptor = PluginPrimaryPanelDescriptor(
-        controlStyle: .disclosure,
-        menuActionBehavior: .keepPresented
+        controlStyle: .button,
+        menuActionBehavior: .dismissBeforeHandling,
+        buttonTitle: "管理"
     )
 
     public var onStateChange: (() -> Void)?
     public var requestPermissionGuidance: ((String) -> Void)?
     public var shortcutBindingResolver: ((String) -> ShortcutBinding?)?
+    public var requestConfigurationPresentation: (() -> Void)?
 
     private let controller: HomebrewController
     private let localization: PluginLocalization
-    private let confirmationPresenter: HomebrewConfirmationPresenting
-    private var isExpanded = false
 
     public init(
         controller: HomebrewController,
@@ -94,7 +51,6 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
     ) {
         self.controller = controller
         self.localization = localization
-        self.confirmationPresenter = HomebrewAlertConfirmationPresenter(localization: localization)
         
         self.metadata = PluginMetadata(
             id: "homebrew",
@@ -127,11 +83,11 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
         PluginPanelState(
             subtitle: subtitleText,
             isOn: controller.isBusy,
-            isExpanded: isExpanded,
+            isExpanded: false,
             isEnabled: true,
             isVisible: true,
-            detail: isExpanded ? buildDetail() : nil,
-            errorMessage: controller.isBrewAvailable ? nil : localization.string("panel.subtitle.notInstalled", defaultValue: "Homebrew not installed")
+            detail: nil,
+            errorMessage: controller.isBrewAvailable ? nil : "需要配置 brew 路径"
         )
     }
 
@@ -158,9 +114,6 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
 
     public func handleAction(_ action: PluginPanelAction) {
         switch action {
-        case let .setDisclosureExpanded(value):
-            isExpanded = value
-            onStateChange?()
         case let .invokeAction(controlID):
             handleInvoke(controlID: controlID)
         default:
@@ -180,141 +133,20 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
 
     private var subtitleText: String {
         guard controller.isBrewAvailable else {
-            return localization.string("panel.subtitle.notInstalled", defaultValue: "Homebrew not installed")
+            return "需要配置 brew 路径"
         }
         if controller.isBusy {
             return controller.currentOperationName
         }
-        let outdatedCount = controller.outdatedPackages.count
-        if outdatedCount > 0 {
-            return String(format: localization.string("panel.subtitle.upgradable", defaultValue: "%d package(s) upgradable"), outdatedCount)
-        }
-        if controller.installedPackages.isEmpty {
-            return localization.string("panel.subtitle.ready", defaultValue: "Ready to check")
-        }
-        return localization.string("panel.subtitle.upToDate", defaultValue: "All packages up to date")
+        return "管理包、软件源与诊断"
     }
 
     private func handleInvoke(controlID: String) {
         switch controlID {
-        case ControlID.scan:
-            controller.scanAll()
-        case ControlID.upgradeAll:
-            confirmUpgradeAll()
-        case ControlID.cleanup:
-            confirmCleanup()
-        case ControlID.stop:
-            controller.cancelCurrentOperation()
+        case ControlID.manage:
+            requestConfigurationPresentation?()
         default:
             break
         }
-    }
-
-    private func confirmUpgradeAll() {
-        confirmationPresenter.confirm(
-            title: localization.string("confirm.upgradeAll.title", defaultValue: "确认更新所有包？"),
-            message: localization.string(
-                "confirm.upgradeAll.message",
-                defaultValue: "将执行 brew upgrade，更新所有可升级的 Homebrew 包。此操作可能修改已安装软件。"
-            ),
-            confirmTitle: localization.string("confirm.upgradeAll.button", defaultValue: "更新全部"),
-            isDestructive: false
-        ) { [weak self] in
-            self?.controller.upgradeAll()
-        }
-    }
-
-    private func confirmCleanup() {
-        confirmationPresenter.confirm(
-            title: localization.string("confirm.cleanup.title", defaultValue: "确认清理 Homebrew 缓存？"),
-            message: localization.string(
-                "confirm.cleanup.message",
-                defaultValue: "将执行 brew cleanup，删除 Homebrew 旧版本和下载缓存。"
-            ),
-            confirmTitle: localization.string("confirm.cleanup.button", defaultValue: "清理"),
-            isDestructive: true
-        ) { [weak self] in
-            self?.controller.runCleanup()
-        }
-    }
-
-    private func buildDetail() -> PluginPanelDetail {
-        var controls: [PluginPanelControl] = []
-
-        controls.append(
-            PluginPanelControl(
-                id: ControlID.scan,
-                kind: .actionRow,
-                options: [],
-                selectedOptionID: nil,
-                dateValue: nil,
-                minimumDate: nil,
-                displayedComponents: nil,
-                datePickerStyle: nil,
-                sectionTitle: nil,
-                actionTitle: controller.isBusy ? localization.string("panel.action.scanning", defaultValue: "Scanning...") : localization.string("panel.action.scan", defaultValue: "Check for Updates"),
-                actionIconSystemName: "magnifyingglass",
-                isEnabled: !controller.isBusy && controller.isBrewAvailable
-            )
-        )
-
-        let outdatedCount = controller.outdatedPackages.count
-        controls.append(
-            PluginPanelControl(
-                id: ControlID.upgradeAll,
-                kind: .actionRow,
-                options: [],
-                selectedOptionID: nil,
-                dateValue: nil,
-                minimumDate: nil,
-                displayedComponents: nil,
-                datePickerStyle: nil,
-                sectionTitle: nil,
-                actionTitle: localization.string("panel.action.upgradeAll", defaultValue: "Upgrade All"),
-                actionIconSystemName: "arrow.up.circle",
-                showsLeadingDivider: true,
-                isEnabled: !controller.isBusy && controller.isBrewAvailable && outdatedCount > 0
-            )
-        )
-
-        controls.append(
-            PluginPanelControl(
-                id: ControlID.cleanup,
-                kind: .actionRow,
-                options: [],
-                selectedOptionID: nil,
-                dateValue: nil,
-                minimumDate: nil,
-                displayedComponents: nil,
-                datePickerStyle: nil,
-                sectionTitle: nil,
-                actionTitle: localization.string("panel.action.cleanup", defaultValue: "Cleanup Caches"),
-                actionIconSystemName: "trash",
-                showsLeadingDivider: true,
-                isEnabled: !controller.isBusy && controller.isBrewAvailable
-            )
-        )
-
-        if controller.isBusy {
-            controls.append(
-                PluginPanelControl(
-                    id: ControlID.stop,
-                    kind: .actionRow,
-                    options: [],
-                    selectedOptionID: nil,
-                    dateValue: nil,
-                    minimumDate: nil,
-                    displayedComponents: nil,
-                    datePickerStyle: nil,
-                    sectionTitle: nil,
-                    actionTitle: localization.string("panel.action.stop", defaultValue: "Cancel"),
-                    actionIconSystemName: "xmark.circle",
-                    showsLeadingDivider: true,
-                    isEnabled: true
-                )
-            )
-        }
-
-        return PluginPanelDetail(primaryControls: controls, secondaryPanel: nil)
     }
 }

--- a/Plugins/Homebrew/Sources/HomebrewPlugin.swift
+++ b/Plugins/Homebrew/Sources/HomebrewPlugin.swift
@@ -15,7 +15,7 @@ private struct HomebrewPluginProvider: PluginProvider {
 
     func makePlugins() -> [any MacToolsPlugin] {
         let localization = PluginLocalization(bundle: context.resourceBundle)
-        let controller = HomebrewController()
+        let controller = HomebrewController(localization: localization)
         return [HomebrewPlugin(
             controller: controller,
             localization: localization
@@ -30,12 +30,7 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginCon
     }
 
     public let metadata: PluginMetadata
-
-    public let primaryPanelDescriptor = PluginPrimaryPanelDescriptor(
-        controlStyle: .button,
-        menuActionBehavior: .dismissBeforeHandling,
-        buttonTitle: "管理"
-    )
+    public let primaryPanelDescriptor: PluginPrimaryPanelDescriptor
 
     public var onStateChange: (() -> Void)?
     public var requestPermissionGuidance: ((String) -> Void)?
@@ -51,6 +46,11 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginCon
     ) {
         self.controller = controller
         self.localization = localization
+        self.primaryPanelDescriptor = PluginPrimaryPanelDescriptor(
+            controlStyle: .button,
+            menuActionBehavior: .dismissBeforeHandling,
+            buttonTitle: localization.string("panel.action.manage", defaultValue: "管理")
+        )
         
         self.metadata = PluginMetadata(
             id: "homebrew",
@@ -87,7 +87,9 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginCon
             isEnabled: true,
             isVisible: true,
             detail: nil,
-            errorMessage: controller.isBrewAvailable ? nil : "需要配置 brew 路径"
+            errorMessage: controller.isBrewAvailable
+                ? nil
+                : localization.string("panel.error.brewPathRequired", defaultValue: "需要配置 brew 路径")
         )
     }
 
@@ -133,12 +135,12 @@ public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginCon
 
     private var subtitleText: String {
         guard controller.isBrewAvailable else {
-            return "需要配置 brew 路径"
+            return localization.string("panel.error.brewPathRequired", defaultValue: "需要配置 brew 路径")
         }
         if controller.isBusy {
             return controller.currentOperationName
         }
-        return "管理包、软件源与诊断"
+        return localization.string("panel.subtitle.manage", defaultValue: "管理包、软件源与诊断")
     }
 
     private func handleInvoke(controlID: String) {

--- a/Plugins/Homebrew/Sources/HomebrewPlugin.swift
+++ b/Plugins/Homebrew/Sources/HomebrewPlugin.swift
@@ -1,0 +1,249 @@
+import AppKit
+import Foundation
+import SwiftUI
+import MacToolsPluginKit
+
+public final class HomebrewPluginFactory: NSObject, MacToolsPluginBundleFactory {
+    public static func makeProvider(context: PluginRuntimeContext) throws -> any PluginProvider {
+        HomebrewPluginProvider(context: context)
+    }
+}
+
+@MainActor
+private struct HomebrewPluginProvider: PluginProvider {
+    let context: PluginRuntimeContext
+
+    func makePlugins() -> [any MacToolsPlugin] {
+        let localization = PluginLocalization(bundle: context.resourceBundle)
+        let controller = HomebrewController()
+        return [HomebrewPlugin(
+            controller: controller,
+            localization: localization
+        )]
+    }
+}
+
+@MainActor
+public final class HomebrewPlugin: MacToolsPlugin, PluginPrimaryPanel {
+    public enum ControlID {
+        static let scan = "homebrew-scan"
+        static let upgradeAll = "homebrew-upgrade-all"
+        static let cleanup = "homebrew-cleanup"
+        static let stop = "homebrew-stop"
+    }
+
+    public let metadata: PluginMetadata
+
+    public let primaryPanelDescriptor = PluginPrimaryPanelDescriptor(
+        controlStyle: .disclosure,
+        menuActionBehavior: .keepPresented
+    )
+
+    public var onStateChange: (() -> Void)?
+    public var requestPermissionGuidance: ((String) -> Void)?
+    public var shortcutBindingResolver: ((String) -> ShortcutBinding?)?
+
+    private let controller: HomebrewController
+    private let localization: PluginLocalization
+    private var isExpanded = false
+
+    public init(
+        controller: HomebrewController,
+        localization: PluginLocalization
+    ) {
+        self.controller = controller
+        self.localization = localization
+        
+        self.metadata = PluginMetadata(
+            id: "homebrew",
+            title: localization.string("metadata.title", defaultValue: "Homebrew"),
+            iconName: "shippingbox.fill",
+            iconTint: Color(nsColor: .systemOrange),
+            order: 92,
+            defaultDescription: localization.string("metadata.description", defaultValue: "Manage Homebrew packages, repositories, and perform diagnostics")
+        )
+
+        self.controller.onStateChange = { [weak self] in
+            self?.onStateChange?()
+        }
+    }
+
+    public func activate(context: PluginRuntimeContext) {
+        // Auto scan on launch to populate initial count
+        if controller.isBrewAvailable && controller.installedPackages.isEmpty {
+            controller.scanAll()
+        }
+    }
+
+    public func deactivate(reason: PluginDeactivationReason) {
+        controller.cancelCurrentOperation()
+    }
+
+    public func refresh() {
+        controller.scanAll()
+    }
+
+    public var primaryPanelState: PluginPanelState {
+        PluginPanelState(
+            subtitle: subtitleText,
+            isOn: controller.isBusy,
+            isExpanded: isExpanded,
+            isEnabled: true,
+            isVisible: true,
+            detail: isExpanded ? buildDetail() : nil,
+            errorMessage: controller.isBrewAvailable ? nil : localization.string("panel.subtitle.notInstalled", defaultValue: "Homebrew not installed")
+        )
+    }
+
+    public var permissionRequirements: [PluginPermissionRequirement] { [] }
+    public var settingsSections: [PluginSettingsSection] { [] }
+    public var shortcutDefinitions: [PluginShortcutDefinition] { [] }
+
+    public var configuration: PluginConfiguration? {
+        let controller = self.controller
+        let localization = self.localization
+        return PluginConfiguration(
+            description: metadata.defaultDescription,
+            prefersFullHeight: true
+        ) { _ in
+            HomebrewDetailView(
+                controller: controller,
+                localization: localization,
+                showsHeader: false,
+                contentPadding: 0,
+                minimumContentHeight: 480
+            )
+        }
+    }
+
+    public func handleAction(_ action: PluginPanelAction) {
+        switch action {
+        case let .setDisclosureExpanded(value):
+            isExpanded = value
+            onStateChange?()
+        case let .invokeAction(controlID):
+            handleInvoke(controlID: controlID)
+        default:
+            break
+        }
+    }
+
+    public func permissionState(for permissionID: String) -> PluginPermissionState {
+        PluginPermissionState(isGranted: true, footnote: nil)
+    }
+
+    public func handlePermissionAction(id: String) {}
+    public func handleSettingsAction(id: String) {}
+    public func handleShortcutAction(id: String) {}
+
+    // MARK: - Private
+
+    private var subtitleText: String {
+        guard controller.isBrewAvailable else {
+            return localization.string("panel.subtitle.notInstalled", defaultValue: "Homebrew not installed")
+        }
+        if controller.isBusy {
+            return controller.currentOperationName
+        }
+        let outdatedCount = controller.outdatedPackages.count
+        if outdatedCount > 0 {
+            return String(format: localization.string("panel.subtitle.upgradable", defaultValue: "%d package(s) upgradable"), outdatedCount)
+        }
+        return localization.string("panel.subtitle.upToDate", defaultValue: "All packages up to date")
+    }
+
+    private func handleInvoke(controlID: String) {
+        switch controlID {
+        case ControlID.scan:
+            controller.scanAll()
+        case ControlID.upgradeAll:
+            controller.upgradeAll()
+        case ControlID.cleanup:
+            controller.runCleanup()
+        case ControlID.stop:
+            controller.cancelCurrentOperation()
+        default:
+            break
+        }
+    }
+
+    private func buildDetail() -> PluginPanelDetail {
+        var controls: [PluginPanelControl] = []
+
+        controls.append(
+            PluginPanelControl(
+                id: ControlID.scan,
+                kind: .actionRow,
+                options: [],
+                selectedOptionID: nil,
+                dateValue: nil,
+                minimumDate: nil,
+                displayedComponents: nil,
+                datePickerStyle: nil,
+                sectionTitle: nil,
+                actionTitle: controller.isBusy ? localization.string("panel.action.scanning", defaultValue: "Scanning...") : localization.string("panel.action.scan", defaultValue: "Check for Updates"),
+                actionIconSystemName: "magnifyingglass",
+                isEnabled: !controller.isBusy && controller.isBrewAvailable
+            )
+        )
+
+        let outdatedCount = controller.outdatedPackages.count
+        controls.append(
+            PluginPanelControl(
+                id: ControlID.upgradeAll,
+                kind: .actionRow,
+                options: [],
+                selectedOptionID: nil,
+                dateValue: nil,
+                minimumDate: nil,
+                displayedComponents: nil,
+                datePickerStyle: nil,
+                sectionTitle: nil,
+                actionTitle: localization.string("panel.action.upgradeAll", defaultValue: "Upgrade All"),
+                actionIconSystemName: "arrow.up.circle",
+                showsLeadingDivider: true,
+                isEnabled: !controller.isBusy && controller.isBrewAvailable && outdatedCount > 0
+            )
+        )
+
+        controls.append(
+            PluginPanelControl(
+                id: ControlID.cleanup,
+                kind: .actionRow,
+                options: [],
+                selectedOptionID: nil,
+                dateValue: nil,
+                minimumDate: nil,
+                displayedComponents: nil,
+                datePickerStyle: nil,
+                sectionTitle: nil,
+                actionTitle: localization.string("panel.action.cleanup", defaultValue: "Cleanup Caches"),
+                actionIconSystemName: "trash",
+                showsLeadingDivider: true,
+                isEnabled: !controller.isBusy && controller.isBrewAvailable
+            )
+        )
+
+        if controller.isBusy {
+            controls.append(
+                PluginPanelControl(
+                    id: ControlID.stop,
+                    kind: .actionRow,
+                    options: [],
+                    selectedOptionID: nil,
+                    dateValue: nil,
+                    minimumDate: nil,
+                    displayedComponents: nil,
+                    datePickerStyle: nil,
+                    sectionTitle: nil,
+                    actionTitle: localization.string("panel.action.stop", defaultValue: "Cancel"),
+                    actionIconSystemName: "xmark.circle",
+                    showsLeadingDivider: true,
+                    isEnabled: true
+                )
+            )
+        }
+
+        return PluginPanelDetail(primaryControls: controls, secondaryPanel: nil)
+    }
+}

--- a/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
+++ b/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
@@ -194,52 +194,62 @@ final class HomebrewPluginTests: XCTestCase {
         XCTAssertEqual(UserDefaults.standard.string(forKey: "mactools.homebrew.customPath"), nil)
     }
     
-    func testHandleActionInvokeActions() async throws {
+    func testUnknownPanelActionIsIgnored() {
         let runner = FakeHomebrewCommandRunner()
         let controller = HomebrewController(runner: runner)
         controller.isBrewAvailable = true
         controller.brewPath = "/opt/homebrew/bin/brew"
-        
+
         let localization = PluginLocalization(bundle: .main)
         let plugin = HomebrewPlugin(controller: controller, localization: localization)
-        
-        // 1. Scan Action
-        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.scan))
-        XCTAssertTrue(controller.isBusy)
-        
-        // Wait for it to finish
-        let deadline = Date().addingTimeInterval(5.0)
+
+        plugin.handleAction(.invokeAction(controlID: "legacy-scan"))
+
+        XCTAssertFalse(controller.isBusy)
+        XCTAssertTrue(runner.runCalls.isEmpty)
+    }
+
+    func testCaskPackageActionsUseBrewSubcommandBeforeCaskFlag() async throws {
+        let runner = FakeHomebrewCommandRunner()
+        runner.stubbedStatus = 1
+
+        let controller = HomebrewController(runner: runner)
+        controller.isBrewAvailable = true
+        controller.brewPath = "/opt/homebrew/bin/brew"
+
+        let package = BrewPackage(
+            name: "iterm2",
+            version: "3.5.0",
+            latestVersion: "3.5.0",
+            isCask: true,
+            desc: "",
+            homepage: "",
+            isOutdated: false,
+            isPinned: false
+        )
+
+        controller.install(package: package)
+        var deadline = Date().addingTimeInterval(5.0)
         while controller.isBusy && Date() < deadline {
             try await Task.sleep(for: .milliseconds(10))
         }
-        XCTAssertFalse(controller.isBusy)
-        
-        // 2. Upgrade All Action
-        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.upgradeAll))
-        XCTAssertTrue(controller.isBusy)
-        XCTAssertEqual(controller.currentOperationName, "正在更新所有包...")
-        
-        // Cancel the operation to test Cancel action
-        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.stop))
-        
-        // Wait for it to settle
-        let cancelDeadline = Date().addingTimeInterval(5.0)
-        while controller.isBusy && Date() < cancelDeadline {
+        XCTAssertEqual(runner.runCalls.last, ["install", "--cask", "iterm2"])
+
+        runner.runCalls.removeAll()
+        controller.uninstall(package: package)
+        deadline = Date().addingTimeInterval(5.0)
+        while controller.isBusy && Date() < deadline {
             try await Task.sleep(for: .milliseconds(10))
         }
-        XCTAssertTrue(runner.isCancelled)
-        
-        // 3. Cleanup Action
-        runner.isCancelled = false
-        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.cleanup))
-        XCTAssertTrue(controller.isBusy)
-        XCTAssertEqual(controller.currentOperationName, "正在清理 Homebrew 缓存...")
-        
-        let cleanDeadline = Date().addingTimeInterval(5.0)
-        while controller.isBusy && Date() < cleanDeadline {
+        XCTAssertEqual(runner.runCalls.last, ["uninstall", "--cask", "iterm2"])
+
+        runner.runCalls.removeAll()
+        controller.upgrade(package: package)
+        deadline = Date().addingTimeInterval(5.0)
+        while controller.isBusy && Date() < deadline {
             try await Task.sleep(for: .milliseconds(10))
         }
-        XCTAssertFalse(controller.isBusy)
+        XCTAssertEqual(runner.runCalls.last, ["upgrade", "--cask", "iterm2"])
     }
     
     func testPanelStateBusyAndNotAvailable() {

--- a/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
+++ b/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
@@ -44,6 +44,10 @@ final class HomebrewPluginTests: XCTestCase {
                 matchKey = "outdated"
             } else if arguments.contains("info") && arguments.contains("--installed") {
                 matchKey = "info-installed"
+            } else if arguments.contains("search") && arguments.contains("--formula") {
+                matchKey = "search-formula"
+            } else if arguments.contains("search") && arguments.contains("--cask") {
+                matchKey = "search-cask"
             }
             
             if let output = stubbedOutputs[matchKey] {
@@ -68,13 +72,31 @@ final class HomebrewPluginTests: XCTestCase {
         XCTAssertEqual(plugin.metadata.title, "Homebrew")
     }
     
-    func testControlStyleIsDisclosure() {
+    func testPanelUsesManageButton() {
         let runner = FakeHomebrewCommandRunner()
         let controller = HomebrewController(runner: runner)
         let localization = PluginLocalization(bundle: .main)
         let plugin = HomebrewPlugin(controller: controller, localization: localization)
         
-        XCTAssertEqual(plugin.primaryPanelDescriptor.controlStyle, .disclosure)
+        XCTAssertEqual(plugin.primaryPanelDescriptor.controlStyle, .button)
+        XCTAssertEqual(plugin.primaryPanelDescriptor.menuActionBehavior, .dismissBeforeHandling)
+        XCTAssertEqual(plugin.primaryPanelDescriptor.buttonTitle, "管理")
+        XCTAssertNil(plugin.primaryPanelState.detail)
+    }
+
+    func testManageButtonRequestsConfigurationPresentation() {
+        let runner = FakeHomebrewCommandRunner()
+        let controller = HomebrewController(runner: runner)
+        let localization = PluginLocalization(bundle: .main)
+        let plugin = HomebrewPlugin(controller: controller, localization: localization)
+        var requestCount = 0
+        plugin.requestConfigurationPresentation = {
+            requestCount += 1
+        }
+
+        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.manage))
+
+        XCTAssertEqual(requestCount, 1)
     }
     
     func testScanPopulatesPackagesAndTaps() async throws {
@@ -116,6 +138,32 @@ final class HomebrewPluginTests: XCTestCase {
         let ripPkg = try XCTUnwrap(controller.installedPackages.first { $0.name == "ripgrep" })
         XCTAssertFalse(ripPkg.isOutdated)
         XCTAssertEqual(ripPkg.requiredBy(in: controller.installedPackages), [])
+    }
+
+    func testSearchSkipsDuplicatePopulatedQuery() async throws {
+        let runner = FakeHomebrewCommandRunner()
+        runner.stubbedOutputs = [
+            "search-formula": "wget\n",
+            "search-cask": "warp\n"
+        ]
+
+        let controller = HomebrewController(runner: runner)
+        controller.isBrewAvailable = true
+        controller.brewPath = "/opt/homebrew/bin/brew"
+
+        controller.search(query: "w")
+        let deadline = Date().addingTimeInterval(5.0)
+        while controller.isSearching && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(controller.searchResults.map(\.name), ["warp", "wget"])
+        XCTAssertEqual(runner.runCalls.count, 2)
+
+        controller.search(query: " w ")
+
+        XCTAssertEqual(controller.searchResults.map(\.name), ["warp", "wget"])
+        XCTAssertEqual(runner.runCalls.count, 2)
     }
     
     func testCustomPathPersistence() {

--- a/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
+++ b/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+import MacToolsPluginKit
+@testable import MacTools
+@testable import HomebrewPlugin
+
+@MainActor
+final class HomebrewPluginTests: XCTestCase {
+    
+    // Fake runner for testing
+    @MainActor
+    final class FakeHomebrewCommandRunner: HomebrewCommandRunning {
+        var stubbedStatus: Int32 = 0
+        var stubbedOutputs: [String: String] = [:]
+        var runCalls: [[String]] = []
+        var isCancelled = false
+        
+        func run(
+            executable: String,
+            arguments: [String],
+            onOutput: @escaping @MainActor (String) -> Void,
+            onError: @escaping @MainActor (String) -> Void
+        ) async throws -> Int32 {
+            runCalls.append(arguments)
+            
+            // Determine stubbed output based on arguments
+            var matchKey = ""
+            if arguments.contains("tap") {
+                matchKey = "tap"
+            } else if arguments.contains("list") && arguments.contains("--formula") {
+                matchKey = "list-formula"
+            } else if arguments.contains("list") && arguments.contains("--cask") {
+                matchKey = "list-cask"
+            } else if arguments.contains("outdated") {
+                matchKey = "outdated"
+            } else if arguments.contains("info") && arguments.contains("--installed") {
+                matchKey = "info-installed"
+            }
+            
+            if let output = stubbedOutputs[matchKey] {
+                onOutput(output)
+            }
+            
+            return stubbedStatus
+        }
+        
+        func cancel() async {
+            isCancelled = true
+        }
+    }
+    
+    func testMetadataIdentifiesHomebrewPlugin() {
+        let runner = FakeHomebrewCommandRunner()
+        let controller = HomebrewController(runner: runner)
+        let localization = PluginLocalization(bundle: .main)
+        let plugin = HomebrewPlugin(controller: controller, localization: localization)
+        
+        XCTAssertEqual(plugin.metadata.id, "homebrew")
+        XCTAssertEqual(plugin.metadata.title, "Homebrew")
+    }
+    
+    func testControlStyleIsDisclosure() {
+        let runner = FakeHomebrewCommandRunner()
+        let controller = HomebrewController(runner: runner)
+        let localization = PluginLocalization(bundle: .main)
+        let plugin = HomebrewPlugin(controller: controller, localization: localization)
+        
+        XCTAssertEqual(plugin.primaryPanelDescriptor.controlStyle, .disclosure)
+    }
+    
+    func testScanPopulatesPackagesAndTaps() async throws {
+        let runner = FakeHomebrewCommandRunner()
+        runner.stubbedOutputs = [
+            "tap": "homebrew/core\nhomebrew/cask\n",
+            "list-formula": "git 2.51.0\nripgrep 15.1.0\n",
+            "list-cask": "iterm2 3.5.0\n",
+            "outdated": "{\"formulae\":[{\"name\":\"git\",\"installed_versions\":[\"2.51.0\"],\"current_version\":\"2.55.0\",\"pinned\":false}],\"casks\":[]}",
+            "info-installed": "{\"formulae\":[{\"name\":\"git\",\"desc\":\"Distributed revision control system\",\"homepage\":\"https://git-scm.com/\",\"dependencies\":[\"pcre2\",\"openssl\"]}],\"casks\":[]}"
+        ]
+        
+        let controller = HomebrewController(runner: runner)
+        controller.isBrewAvailable = true // override for testing
+        controller.brewPath = "/opt/homebrew/bin/brew"
+        
+        // Trigger scan
+        controller.scanAll()
+        
+        // Wait for async operations to settle in controller (robust wait loop)
+        let deadline = Date().addingTimeInterval(5.0)
+        while controller.isBusy && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        
+        XCTAssertEqual(controller.taps.count, 2)
+        XCTAssertEqual(controller.taps.map(\.name), ["homebrew/core", "homebrew/cask"])
+        
+        XCTAssertEqual(controller.installedPackages.count, 3)
+        let gitPkg = try XCTUnwrap(controller.installedPackages.first { $0.name == "git" })
+        XCTAssertEqual(gitPkg.version, "2.51.0")
+        XCTAssertEqual(gitPkg.latestVersion, "2.55.0")
+        XCTAssertTrue(gitPkg.isOutdated)
+        XCTAssertEqual(gitPkg.desc, "Distributed revision control system")
+        XCTAssertEqual(gitPkg.homepage, "https://git-scm.com/")
+        XCTAssertEqual(gitPkg.dependencies, ["pcre2", "openssl"])
+        
+        // Verify reverse dependency logic
+        let ripPkg = try XCTUnwrap(controller.installedPackages.first { $0.name == "ripgrep" })
+        XCTAssertFalse(ripPkg.isOutdated)
+        XCTAssertEqual(ripPkg.requiredBy(in: controller.installedPackages), [])
+    }
+    
+    func testCustomPathPersistence() {
+        let runner = FakeHomebrewCommandRunner()
+        let controller = HomebrewController(runner: runner)
+        
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempBrewFile = tempDir.appendingPathComponent("brew")
+        try? "test".write(to: tempBrewFile, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: tempBrewFile)
+            UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
+        }
+        
+        // Test updating path
+        controller.updateCustomPath(tempBrewFile.path)
+        XCTAssertTrue(controller.isBrewAvailable)
+        XCTAssertEqual(controller.brewPath, tempBrewFile.path)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "mactools.homebrew.customPath"), tempBrewFile.path)
+        
+        // Test empty path resets standard path discovery
+        controller.updateCustomPath("")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "mactools.homebrew.customPath"), nil)
+    }
+}

--- a/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
+++ b/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
@@ -119,14 +119,20 @@ final class HomebrewPluginTests: XCTestCase {
     }
     
     func testCustomPathPersistence() {
+        UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
         let runner = FakeHomebrewCommandRunner()
         let controller = HomebrewController(runner: runner)
         
         let tempDir = FileManager.default.temporaryDirectory
-        let tempBrewFile = tempDir.appendingPathComponent("brew")
-        try? "test".write(to: tempBrewFile, atomically: true, encoding: .utf8)
+            .appendingPathComponent(UUID().uuidString)
+        let binDir = tempDir.appendingPathComponent("bin")
+        let tempBrewFile = binDir.appendingPathComponent("brew")
+        try? FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try? "#!/bin/sh\n# HOMEBREW test shim\n".write(to: tempBrewFile, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: tempBrewFile.path)
         defer {
-            try? FileManager.default.removeItem(at: tempBrewFile)
+            try? FileManager.default.removeItem(at: tempDir)
+            UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
         }
         
         // Test updating path
@@ -227,5 +233,29 @@ final class HomebrewPluginTests: XCTestCase {
         // Verify logs contain system error entries
         let hasErrorLog = controller.logs.contains { $0.isError }
         XCTAssertTrue(hasErrorLog)
+    }
+
+    func testInvalidCustomPathIsRejected() {
+        UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
+        let runner = FakeHomebrewCommandRunner()
+        let controller = HomebrewController(runner: runner)
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let binDir = tempDir.appendingPathComponent("bin")
+        let invalidBrewFile = binDir.appendingPathComponent("brew")
+        try? FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try? "#!/bin/sh\n# not homebrew\n".write(to: invalidBrewFile, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: invalidBrewFile.path)
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
+        }
+
+        controller.updateCustomPath(invalidBrewFile.path)
+
+        XCTAssertNil(UserDefaults.standard.string(forKey: "mactools.homebrew.customPath"))
+        XCTAssertNotEqual(controller.brewPath, invalidBrewFile.path)
+        XCTAssertTrue(controller.logs.contains { $0.isError })
     }
 }

--- a/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
+++ b/Plugins/Homebrew/Tests/HomebrewPluginTests.swift
@@ -6,6 +6,16 @@ import MacToolsPluginKit
 @MainActor
 final class HomebrewPluginTests: XCTestCase {
     
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
+    }
+    
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
+        super.tearDown()
+    }
+    
     // Fake runner for testing
     @MainActor
     final class FakeHomebrewCommandRunner: HomebrewCommandRunning {
@@ -117,7 +127,6 @@ final class HomebrewPluginTests: XCTestCase {
         try? "test".write(to: tempBrewFile, atomically: true, encoding: .utf8)
         defer {
             try? FileManager.default.removeItem(at: tempBrewFile)
-            UserDefaults.standard.removeObject(forKey: "mactools.homebrew.customPath")
         }
         
         // Test updating path
@@ -129,5 +138,94 @@ final class HomebrewPluginTests: XCTestCase {
         // Test empty path resets standard path discovery
         controller.updateCustomPath("")
         XCTAssertEqual(UserDefaults.standard.string(forKey: "mactools.homebrew.customPath"), nil)
+    }
+    
+    func testHandleActionInvokeActions() async throws {
+        let runner = FakeHomebrewCommandRunner()
+        let controller = HomebrewController(runner: runner)
+        controller.isBrewAvailable = true
+        controller.brewPath = "/opt/homebrew/bin/brew"
+        
+        let localization = PluginLocalization(bundle: .main)
+        let plugin = HomebrewPlugin(controller: controller, localization: localization)
+        
+        // 1. Scan Action
+        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.scan))
+        XCTAssertTrue(controller.isBusy)
+        
+        // Wait for it to finish
+        let deadline = Date().addingTimeInterval(5.0)
+        while controller.isBusy && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertFalse(controller.isBusy)
+        
+        // 2. Upgrade All Action
+        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.upgradeAll))
+        XCTAssertTrue(controller.isBusy)
+        XCTAssertEqual(controller.currentOperationName, "正在更新所有包...")
+        
+        // Cancel the operation to test Cancel action
+        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.stop))
+        
+        // Wait for it to settle
+        let cancelDeadline = Date().addingTimeInterval(5.0)
+        while controller.isBusy && Date() < cancelDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertTrue(runner.isCancelled)
+        
+        // 3. Cleanup Action
+        runner.isCancelled = false
+        plugin.handleAction(.invokeAction(controlID: HomebrewPlugin.ControlID.cleanup))
+        XCTAssertTrue(controller.isBusy)
+        XCTAssertEqual(controller.currentOperationName, "正在清理 Homebrew 缓存...")
+        
+        let cleanDeadline = Date().addingTimeInterval(5.0)
+        while controller.isBusy && Date() < cleanDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertFalse(controller.isBusy)
+    }
+    
+    func testPanelStateBusyAndNotAvailable() {
+        let runner = FakeHomebrewCommandRunner()
+        let controller = HomebrewController(runner: runner)
+        let localization = PluginLocalization(bundle: .main)
+        let plugin = HomebrewPlugin(controller: controller, localization: localization)
+        
+        // Case 1: Not installed
+        controller.isBrewAvailable = false
+        var state = plugin.primaryPanelState
+        XCTAssertNotNil(state.errorMessage)
+        
+        // Case 2: Available and Busy
+        controller.isBrewAvailable = true
+        controller.isBusy = true
+        controller.currentOperationName = "Scanning..."
+        state = plugin.primaryPanelState
+        XCTAssertNil(state.errorMessage)
+        XCTAssertTrue(state.isOn)
+        XCTAssertEqual(state.subtitle, "Scanning...")
+    }
+    
+    func testScanAllFailurePath() async throws {
+        let runner = FakeHomebrewCommandRunner()
+        runner.stubbedStatus = 1 // non-zero status indicating failure
+        
+        let controller = HomebrewController(runner: runner)
+        controller.isBrewAvailable = true
+        controller.brewPath = "/opt/homebrew/bin/brew"
+        
+        controller.scanAll()
+        
+        let deadline = Date().addingTimeInterval(5.0)
+        while controller.isBusy && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        
+        // Verify logs contain system error entries
+        let hasErrorLog = controller.logs.contains { $0.isError }
+        XCTAssertTrue(hasErrorLog)
     }
 }

--- a/Plugins/Homebrew/plugin.json
+++ b/Plugins/Homebrew/plugin.json
@@ -3,13 +3,37 @@
   "displayName": "Homebrew 管理",
   "summary": "管理 Homebrew 包、库仓库并执行系统诊断",
   "localizedMetadata": {
+    "ar": {
+      "displayName": "Homebrew",
+      "summary": "إدارة حزم Homebrew والمستودعات وتشغيل تشخيصات النظام."
+    },
     "en": {
       "displayName": "Homebrew Manager",
       "summary": "Manage Homebrew packages, repositories, and perform system diagnostics"
     },
+    "es": {
+      "displayName": "Homebrew",
+      "summary": "Administrar paquetes de Homebrew, repositorios y realizar diagnósticos del sistema."
+    },
+    "fr": {
+      "displayName": "Homebrew",
+      "summary": "Gérer les paquets Homebrew, les dépôts et effectuer des diagnostics système."
+    },
+    "ja": {
+      "displayName": "Homebrew",
+      "summary": "Homebrew パッケージ、リポジトリの管理、およびシステム診断の実行。"
+    },
+    "pt": {
+      "displayName": "Homebrew",
+      "summary": "Gerenciar pacotes do Homebrew, repositórios e executar diagnósticos do sistema."
+    },
     "zh-Hans": {
       "displayName": "Homebrew 管理",
-      "summary": "管理 Homebrew 包、库仓库并执行系统诊断"
+      "summary": "管理 Homebrew 包、软件仓库并执行系统诊断"
+    },
+    "zh-Hant": {
+      "displayName": "Homebrew 管理",
+      "summary": "管理 Homebrew 包、軟體倉庫並執行系統診斷"
     }
   },
   "version": "1.0.0",

--- a/Plugins/Homebrew/plugin.json
+++ b/Plugins/Homebrew/plugin.json
@@ -1,0 +1,31 @@
+{
+  "id": "homebrew",
+  "displayName": "Homebrew 管理",
+  "summary": "管理 Homebrew 包、库仓库并执行系统诊断",
+  "localizedMetadata": {
+    "en": {
+      "displayName": "Homebrew Manager",
+      "summary": "Manage Homebrew packages, repositories, and perform system diagnostics"
+    },
+    "zh-Hans": {
+      "displayName": "Homebrew 管理",
+      "summary": "管理 Homebrew 包、库仓库并执行系统诊断"
+    }
+  },
+  "version": "1.0.0",
+  "minHostVersion": "1.0.2",
+  "pluginKitVersion": 2,
+  "bundleRelativePath": "Homebrew.bundle",
+  "factoryClass": "HomebrewPlugin.HomebrewPluginFactory",
+  "build": {
+    "project": "../../MacTools.xcodeproj",
+    "scheme": "HomebrewPlugin"
+  },
+  "capabilities": {
+    "primaryPanel": true,
+    "componentPanel": false,
+    "configuration": true
+  },
+  "permissions": [],
+  "category": "system"
+}

--- a/changes/unreleased/add-homebrew-plugin.md
+++ b/changes/unreleased/add-homebrew-plugin.md
@@ -1,0 +1,6 @@
+---
+release: plugin
+type: added
+---
+
+Add the Homebrew management plugin to enable browsing, installing, upgrading, and diagnostics of packages from the menu bar and settings. Supports automatic path detection and custom 'brew' executable path configurations.

--- a/changes/unreleased/add-homebrew-plugin.md
+++ b/changes/unreleased/add-homebrew-plugin.md
@@ -3,4 +3,4 @@ release: plugin
 type: added
 ---
 
-Add the Homebrew management plugin to enable browsing, installing, upgrading, and diagnostics of packages from the menu bar and settings. Supports validated 'brew' executable path configurations and confirmation for high-impact operations.
+Add the Homebrew management plugin to enable browsing, installing, upgrading, and diagnostics of packages from the menu bar and settings. Supports validated 'brew' executable path configurations, confirmation for high-impact operations, and a management page that loads existing packages on first open.

--- a/changes/unreleased/add-homebrew-plugin.md
+++ b/changes/unreleased/add-homebrew-plugin.md
@@ -3,4 +3,4 @@ release: plugin
 type: added
 ---
 
-Add the Homebrew management plugin to enable browsing, installing, upgrading, and diagnostics of packages from the menu bar and settings. Supports automatic path detection and custom 'brew' executable path configurations.
+Add the Homebrew management plugin to enable browsing, installing, upgrading, and diagnostics of packages from the menu bar and settings. Supports validated 'brew' executable path configurations and confirmation for high-impact operations.

--- a/changes/unreleased/add-homebrew-plugin.md
+++ b/changes/unreleased/add-homebrew-plugin.md
@@ -3,4 +3,4 @@ release: plugin
 type: added
 ---
 
-Add the Homebrew management plugin to enable browsing, installing, upgrading, and diagnostics of packages from the menu bar and settings. Supports validated 'brew' executable path configurations, confirmation for high-impact operations, and a management page that loads existing packages on first open.
+Add the Homebrew management plugin to enable browsing, installing, upgrading, and diagnostics of packages from the menu bar and settings. Supports validated 'brew' executable path configurations, confirmation for high-impact operations, localized management copy, and a management page that loads existing packages on first open.


### PR DESCRIPTION
Add Homebrew plugin under Plugins/Homebrew to manage packages, casks, taps, and run environment diagnostics.

Features:
- Full package listing, searching, detailed dependencies view, and installation/removal actions.
- Automatic brew path detection with environment/shell check fallbacks.
- Manual path configuration overlay and persistence via UserDefaults for non-standard path configurations.
- Integrated terminal logger console drawer.
- Localization support in 8 languages (ar, en, es, fr, ja, pt, zh-Hans, zh-Hant) with English as the fallback.
- Added comprehensive unit tests for metadata, scanning, and custom path persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added a Homebrew menu/settings plugin for managing formulas/casks/taps, running install/uninstall/upgrade/doctor/cleanup actions, and showing an integrated streaming console drawer.
- Implemented `HomebrewController` + SwiftUI `HomebrewDetailView`, `BrewPackage`/`BrewTap`/`BrewCommandLog` models, plugin wiring/manifest, 8-language localization, and XCTest coverage (metadata, scanning, search, and custom `brew` path persistence).
- Added `HomebrewExecutableValidator` to validate a configured `brew` path (tilde expansion, `bin/brew` shape checks, executable checks, symlink resolution, and heuristic file-content markers).

## Security (CRITICAL)
- No evidence of clipboard (`NSPasteboard`), Keychain access, SSH key scanning, LaunchAgent/Daemon installation, or screen/camera capture within `Plugins/Homebrew`.
- Command execution uses `Process` with `executableURL` (not shell-string concatenation), reducing command-injection risk.
- **Risk: `UserDefaults`-driven arbitrary executable execution.** A malicious actor who can modify `mactools.homebrew.customPath` can potentially point to a trojan binary/script that passes the heuristic “looks like Homebrew” checks (it’s content-based, not cryptographically verified).  
  **Suggestion:** strengthen validation when accepting a custom path, e.g. also require that `brew` responds to a harmless version probe and contains `Homebrew` in stdout, with a short timeout, before marking `isBrewAvailable = true`.

## Stability & Robustness (PROTECT THE HOST)
- **Compile/API conformance issue:** `HomebrewCommandRunning` declares `func cancel() async`, but `HomebrewCommandRunner` implements `public func cancel()` (non-`async`). This should be aligned to avoid protocol conformance/signature mismatches.
  ```swift
  // HomebrewCommandRunner.swift

  public protocol HomebrewCommandRunning: Sendable {
      // ...
      func cancel() // remove async
  }

  public actor HomebrewCommandRunner: HomebrewCommandRunning {
      public func cancel() { // stays non-async
          if let process = activeProcess, process.isRunning {
              process.terminate()
          }
      }
  }
  ```

- **Main-thread blocking risk:** `HomebrewController` is `@MainActor`, and its init/synchronous path discovery calls `HomebrewExecutableValidator`, whose `looksLikeHomebrewExecutable` performs synchronous file I/O (`FileHandle(forReadingFrom:)` + `read(upToCount:)`). This can block startup/UI responsiveness.
  **Suggestion:** move brew validation/discovery off the main actor and then publish results back on the main actor.
  ```swift
  `@MainActor`
  public init(...) {
      self.runner = runner
      self.localization = localization

      Task { `@MainActor` in
          await self.initializeBrewPath()
      }
  }

  private func initializeBrewPath() async {
      let customPath = UserDefaults.standard.string(forKey: "mactools.homebrew.customPath")
      let resolved: String? = await Task.detached(priority: .utility) {
          if let cp = customPath, !cp.isEmpty {
              return HomebrewExecutableValidator.validatedPath(for: cp)
          }
          return nil
      }.value

      if let resolved {
          self.brewPath = resolved
          self.isBrewAvailable = true
          return
      }

      let discovered = await Task.detached(priority: .utility) {
          self.discoverBrewPath() // keep this sync but run detached
      }.value

      if let discovered {
          self.brewPath = discovered
          self.isBrewAvailable = true
      }
  }
  ```

## Performance (PREVENT BATTERY DRAIN & LAG)
- Logs are capped (`logs.count > 1000` => trim), mitigating unbounded growth.
- The console streaming implementation spawns `Task { `@MainActor` ... }` per output chunk; this is acceptable for typical command volumes, but combined with synchronous main-actor I/O during init is the bigger performance concern (covered above).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->