### PR TITLE
fix: narrow menu bar icon settings card

### DIFF
--- a/Sources/App/MenuBarIconSettingsView.swift
+++ b/Sources/App/MenuBarIconSettingsView.swift
@@ -81,12 +81,9 @@ private struct MenuBarIconEditorControls: View {
     @State private var sliderID = UUID()
 
     private let rowLabelWidth: CGFloat = 76
-    private let contentWidth: CGFloat = 520
+    private let contentMaxWidth: CGFloat = 520
     private let animationModePickerWidth: CGFloat = 240
     private let manualSpeedSliderWidth: CGFloat = 180
-    private var sourceButtonWidth: CGFloat {
-        (contentWidth - 8) / 2
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -94,20 +91,21 @@ private struct MenuBarIconEditorControls: View {
                 actionButtons
             }
 
-            Text(AppL10n.settings(
-                "menuBarIcon.sourceDescription",
-                defaultValue: "支持图片、轻量 GIF/MP4 和在线动态图标；导入时会自动扣除纯色背景。"
-            ))
-                .font(PluginSettingsTheme.Typography.rowDescription)
-                .foregroundStyle(.secondary)
-                .frame(width: contentWidth, alignment: .leading)
-                .frame(maxWidth: .infinity, alignment: .trailing)
+            contentOnlyRow {
+                Text(AppL10n.settings(
+                    "menuBarIcon.sourceDescription",
+                    defaultValue: "支持图片、轻量 GIF/MP4 和在线动态图标；导入时会自动扣除纯色背景。"
+                ))
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: contentMaxWidth, alignment: .leading)
+            }
 
             animationSpeedControls
 
             controlRow(AppL10n.settings("menuBarIcon.recent", defaultValue: "最近使用"), alignment: .top) {
                 MenuBarIconRecentGrid(iconSettings: iconSettings, gallery: gallery)
-                    .frame(width: contentWidth, alignment: .leading)
+                    .frame(maxWidth: contentMaxWidth, alignment: .leading)
             }
 
             if let warningText = iconSettings.contrastReport(for: .light).warningText
@@ -154,7 +152,7 @@ private struct MenuBarIconEditorControls: View {
                 .frame(width: rowLabelWidth, height: 1)
 
             content()
-                .frame(width: contentWidth, alignment: .leading)
+                .frame(maxWidth: contentMaxWidth, alignment: .leading)
                 .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -169,12 +167,11 @@ private struct MenuBarIconEditorControls: View {
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
-            .frame(width: sourceButtonWidth)
 
             MenuBarIconGalleryPicker(iconSettings: iconSettings, gallery: gallery)
-            .frame(width: sourceButtonWidth)
+                .frame(maxWidth: .infinity)
         }
-        .frame(width: contentWidth, alignment: .leading)
+        .frame(maxWidth: contentMaxWidth, alignment: .leading)
     }
 
     private var animationSpeedControls: some View {
@@ -191,7 +188,7 @@ private struct MenuBarIconEditorControls: View {
                 .labelsHidden()
                 .pickerStyle(.segmented)
                 .frame(width: animationModePickerWidth, alignment: .leading)
-                .frame(width: contentWidth, alignment: .leading)
+                .frame(maxWidth: contentMaxWidth, alignment: .leading)
             }
 
             controlRow(AppL10n.settings("menuBarIcon.multiplier", defaultValue: "倍率")) {
@@ -228,7 +225,7 @@ private struct MenuBarIconEditorControls: View {
 
             Spacer(minLength: 0)
         }
-        .frame(width: contentWidth, height: PluginSettingsTheme.Size.controlHeight, alignment: .leading)
+        .frame(maxWidth: contentMaxWidth, minHeight: PluginSettingsTheme.Size.controlHeight, alignment: .leading)
         .onAppear {
             DispatchQueue.main.async {
                 sliderID = UUID()


### PR DESCRIPTION
修复卡片尺寸异常：

<img width="2078" height="785" alt="image" src="https://github.com/user-attachments/assets/4ade200b-8661-4b92-970f-38edab39df4b" />

---

如是国际化原因，设计的大卡片防止溢出，则可关闭

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 总结

- 将菜单栏图标设置卡片由固定宽度调整为基于 `contentMaxWidth` 的最大宽度布局。
- 优化图标来源、最近使用、播放速度及动画倍率控件的自适应排列与左对齐。
- 移除部分固定按钮宽度和高度限制，缓解国际化文本导致的卡片尺寸异常。

## 安全性

未发现新增后台进程、脚本执行、敏感目录扫描、剪贴板访问或异常凭据读取。

## 稳定性与性能

未发现强制解包、越界访问、阻塞式初始化、轮询、定时器泄漏或主线程重型 I/O。

## 代码规范

布局修改符合现有 SwiftUI 自适应布局方式，未发现需要额外修正的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->