### PR TITLE
Fix adaptive secondary panel placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 | Feature | Description |
 | ------- | ----------- |
-| Display Resolution | View connected displays and switch each display to an available resolution. |
+| Display Resolution | View connected displays and switch each display to an available resolution, with an adaptive list that remains usable near screen edges. |
 | Display Brightness | Quickly adjust built-in and DDC/CI external display brightness, with shortcuts that can follow the mouse or control all displays together, plus Gamma/Shade fallbacks. |
 | True Tone | Automatically adapt display colors to ambient light on MacBooks and compatible displays. |
 | Display Sleep | Put all displays to sleep immediately, then wake them with mouse movement or keyboard input. |

--- a/Sources/App/MenuBarContent.swift
+++ b/Sources/App/MenuBarContent.swift
@@ -1823,8 +1823,12 @@ private struct SecondarySlidingPanel: View {
                             .frame(width: 18, height: 18)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("返回")
-                    .help("返回")
+                    .accessibilityLabel(
+                        AppL10n.settings("secondaryPanel.back", defaultValue: "返回")
+                    )
+                    .help(
+                        AppL10n.settings("secondaryPanel.back", defaultValue: "返回")
+                    )
                 }
 
                 Text(title)

--- a/Sources/App/MenuBarContent.swift
+++ b/Sources/App/MenuBarContent.swift
@@ -27,6 +27,8 @@ enum MenuBarPanelLayout {
     static let sliderVerticalPadding: CGFloat = 9
     static let navigationRowHeight: CGFloat = 52
     static let secondaryPanelMinimumHeight: CGFloat = 148
+    static let secondaryPanelScreenMargin: CGFloat = 8
+    static let secondaryPanelContentChromeHeight: CGFloat = 40
 
     static var surfaceWidth: CGFloat {
         baseWidth - (outerPadding * 2)
@@ -224,6 +226,56 @@ enum MenuBarPanelLayout {
         }
     }
 
+}
+
+enum SecondaryPanelPlacement: Equatable {
+    case right(CGRect)
+    case left(CGRect)
+    case inline
+
+    static func resolve(
+        anchorRect: CGRect,
+        panelSize: CGSize,
+        visibleFrame: CGRect
+    ) -> Self {
+        let availableFrame = visibleFrame.insetBy(
+            dx: MenuBarPanelLayout.secondaryPanelScreenMargin,
+            dy: MenuBarPanelLayout.secondaryPanelScreenMargin
+        )
+
+        guard
+            panelSize.width <= availableFrame.width,
+            panelSize.height <= availableFrame.height
+        else {
+            return .inline
+        }
+
+        let y = min(
+            max(anchorRect.maxY - panelSize.height, availableFrame.minY),
+            availableFrame.maxY - panelSize.height
+        )
+        let rightFrame = CGRect(
+            x: anchorRect.maxX + MenuBarPanelLayout.panelSpacing,
+            y: y,
+            width: panelSize.width,
+            height: panelSize.height
+        )
+        if rightFrame.maxX <= availableFrame.maxX {
+            return .right(rightFrame)
+        }
+
+        let leftFrame = CGRect(
+            x: anchorRect.minX - MenuBarPanelLayout.panelSpacing - panelSize.width,
+            y: y,
+            width: panelSize.width,
+            height: panelSize.height
+        )
+        if leftFrame.minX >= availableFrame.minX {
+            return .left(leftFrame)
+        }
+
+        return .inline
+    }
 }
 
 private enum FeatureRowLayout {
@@ -521,13 +573,68 @@ struct MenuBarContent: View {
     }
 
     private var content: some View {
-        featureList
-            .frame(height: visibleFeatureListHeight, alignment: .topLeading)
-            .frame(
-                width: MenuBarPanelLayout.surfaceWidth,
-                height: contentBodyHeight,
-                alignment: .topLeading
-            )
+        ZStack(alignment: .topLeading) {
+            featureList
+                .frame(height: visibleFeatureListHeight, alignment: .topLeading)
+                // Keep the navigation rows alive behind the drill-in panel. Their screen frames
+                // are also the hover coordinator's anchors; removing them would immediately
+                // dismiss the active secondary panel.
+                .opacity(secondaryPanelController.isPresentingInline ? 0 : 1)
+                .allowsHitTesting(!secondaryPanelController.isPresentingInline)
+
+            if
+                secondaryPanelController.isPresentingInline,
+                let activeSecondaryPanel
+            {
+                SecondarySlidingPanel(
+                    title: activeSecondaryPanel.panel.title,
+                    controls: activeSecondaryPanel.panel.controls,
+                    maximumContentHeight: max(
+                        0,
+                        contentBodyHeight - MenuBarPanelLayout.secondaryPanelContentChromeHeight
+                    ),
+                    showsDismissButton: true,
+                    onDismiss: {
+                        hoverCoordinator.dismissImmediately()
+                    },
+                    onSelectionChange: { controlID, optionID in
+                        pluginHost.setPanelSelectionValue(
+                            optionID,
+                            controlID: controlID,
+                            for: activeSecondaryPanel.item.id
+                        )
+                    },
+                    onNavigationSelectionChange: { controlID, optionID in
+                        pluginHost.setPanelNavigationSelectionValue(
+                            optionID,
+                            controlID: controlID,
+                            for: activeSecondaryPanel.item.id
+                        )
+                    },
+                    onDateChange: { controlID, date in
+                        pluginHost.setPanelDateValue(
+                            date,
+                            controlID: controlID,
+                            for: activeSecondaryPanel.item.id
+                        )
+                    },
+                    onHoverChange: handleSecondaryPanelHoverChange,
+                    onSliderChange: { controlID, value, phase in
+                        pluginHost.setPanelSliderValue(
+                            value,
+                            controlID: controlID,
+                            for: activeSecondaryPanel.item.id,
+                            phase: phase
+                        )
+                    }
+                )
+            }
+        }
+        .frame(
+            width: MenuBarPanelLayout.surfaceWidth,
+            height: contentBodyHeight,
+            alignment: .topLeading
+        )
     }
 
     @ViewBuilder
@@ -702,37 +809,41 @@ struct MenuBarContent: View {
     }
 
     private func syncSecondaryPanelWindow() {
-        guard
-            let activation = hoverCoordinator.activeActivation,
-            let panelItem = pluginHost.panelItems.first(where: { $0.id == activation.pluginID }),
-            let panel = panelItem.detail?.secondaryPanel(
-                controlID: activation.controlID,
-                optionID: activation.optionID
-            ),
-            let anchorRect = hoverCoordinator.selectedRowFrame
-        else {
+        guard let activeSecondaryPanel, let anchorRect = hoverCoordinator.selectedRowFrame else {
             secondaryPanelController.hide()
             return
         }
 
         secondaryPanelController.show(
-            panel: panel,
+            panel: activeSecondaryPanel.panel,
             anchorRect: anchorRect,
             onSelectionChange: { controlID, optionID in
-                pluginHost.setPanelSelectionValue(optionID, controlID: controlID, for: panelItem.id)
+                pluginHost.setPanelSelectionValue(
+                    optionID,
+                    controlID: controlID,
+                    for: activeSecondaryPanel.item.id
+                )
             },
             onNavigationSelectionChange: { controlID, optionID in
-                pluginHost.setPanelNavigationSelectionValue(optionID, controlID: controlID, for: panelItem.id)
+                pluginHost.setPanelNavigationSelectionValue(
+                    optionID,
+                    controlID: controlID,
+                    for: activeSecondaryPanel.item.id
+                )
             },
             onDateChange: { controlID, date in
-                pluginHost.setPanelDateValue(date, controlID: controlID, for: panelItem.id)
+                pluginHost.setPanelDateValue(
+                    date,
+                    controlID: controlID,
+                    for: activeSecondaryPanel.item.id
+                )
             },
             onHoverChange: handleSecondaryPanelHoverChange,
             onSliderChange: { controlID, value, phase in
                 pluginHost.setPanelSliderValue(
                     value,
                     controlID: controlID,
-                    for: panelItem.id,
+                    for: activeSecondaryPanel.item.id,
                     phase: phase
                 )
             }
@@ -766,10 +877,19 @@ struct MenuBarContent: View {
     }
 
     private var activeSecondaryPanelSignature: String? {
+        guard let activeSecondaryPanel else {
+            return nil
+        }
+
+        let controlIDs = activeSecondaryPanel.panel.controls.map(\.id).joined(separator: ",")
+        return "\(activeSecondaryPanel.activation.pluginID)|\(activeSecondaryPanel.activation.optionID)|\(activeSecondaryPanel.panel.title)|\(controlIDs)"
+    }
+
+    private var activeSecondaryPanel: ActiveSecondaryPanel? {
         guard
             let activation = hoverCoordinator.activeActivation,
-            let panelItem = pluginHost.panelItems.first(where: { $0.id == activation.pluginID }),
-            let panel = panelItem.detail?.secondaryPanel(
+            let item = pluginHost.panelItems.first(where: { $0.id == activation.pluginID }),
+            let panel = item.detail?.secondaryPanel(
                 controlID: activation.controlID,
                 optionID: activation.optionID
             )
@@ -777,8 +897,17 @@ struct MenuBarContent: View {
             return nil
         }
 
-        let controlIDs = panel.controls.map(\.id).joined(separator: ",")
-        return "\(activation.pluginID)|\(activation.optionID)|\(panel.title)|\(controlIDs)"
+        return ActiveSecondaryPanel(
+            activation: activation,
+            item: item,
+            panel: panel
+        )
+    }
+
+    private struct ActiveSecondaryPanel {
+        let activation: HoverSecondaryPanelCoordinator.Activation
+        let item: PluginPanelItem
+        let panel: PluginPanelSecondaryPanel
     }
 
     private var featureCards: some View {
@@ -1675,6 +1804,9 @@ private struct SecondarySlidingPanel: View {
 
     let title: String
     let controls: [PluginPanelControl]
+    let maximumContentHeight: CGFloat
+    let showsDismissButton: Bool
+    let onDismiss: (() -> Void)?
     let onSelectionChange: (String, String) -> Void
     let onNavigationSelectionChange: (String, String) -> Void
     let onDateChange: (String, Date) -> Void
@@ -1683,23 +1815,42 @@ private struct SecondarySlidingPanel: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.primary)
+            HStack(spacing: 8) {
+                if showsDismissButton {
+                    Button(action: { onDismiss?() }) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 11, weight: .semibold))
+                            .frame(width: 18, height: 18)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("返回")
+                    .help("返回")
+                }
 
-            PluginPanelDetailView(
-                detail: PluginPanelDetail(primaryControls: controls, secondaryPanel: nil),
-                isOn: .constant(false),
-                showsSecondaryPanel: false,
-                onSelectionChange: onSelectionChange,
-                onNavigationSelectionChange: onNavigationSelectionChange,
-                onNavigationHoverChange: { _, _, _ in },
-                onNavigationRowFrameChange: { _, _, _ in },
-                onDateChange: onDateChange,
-                onSwitchChange: { _ in },
-                onSliderChange: onSliderChange,
-                onActionInvoke: { _, _ in }
-            )
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+
+            ScrollView(.vertical, showsIndicators: true) {
+                PluginPanelDetailView(
+                    detail: PluginPanelDetail(primaryControls: controls, secondaryPanel: nil),
+                    isOn: .constant(false),
+                    showsSecondaryPanel: false,
+                    onSelectionChange: onSelectionChange,
+                    onNavigationSelectionChange: onNavigationSelectionChange,
+                    onNavigationHoverChange: { _, _, _ in },
+                    onNavigationRowFrameChange: { _, _, _ in },
+                    onDateChange: onDateChange,
+                    onSwitchChange: { _ in },
+                    onSliderChange: onSliderChange,
+                    onActionInvoke: { _, _ in }
+                )
+            }
+            .frame(maxHeight: maximumContentHeight, alignment: .top)
         }
         .padding(MenuBarPanelLayout.outerPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -1755,9 +1906,9 @@ private final class SecondaryPanelController: ObservableObject {
     // `WindowMenuBarExtraBehavior`, relies on the popover's `didResignKey` notification. Once this
     // panel is attached as a child window, the popover never closes itself.
     //
-    // Solution: keep it as an independent sibling NSPanel and never call `addChildWindow`. Position
-    // is computed directly from `anchorRect`; the level is raised above the popover; lifecycle
-    // cleanup is driven by the SwiftUI view's `.onDisappear` cascading to `hide()`.
+    // Solution: keep it as an independent sibling NSPanel and never call `addChildWindow`. Its
+    // placement is computed from `anchorRect` and the anchor screen's visible frame; when neither
+    // side has enough room, MenuBarContent renders the same panel as an in-place drill-in view.
     //
     // References:
     // - MenuBarExtraAccess source, which observes `didResignKey` on `MenuBarExtraWindow`
@@ -1769,6 +1920,7 @@ private final class SecondaryPanelController: ObservableObject {
     private var panelWindow: SecondaryPanelWindow?
     private var panelHostingView: NSHostingView<AnyView>?
     private var hostWindowObservers: [NSObjectProtocol] = []
+    @Published private(set) var isPresentingInline = false
     var onHostWindowDismissRequest: (() -> Void)?
 
     func setHostWindow(_ window: NSWindow?) {
@@ -1802,10 +1954,16 @@ private final class SecondaryPanelController: ObservableObject {
         // is already not visible; use that to block the race from re-showing the panel.
         guard hostWindow.isVisible else { return }
 
+        let screen = screenContaining(anchorRect: anchorRect)
         let rootView = AnyView(
             SecondarySlidingPanel(
                 title: panel.title,
                 controls: panel.controls,
+                maximumContentHeight: maximumSecondaryPanelContentHeight(
+                    for: screen
+                ),
+                showsDismissButton: false,
+                onDismiss: nil,
                 onSelectionChange: onSelectionChange,
                 onNavigationSelectionChange: onNavigationSelectionChange,
                 onDateChange: onDateChange,
@@ -1833,18 +1991,32 @@ private final class SecondaryPanelController: ObservableObject {
 
         let fittingSize = hostingView.fittingSize
         let width = MenuBarPanelLayout.secondaryPanelWidth
-        let height = max(fittingSize.height, MenuBarPanelLayout.secondaryPanelMinimumHeight)
-        let origin = CGPoint(
-            x: anchorRect.maxX + MenuBarPanelLayout.panelSpacing,
-            y: anchorRect.maxY - height
+        let height = min(
+            max(fittingSize.height, MenuBarPanelLayout.secondaryPanelMinimumHeight),
+            maximumSecondaryPanelHeight(for: screen)
         )
-        let frame = CGRect(origin: origin, size: CGSize(width: width, height: height))
+        let visibleFrame = screen?.visibleFrame
+            ?? hostWindow.screen?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? .zero
+        let placement = SecondaryPanelPlacement.resolve(
+            anchorRect: anchorRect,
+            panelSize: CGSize(width: width, height: height),
+            visibleFrame: visibleFrame
+        )
 
-        panelWindow.setFrame(frame, display: true)
-        // Align the panel level to `hostWindow.level + 1` at runtime so it stays above the popover.
-        // The MenuBarExtra popover level is a private SwiftUI implementation detail.
-        panelWindow.level = NSWindow.Level(rawValue: hostWindow.level.rawValue + 1)
-        panelWindow.orderFrontRegardless()
+        switch placement {
+        case let .right(frame), let .left(frame):
+            isPresentingInline = false
+            panelWindow.setFrame(frame, display: true)
+            // Align the panel level to `hostWindow.level + 1` at runtime so it stays above the popover.
+            // The MenuBarExtra popover level is a private SwiftUI implementation detail.
+            panelWindow.level = NSWindow.Level(rawValue: hostWindow.level.rawValue + 1)
+            panelWindow.orderFrontRegardless()
+        case .inline:
+            isPresentingInline = true
+            panelWindow.orderOut(nil)
+        }
         self.panelWindow = panelWindow
     }
 
@@ -1855,10 +2027,32 @@ private final class SecondaryPanelController: ObservableObject {
     }
 
     func hide() {
-        guard let panelWindow else { return }
-        panelWindow.orderOut(nil)
+        panelWindow?.orderOut(nil)
         self.panelWindow = nil
         self.panelHostingView = nil
+        isPresentingInline = false
+    }
+
+    private func screenContaining(anchorRect: CGRect) -> NSScreen? {
+        let anchorPoint = CGPoint(x: anchorRect.midX, y: anchorRect.midY)
+        return NSScreen.screens.first(where: { $0.frame.contains(anchorPoint) })
+            ?? hostWindow?.screen
+            ?? NSScreen.main
+    }
+
+    private func maximumSecondaryPanelHeight(for screen: NSScreen?) -> CGFloat {
+        let visibleHeight = screen?.visibleFrame.height
+            ?? NSScreen.main?.visibleFrame.height
+            ?? MenuBarPanelLayout.maximumPanelHeight
+        return max(0, visibleHeight - (MenuBarPanelLayout.secondaryPanelScreenMargin * 2))
+    }
+
+    private func maximumSecondaryPanelContentHeight(for screen: NSScreen?) -> CGFloat {
+        max(
+            0,
+            maximumSecondaryPanelHeight(for: screen)
+                - MenuBarPanelLayout.secondaryPanelContentChromeHeight
+        )
     }
 
     private func makePanel() -> SecondaryPanelWindow {

--- a/Sources/Resources/Localization/Settings.xcstrings
+++ b/Sources/Resources/Localization/Settings.xcstrings
@@ -1,6 +1,77 @@
 {
   "sourceLanguage": "zh-Hans",
   "strings": {
+    "secondaryPanel.back": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رجوع"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurück"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "戻る"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "뒤로"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回"
+          }
+        }
+      }
+    },
     "about.description": {
       "extractionState": "manual",
       "localizations": {

--- a/Tests/App/MenuBarPanelLayoutTests.swift
+++ b/Tests/App/MenuBarPanelLayoutTests.swift
@@ -5,6 +5,60 @@ import MacToolsPluginKit
 @testable import MacTools
 
 final class MenuBarPanelLayoutTests: XCTestCase {
+    func testSecondaryPanelPlacementPrefersRightWhenItFits() {
+        let placement = SecondaryPanelPlacement.resolve(
+            anchorRect: CGRect(x: 100, y: 500, width: 280, height: 52),
+            panelSize: CGSize(width: 216, height: 300),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        )
+
+        guard case let .right(frame) = placement else {
+            return XCTFail("Expected a right-side secondary panel")
+        }
+
+        XCTAssertEqual(frame.origin.x, 390)
+        XCTAssertEqual(frame.origin.y, 252)
+    }
+
+    func testSecondaryPanelPlacementFallsBackToLeftWhenRightDoesNotFit() {
+        let placement = SecondaryPanelPlacement.resolve(
+            anchorRect: CGRect(x: 1_150, y: 500, width: 200, height: 52),
+            panelSize: CGSize(width: 216, height: 300),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        )
+
+        guard case let .left(frame) = placement else {
+            return XCTFail("Expected a left-side secondary panel")
+        }
+
+        XCTAssertEqual(frame.origin.x, 924)
+        XCTAssertEqual(frame.origin.y, 252)
+    }
+
+    func testSecondaryPanelPlacementUsesInlineFallbackWhenNeitherSideFits() {
+        let placement = SecondaryPanelPlacement.resolve(
+            anchorRect: CGRect(x: 82, y: 500, width: 316, height: 52),
+            panelSize: CGSize(width: 216, height: 300),
+            visibleFrame: CGRect(x: 0, y: 0, width: 470, height: 900)
+        )
+
+        XCTAssertEqual(placement, .inline)
+    }
+
+    func testSecondaryPanelPlacementKeepsPanelWithinVerticalScreenBounds() {
+        let placement = SecondaryPanelPlacement.resolve(
+            anchorRect: CGRect(x: 100, y: 100, width: 200, height: 52),
+            panelSize: CGSize(width: 216, height: 500),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        )
+
+        guard case let .right(frame) = placement else {
+            return XCTFail("Expected a right-side secondary panel")
+        }
+
+        XCTAssertEqual(frame.minY, MenuBarPanelLayout.secondaryPanelScreenMargin)
+    }
+
     func testBaseLayoutMetricsStayStable() {
         XCTAssertEqual(MenuBarPanelLayout.baseWidth, 316)
         XCTAssertEqual(

--- a/changes/unreleased/adaptive-secondary-panels.md
+++ b/changes/unreleased/adaptive-secondary-panels.md
@@ -1,0 +1,7 @@
+---
+release: app
+type: fixed
+area: Menu Bar
+---
+
+Secondary menu-bar lists now open on the available side of the panel and switch to an in-panel view when screen space is limited.


### PR DESCRIPTION
## Summary

- Make the shared secondary-panel presentation adapt to the available screen space.
- Keep long secondary lists usable by bounding their height and scrolling their content.
- Add placement coverage and a release-note entry.

## Root cause

The fixed-width secondary NSPanel was always positioned to the right of its source row without checking the display visible frame. When the menu-bar popover was near the right screen edge, the panel could render offscreen.

## Behavior

- Open on the right when it fits.
- Open on the left when the right side does not fit.
- Use an in-panel drill-in view with a Back control when neither side fits.

## Visual verification

### Normal placement (right)

<img width="800" height="600" alt="codex-clipboard-1a20f05c-bb59-458b-9048-483d51d39317" src="https://github.com/user-attachments/assets/0a312326-5e42-48c0-ae57-cbff7b954683" />

### Near-right-edge fallback (left)

<img width="1024" height="768" alt="codex-clipboard-6c1210b3-a26f-416b-9ac3-b0400145f0fb" src="https://github.com/user-attachments/assets/732117ac-7da5-41d3-a87a-bedd499016cd" />

### Wide-screen edge fallback (left)

<img width="1920" height="1080" alt="codex-clipboard-bde2699f-20ed-438e-82cb-77f16015686a" src="https://github.com/user-attachments/assets/e8c0d429-c38d-4c1d-a59f-6c2861b2128d" />

## Validation

- `xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug -derivedDataPath build/DerivedDataSecondaryPanel -only-testing:MacToolsTests/MenuBarPanelLayoutTests test -quiet`
- `make build`
- `make run`
- `git diff --check`