### PR TITLE
Fix Sidecar and grouped shortcut settings layouts

### DIFF
--- a/Plugins/Sidecar/Resources/Localizable.xcstrings
+++ b/Plugins/Sidecar/Resources/Localizable.xcstrings
@@ -801,6 +801,12 @@
         "ar" : { "stringUnit" : { "state" : "translated", "value" : "هذا الاختصار مستخدم لعملية Sidecar أخرى." } }, "de" : { "stringUnit" : { "state" : "translated", "value" : "Dieser Kurzbefehl wird bereits für eine andere Sidecar-Aktion verwendet." } }, "en" : { "stringUnit" : { "state" : "translated", "value" : "This shortcut is already used by another Sidecar action." } }, "es" : { "stringUnit" : { "state" : "translated", "value" : "Este atajo ya se usa para otra acción de Sidecar." } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ce raccourci est déjà utilisé par une autre action Sidecar." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このショートカットは別のSidecarアクションで使用されています。" } }, "ko" : { "stringUnit" : { "state" : "translated", "value" : "이 단축키는 다른 Sidecar 동작에 이미 사용 중입니다." } }, "pt" : { "stringUnit" : { "state" : "translated", "value" : "Este atalho já é utilizado por outra ação do Sidecar." } }, "ru" : { "stringUnit" : { "state" : "translated", "value" : "Это сочетание клавиш уже используется другим действием Sidecar." } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "此快捷键已用于其他 Sidecar 操作。" } }, "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "此快速鍵已用於其他 Sidecar 操作。" } }
       }
     },
+    "settings.shortcut.clear" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "مسح الاختصار" } }, "de" : { "stringUnit" : { "state" : "translated", "value" : "Kurzbefehl löschen" } }, "en" : { "stringUnit" : { "state" : "translated", "value" : "Clear Shortcut" } }, "es" : { "stringUnit" : { "state" : "translated", "value" : "Borrar atajo" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Effacer le raccourci" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ショートカットを消去" } }, "ko" : { "stringUnit" : { "state" : "translated", "value" : "단축키 지우기" } }, "pt" : { "stringUnit" : { "state" : "translated", "value" : "Limpar atalho" } }, "ru" : { "stringUnit" : { "state" : "translated", "value" : "Очистить сочетание клавиш" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "清除快捷键" } }, "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "清除快速鍵" } }
+      }
+    },
     "settings.shortcut.unset" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Plugins/Sidecar/Resources/Localizable.xcstrings
+++ b/Plugins/Sidecar/Resources/Localizable.xcstrings
@@ -873,6 +873,12 @@
         "ar" : { "stringUnit" : { "state" : "translated", "value" : "طريقة الاتصال" } }, "de" : { "stringUnit" : { "state" : "translated", "value" : "Verbindungsart" } }, "en" : { "stringUnit" : { "state" : "translated", "value" : "Connection Mode" } }, "es" : { "stringUnit" : { "state" : "translated", "value" : "Modo de conexión" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mode de connexion" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "接続方法" } }, "ko" : { "stringUnit" : { "state" : "translated", "value" : "연결 방식" } }, "pt" : { "stringUnit" : { "state" : "translated", "value" : "Modo de ligação" } }, "ru" : { "stringUnit" : { "state" : "translated", "value" : "Способ подключения" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "连接方式" } }, "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "連線方式" } }
       }
     },
+    "settings.column.action" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "الإجراء" } }, "de" : { "stringUnit" : { "state" : "translated", "value" : "Aktion" } }, "en" : { "stringUnit" : { "state" : "translated", "value" : "Action" } }, "es" : { "stringUnit" : { "state" : "translated", "value" : "Acción" } }, "fr" : { "stringUnit" : { "state" : "translated", "value" : "Action" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "操作" } }, "ko" : { "stringUnit" : { "state" : "translated", "value" : "동작" } }, "pt" : { "stringUnit" : { "state" : "translated", "value" : "Ação" } }, "ru" : { "stringUnit" : { "state" : "translated", "value" : "Действие" } }, "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "操作" } }, "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "操作" } }
+      }
+    },
     "settings.column.shortcut" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Plugins/Sidecar/Sources/SidecarPlugin.swift
+++ b/Plugins/Sidecar/Sources/SidecarPlugin.swift
@@ -209,12 +209,16 @@ final class SidecarPlugin: MacToolsPlugin, PluginPrimaryPanel, PluginPanelSurfac
     }
 
     var configuration: PluginConfiguration? {
-        PluginConfiguration(description: metadata.defaultDescription) { [weak self] _ in
+        PluginConfiguration(
+            description: metadata.defaultDescription,
+            integratedShortcutGroupIDs: ["devices"]
+        ) { [weak self] context in
             if let self {
                 SidecarSettingsView(
                     store: self.preferences,
                     liveDevices: self.devices,
                     localization: self.localization,
+                    configurationContext: context,
                     onRefresh: { [weak self] in self?.refresh() },
                     onUpdate: { [weak self] in
                         self?.onStateChange?()

--- a/Plugins/Sidecar/Sources/SidecarSettingsView.swift
+++ b/Plugins/Sidecar/Sources/SidecarSettingsView.swift
@@ -6,12 +6,16 @@ import MacToolsPluginKit
 private enum SidecarSettingsColumnWidth {
     static let connection: CGFloat = 144
     static let shortcutAction: CGFloat = 112
+    static let shortcutRecorder: CGFloat = 126
+    static let shortcutActionButton: CGFloat = 22
+    static let shortcutActions: CGFloat = 50
 }
 
 struct SidecarSettingsView: View {
     @ObservedObject var store: SidecarPreferencesStore
     let liveDevices: [SidecarDevice]
     let localization: PluginLocalization
+    let configurationContext: PluginConfigurationContext
     let onRefresh: () -> Void
     let onUpdate: () -> Void
 
@@ -100,25 +104,30 @@ struct SidecarSettingsView: View {
                 .padding(.vertical, PluginSettingsTheme.Spacing.pagePadding)
                 .pluginSettingsCardBackground(.host)
             } else {
-                VStack(spacing: 0) {
-                    SidecarDeviceSettingsColumnHeader(localization: localization)
-                    PluginSettingsListDivider()
-
-                    SidecarDeviceSettingsTable(
-                        items: displayedDeviceRows,
-                        makeRow: { item, isLast in
-                            AnyView(deviceSettingsRow(for: item, isLast: isLast))
-                        },
-                        onMoveBefore: { draggedDeviceID, targetDeviceID in
-                            store.move(deviceID: draggedDeviceID, before: targetDeviceID)
-                            onUpdate()
-                        }
-                    )
-                    .frame(height: SidecarDeviceSettingsTable.preferredHeight(for: displayedDeviceRows.count))
-                }
-                .pluginSettingsCardBackground(.host)
+                deviceSettingsCard
             }
         }
+    }
+
+    private var deviceSettingsCard: some View {
+        VStack(spacing: 0) {
+            SidecarDeviceSettingsColumnHeader(localization: localization)
+            PluginSettingsListDivider()
+
+            SidecarDeviceSettingsTable(
+                items: displayedDeviceRows,
+                makeRow: { item, isLast in
+                    AnyView(deviceSettingsRow(for: item, isLast: isLast))
+                },
+                onMoveBefore: { draggedDeviceID, targetDeviceID in
+                    store.move(deviceID: draggedDeviceID, before: targetDeviceID)
+                    onUpdate()
+                }
+            )
+            .frame(height: SidecarDeviceSettingsTable.preferredHeight(for: displayedDeviceRows.count))
+        }
+        .frame(maxWidth: .infinity)
+        .pluginSettingsCardBackground(.host)
     }
 
     private func state(for preference: SidecarDevicePreference) -> SidecarDeviceSettingsState {
@@ -147,6 +156,7 @@ struct SidecarSettingsView: View {
                 preference: item.preference,
                 state: item.state,
                 localization: localization,
+                configurationContext: configurationContext,
                 onTransportChange: { transport in
                     store.updateTransport(transport, for: item.preference.id)
                     onUpdate()
@@ -182,7 +192,7 @@ private struct SidecarDeviceSettingsTable: NSViewRepresentable {
         var id: String { preference.id }
     }
 
-    static let rowHeight: CGFloat = 66
+    static let rowHeight: CGFloat = 116
     private static let dragType = NSPasteboard.PasteboardType("com.ggbond.mactools.sidecar-device")
 
     let items: [Item]
@@ -437,11 +447,131 @@ private struct SidecarDeviceSettingsRow: View {
     let preference: SidecarDevicePreference
     let state: SidecarDeviceSettingsState
     let localization: PluginLocalization
+    let configurationContext: PluginConfigurationContext
     let onTransportChange: (SidecarConnectionTransport) -> Void
     let onShortcutActionChange: (SidecarShortcutAction) -> Void
     let isReorderable: Bool
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            connectionLine
+            innerDivider
+            shortcutLine
+        }
+        .pluginSettingsListRowPadding(interactive: true)
+    }
+
+    private var connectionLine: some View {
+        HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            deviceIdentity
+
+            transportPicker
+                .frame(width: SidecarSettingsColumnWidth.connection)
+        }
+    }
+
+    private var innerDivider: some View {
+        PluginSettingsListDivider()
+            .padding(.leading, shortcutContentInset)
+            .padding(.vertical, PluginSettingsTheme.Spacing.rowTitleDescription + 1)
+            .opacity(0.55)
+    }
+
+    private var shortcutLine: some View {
+        HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            Color.clear
+                .frame(width: 14)
+
+            Image(systemName: "keyboard")
+                .font(PluginSettingsTheme.Typography.rowIcon)
+                .foregroundStyle(.secondary)
+                .frame(width: PluginSettingsTheme.Size.rowIcon)
+
+            Text(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
+                .font(PluginSettingsTheme.Typography.rowDescription)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(minWidth: 80, maxWidth: .infinity, alignment: .leading)
+
+            shortcutActionPicker
+                .frame(width: SidecarSettingsColumnWidth.shortcutAction)
+
+            shortcutControl
+                .frame(
+                    width: SidecarSettingsColumnWidth.shortcutRecorder
+                        + SidecarSettingsColumnWidth.shortcutActions
+                        + PluginSettingsTheme.Spacing.controlCluster,
+                    alignment: .leading
+                )
+        }
+    }
+
+    @ViewBuilder
+    private var shortcutControl: some View {
+        if let shortcutItem {
+            HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                PluginShortcutRecorder(
+                    title: shortcutItem.title,
+                    displayText: shortcutItem.bindingText,
+                    minWidth: SidecarSettingsColumnWidth.shortcutRecorder,
+                    onRecord: { binding in
+                        configurationContext.recordShortcut(binding, for: shortcutItem.id)
+                    },
+                    onBeginRecording: {
+                        configurationContext.beginShortcutRecording(for: shortcutItem.id)
+                    }
+                )
+                .frame(width: SidecarSettingsColumnWidth.shortcutRecorder)
+
+                HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                    if let errorMessage = shortcutItem.errorMessage {
+                        Image(systemName: "exclamationmark.circle.fill")
+                            .foregroundStyle(.red)
+                            .frame(width: SidecarSettingsColumnWidth.shortcutActionButton)
+                            .help(errorMessage)
+                    }
+
+                    if shortcutItem.canClear {
+                        Button {
+                            configurationContext.clearShortcut(for: shortcutItem.id)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(PluginSettingsTheme.Typography.rowIcon)
+                                .frame(
+                                    width: SidecarSettingsColumnWidth.shortcutActionButton,
+                                    height: SidecarSettingsColumnWidth.shortcutActionButton
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                        .help(localization.string("settings.shortcut.clear", defaultValue: "清除快捷键"))
+                    }
+                }
+                .frame(width: SidecarSettingsColumnWidth.shortcutActions, alignment: .leading)
+            }
+        } else {
+            PluginShortcutRecorderField(
+                displayText: "",
+                isRecording: false,
+                minWidth: SidecarSettingsColumnWidth.shortcutRecorder
+            )
+            .frame(width: SidecarSettingsColumnWidth.shortcutRecorder)
+            .disabled(true)
+        }
+    }
+
+    private var shortcutItem: ShortcutSettingsItem? {
+        configurationContext.shortcutItem(definitionID: "device.\(preference.id)")
+    }
+
+    private var shortcutContentInset: CGFloat {
+        14
+            + PluginSettingsTheme.Spacing.rowContentControl
+            + PluginSettingsTheme.Size.rowIcon
+            + PluginSettingsTheme.Spacing.rowContentControl
+    }
+
+    private var deviceIdentity: some View {
         HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
             Group {
                 if isReorderable {
@@ -469,44 +599,50 @@ private struct SidecarDeviceSettingsRow: View {
                     .lineLimit(1)
             }
             .frame(minWidth: 130, maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+    }
 
-            Picker(String(), selection: Binding(
+    private var transportPicker: some View {
+        Picker(String(), selection: Binding(
                 get: { preference.transport },
                 set: { transport in
                     onTransportChange(transport)
                 }
-            )) {
-                Text(localization.string("settings.transport.automatic", defaultValue: "自动"))
-                    .tag(SidecarConnectionTransport.automatic)
-                Text(localization.string("settings.transport.wiredOnly", defaultValue: "仅有线"))
-                    .tag(SidecarConnectionTransport.wiredOnly)
-            }
-            .labelsHidden()
-            .pickerStyle(.menu)
-            .frame(width: SidecarSettingsColumnWidth.connection)
-            .accessibilityLabel(localization.string("settings.column.connection", defaultValue: "连接方式"))
-            .help(localization.string("settings.transport.help", defaultValue: "连接时使用的传输方式"))
+        )) {
+            Text(localization.string("settings.transport.automatic", defaultValue: "自动"))
+                .tag(SidecarConnectionTransport.automatic)
+            Text(localization.string("settings.transport.wiredOnly", defaultValue: "仅有线"))
+                .tag(SidecarConnectionTransport.wiredOnly)
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .frame(maxWidth: .infinity)
+        .accessibilityLabel(localization.string("settings.column.connection", defaultValue: "连接方式"))
+        .help(localization.string("settings.transport.help", defaultValue: "连接时使用的传输方式"))
+    }
 
-            Picker(String(), selection: Binding(
+    private var shortcutActionPicker: some View {
+        Picker(String(), selection: Binding(
                 get: { preference.shortcutAction },
                 set: { action in
                     onShortcutActionChange(action)
                 }
-            )) {
-                Text(localization.string("settings.shortcutAction.toggle", defaultValue: "切换"))
-                    .tag(SidecarShortcutAction.toggle)
-                Text(localization.string("panel.action.connect", defaultValue: "连接"))
-                    .tag(SidecarShortcutAction.connect)
-                Text(localization.string("panel.action.disconnect", defaultValue: "断开连接"))
-                    .tag(SidecarShortcutAction.disconnect)
-            }
-            .labelsHidden()
-            .pickerStyle(.menu)
-            .frame(width: SidecarSettingsColumnWidth.shortcutAction)
-            .accessibilityLabel(localization.string("settings.column.shortcutAction", defaultValue: "快捷键操作"))
-            .help(localization.string("settings.shortcutAction.help", defaultValue: "此设备快捷键执行的操作"))
+        )) {
+            Text(localization.string("settings.shortcutAction.toggle", defaultValue: "切换"))
+                .tag(SidecarShortcutAction.toggle)
+            Text(localization.string("panel.action.connect", defaultValue: "连接"))
+                .tag(SidecarShortcutAction.connect)
+            Text(localization.string("panel.action.disconnect", defaultValue: "断开连接"))
+                .tag(SidecarShortcutAction.disconnect)
         }
-        .pluginSettingsListRowPadding(interactive: true)
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .frame(maxWidth: .infinity)
+        .accessibilityLabel(localization.string("settings.column.shortcutAction", defaultValue: "快捷键操作"))
+        .help(localization.string("settings.shortcutAction.help", defaultValue: "此设备快捷键执行的操作"))
     }
 
     private var statusIcon: String {
@@ -554,15 +690,10 @@ private struct SidecarDeviceSettingsColumnHeader: View {
                 localization.string("settings.group.connectionPolicy", defaultValue: "连接策略"),
                 systemImage: "cable.connector"
             )
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .help(localization.string("settings.group.connectionPolicy", defaultValue: "连接策略"))
                 .frame(width: SidecarSettingsColumnWidth.connection, alignment: .leading)
-            Label(
-                localization.string("settings.column.shortcutAction", defaultValue: "快捷键操作"),
-                systemImage: "keyboard"
-            )
-            .frame(
-                width: SidecarSettingsColumnWidth.shortcutAction,
-                alignment: .leading
-            )
         }
         .font(PluginSettingsTheme.Typography.rowDescription)
         .foregroundStyle(.secondary)

--- a/Plugins/Sidecar/Sources/SidecarSettingsView.swift
+++ b/Plugins/Sidecar/Sources/SidecarSettingsView.swift
@@ -7,8 +7,8 @@ private enum SidecarSettingsColumnWidth {
     static let connection: CGFloat = 144
     static let connectionLabel: CGFloat = 154
     static let shortcutAction: CGFloat = 112
-    static let shortcutActionLabel: CGFloat = 104
-    static let shortcutLabel: CGFloat = 82
+    static let shortcutActionLabel: CGFloat = 82
+    static let shortcutLabel: CGFloat = 104
     static let shortcutRecorder: CGFloat = 126
     static let shortcutActionButton: CGFloat = 22
     static let shortcutActions: CGFloat = 50
@@ -517,49 +517,52 @@ private struct SidecarDeviceSettingsRow: View {
 
     private var shortcutLine: some View {
         ViewThatFits(in: .horizontal) {
-            shortcutLineContent(showsShortcutLabel: true)
-            shortcutLineContent(showsShortcutLabel: false)
+            shortcutLineContent(showsActionLabel: true)
+            shortcutLineContent(showsActionLabel: false)
         }
     }
 
-    private func shortcutLineContent(showsShortcutLabel: Bool) -> some View {
+    private func shortcutLineContent(showsActionLabel: Bool) -> some View {
         HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
             Color.clear
                 .frame(width: 14)
 
-            Label(
-                localization.string("settings.column.action", defaultValue: "操作"),
-                systemImage: "keyboard"
-            )
+            Spacer(minLength: 0)
+
+            HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                Label(
+                    localization.string("settings.column.shortcut", defaultValue: "快捷键"),
+                    systemImage: "keyboard"
+                )
                 .font(PluginSettingsTheme.Typography.rowDescription)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
-                .frame(width: SidecarSettingsColumnWidth.shortcutActionLabel, alignment: .leading)
-                .help(localization.string("settings.column.action", defaultValue: "操作"))
+                .frame(width: SidecarSettingsColumnWidth.shortcutLabel, alignment: .leading)
+                .help(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
 
-            shortcutActionPicker
-                .frame(width: SidecarSettingsColumnWidth.shortcutAction)
+                shortcutControl
+                    .frame(
+                        width: SidecarSettingsColumnWidth.shortcutRecorder
+                            + SidecarSettingsColumnWidth.shortcutActions
+                            + PluginSettingsTheme.Spacing.controlCluster,
+                        alignment: .leading
+                    )
 
-            if showsShortcutLabel {
-                Text(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
-                    .font(PluginSettingsTheme.Typography.rowDescription)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(width: SidecarSettingsColumnWidth.shortcutLabel, alignment: .leading)
-                    .help(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
+                if showsActionLabel {
+                    Text(localization.string("settings.column.action", defaultValue: "操作"))
+                        .font(PluginSettingsTheme.Typography.rowDescription)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(width: SidecarSettingsColumnWidth.shortcutActionLabel, alignment: .leading)
+                        .help(localization.string("settings.column.action", defaultValue: "操作"))
+                }
+
+                shortcutActionPicker
+                    .frame(width: SidecarSettingsColumnWidth.shortcutAction)
             }
-
-            shortcutControl
-                .frame(
-                    width: SidecarSettingsColumnWidth.shortcutRecorder
-                        + SidecarSettingsColumnWidth.shortcutActions
-                        + PluginSettingsTheme.Spacing.controlCluster,
-                    alignment: .leading
-                )
-
-            Spacer(minLength: 0)
+            .fixedSize(horizontal: true, vertical: false)
         }
     }
 

--- a/Plugins/Sidecar/Sources/SidecarSettingsView.swift
+++ b/Plugins/Sidecar/Sources/SidecarSettingsView.swift
@@ -5,7 +5,10 @@ import MacToolsPluginKit
 
 private enum SidecarSettingsColumnWidth {
     static let connection: CGFloat = 144
+    static let connectionLabel: CGFloat = 154
     static let shortcutAction: CGFloat = 112
+    static let shortcutActionLabel: CGFloat = 104
+    static let shortcutLabel: CGFloat = 82
     static let shortcutRecorder: CGFloat = 126
     static let shortcutActionButton: CGFloat = 22
     static let shortcutActions: CGFloat = 50
@@ -111,9 +114,6 @@ struct SidecarSettingsView: View {
 
     private var deviceSettingsCard: some View {
         VStack(spacing: 0) {
-            SidecarDeviceSettingsColumnHeader(localization: localization)
-            PluginSettingsListDivider()
-
             SidecarDeviceSettingsTable(
                 items: displayedDeviceRows,
                 makeRow: { item, isLast in
@@ -462,11 +462,49 @@ private struct SidecarDeviceSettingsRow: View {
     }
 
     private var connectionLine: some View {
+        ViewThatFits(in: .horizontal) {
+            connectionLineContent(showsLabel: true)
+            connectionLineContent(showsLabel: false)
+        }
+    }
+
+    private func connectionLineContent(showsLabel: Bool) -> some View {
         HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
             deviceIdentity
 
-            transportPicker
-                .frame(width: SidecarSettingsColumnWidth.connection)
+            HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                if showsLabel {
+                    Label(
+                        localization.string(
+                            "settings.group.connectionPolicy",
+                            defaultValue: "连接策略"
+                        ),
+                        systemImage: "cable.connector"
+                    )
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(width: SidecarSettingsColumnWidth.connectionLabel, alignment: .leading)
+                    .help(localization.string(
+                        "settings.group.connectionPolicy",
+                        defaultValue: "连接策略"
+                    ))
+                } else {
+                    Image(systemName: "cable.connector")
+                        .font(PluginSettingsTheme.Typography.rowIcon)
+                        .foregroundStyle(.secondary)
+                        .frame(width: PluginSettingsTheme.Size.rowIcon)
+                        .help(localization.string(
+                            "settings.group.connectionPolicy",
+                            defaultValue: "连接策略"
+                        ))
+                }
+
+                transportPicker
+                    .frame(width: SidecarSettingsColumnWidth.connection)
+            }
+            .fixedSize(horizontal: true, vertical: false)
         }
     }
 
@@ -478,23 +516,40 @@ private struct SidecarDeviceSettingsRow: View {
     }
 
     private var shortcutLine: some View {
+        ViewThatFits(in: .horizontal) {
+            shortcutLineContent(showsShortcutLabel: true)
+            shortcutLineContent(showsShortcutLabel: false)
+        }
+    }
+
+    private func shortcutLineContent(showsShortcutLabel: Bool) -> some View {
         HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
             Color.clear
                 .frame(width: 14)
 
-            Image(systemName: "keyboard")
-                .font(PluginSettingsTheme.Typography.rowIcon)
-                .foregroundStyle(.secondary)
-                .frame(width: PluginSettingsTheme.Size.rowIcon)
-
-            Text(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
+            Label(
+                localization.string("settings.column.action", defaultValue: "操作"),
+                systemImage: "keyboard"
+            )
                 .font(PluginSettingsTheme.Typography.rowDescription)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .frame(minWidth: 80, maxWidth: .infinity, alignment: .leading)
+                .truncationMode(.tail)
+                .frame(width: SidecarSettingsColumnWidth.shortcutActionLabel, alignment: .leading)
+                .help(localization.string("settings.column.action", defaultValue: "操作"))
 
             shortcutActionPicker
                 .frame(width: SidecarSettingsColumnWidth.shortcutAction)
+
+            if showsShortcutLabel {
+                Text(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(width: SidecarSettingsColumnWidth.shortcutLabel, alignment: .leading)
+                    .help(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
+            }
 
             shortcutControl
                 .frame(
@@ -503,6 +558,8 @@ private struct SidecarDeviceSettingsRow: View {
                         + PluginSettingsTheme.Spacing.controlCluster,
                     alignment: .leading
                 )
+
+            Spacer(minLength: 0)
         }
     }
 
@@ -674,29 +731,5 @@ private struct SidecarDeviceSettingsRow: View {
         case .unavailable:
             localization.string("settings.deviceStatus.unavailable", defaultValue: "当前不可用")
         }
-    }
-}
-
-private struct SidecarDeviceSettingsColumnHeader: View {
-    let localization: PluginLocalization
-
-    var body: some View {
-        HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-            Color.clear.frame(width: 14)
-            Color.clear.frame(width: PluginSettingsTheme.Size.rowIcon)
-            Color.clear.frame(minWidth: 130, maxWidth: .infinity)
-
-            Label(
-                localization.string("settings.group.connectionPolicy", defaultValue: "连接策略"),
-                systemImage: "cable.connector"
-            )
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .help(localization.string("settings.group.connectionPolicy", defaultValue: "连接策略"))
-                .frame(width: SidecarSettingsColumnWidth.connection, alignment: .leading)
-        }
-        .font(PluginSettingsTheme.Typography.rowDescription)
-        .foregroundStyle(.secondary)
-        .pluginSettingsListRowPadding(interactive: true)
     }
 }

--- a/Plugins/Sidecar/Sources/SidecarSettingsView.swift
+++ b/Plugins/Sidecar/Sources/SidecarSettingsView.swift
@@ -4,9 +4,8 @@ import UniformTypeIdentifiers
 import MacToolsPluginKit
 
 private enum SidecarSettingsColumnWidth {
-    static let connection: CGFloat = 144
+    static let picker: CGFloat = 144
     static let connectionLabel: CGFloat = 154
-    static let shortcutAction: CGFloat = 112
     static let shortcutActionLabel: CGFloat = 82
     static let shortcutLabel: CGFloat = 104
     static let shortcutRecorder: CGFloat = 126
@@ -502,7 +501,7 @@ private struct SidecarDeviceSettingsRow: View {
                 }
 
                 transportPicker
-                    .frame(width: SidecarSettingsColumnWidth.connection)
+                    .frame(width: SidecarSettingsColumnWidth.picker)
             }
             .fixedSize(horizontal: true, vertical: false)
         }
@@ -561,7 +560,7 @@ private struct SidecarDeviceSettingsRow: View {
                 }
 
                 shortcutActionPicker
-                    .frame(width: SidecarSettingsColumnWidth.shortcutAction)
+                    .frame(width: SidecarSettingsColumnWidth.picker)
             }
             .fixedSize(horizontal: true, vertical: false)
         }

--- a/Plugins/Sidecar/Sources/SidecarSettingsView.swift
+++ b/Plugins/Sidecar/Sources/SidecarSettingsView.swift
@@ -5,9 +5,6 @@ import MacToolsPluginKit
 
 private enum SidecarSettingsColumnWidth {
     static let picker: CGFloat = 144
-    static let connectionLabel: CGFloat = 154
-    static let shortcutActionLabel: CGFloat = 82
-    static let shortcutLabel: CGFloat = 104
     static let shortcutRecorder: CGFloat = 126
     static let shortcutActionButton: CGFloat = 22
     static let shortcutActions: CGFloat = 50
@@ -483,8 +480,7 @@ private struct SidecarDeviceSettingsRow: View {
                     .font(PluginSettingsTheme.Typography.rowDescription)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(width: SidecarSettingsColumnWidth.connectionLabel, alignment: .leading)
+                    .fixedSize(horizontal: true, vertical: false)
                     .help(localization.string(
                         "settings.group.connectionPolicy",
                         defaultValue: "连接策略"
@@ -529,38 +525,43 @@ private struct SidecarDeviceSettingsRow: View {
 
             Spacer(minLength: 0)
 
-            HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-                Label(
-                    localization.string("settings.column.shortcut", defaultValue: "快捷键"),
-                    systemImage: "keyboard"
-                )
-                .font(PluginSettingsTheme.Typography.rowDescription)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(width: SidecarSettingsColumnWidth.shortcutLabel, alignment: .leading)
-                .help(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
-
-                shortcutControl
-                    .frame(
-                        width: SidecarSettingsColumnWidth.shortcutRecorder
-                            + SidecarSettingsColumnWidth.shortcutActions
-                            + PluginSettingsTheme.Spacing.controlCluster,
-                        alignment: .leading
+            HStack(
+                alignment: .center,
+                spacing: PluginSettingsTheme.Spacing.rowContentControl * 2
+            ) {
+                HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                    Label(
+                        localization.string("settings.column.shortcut", defaultValue: "快捷键"),
+                        systemImage: "keyboard"
                     )
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .help(localization.string("settings.column.shortcut", defaultValue: "快捷键"))
 
-                if showsActionLabel {
-                    Text(localization.string("settings.column.action", defaultValue: "操作"))
-                        .font(PluginSettingsTheme.Typography.rowDescription)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .frame(width: SidecarSettingsColumnWidth.shortcutActionLabel, alignment: .leading)
-                        .help(localization.string("settings.column.action", defaultValue: "操作"))
+                    shortcutControl
+                        .frame(
+                            width: SidecarSettingsColumnWidth.shortcutRecorder
+                                + SidecarSettingsColumnWidth.shortcutActions
+                                + PluginSettingsTheme.Spacing.controlCluster,
+                            alignment: .leading
+                        )
                 }
 
-                shortcutActionPicker
-                    .frame(width: SidecarSettingsColumnWidth.picker)
+                HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                    if showsActionLabel {
+                        Text(localization.string("settings.column.action", defaultValue: "操作"))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .help(localization.string("settings.column.action", defaultValue: "操作"))
+                    }
+
+                    shortcutActionPicker
+                        .frame(width: SidecarSettingsColumnWidth.picker)
+                }
             }
             .fixedSize(horizontal: true, vertical: false)
         }

--- a/Plugins/Sidecar/Sources/SidecarSettingsView.swift
+++ b/Plugins/Sidecar/Sources/SidecarSettingsView.swift
@@ -506,6 +506,7 @@ private struct SidecarDeviceSettingsRow: View {
             }
             .fixedSize(horizontal: true, vertical: false)
         }
+        .frame(maxWidth: .infinity, alignment: .trailing)
     }
 
     private var innerDivider: some View {
@@ -564,6 +565,7 @@ private struct SidecarDeviceSettingsRow: View {
             }
             .fixedSize(horizontal: true, vertical: false)
         }
+        .frame(maxWidth: .infinity, alignment: .trailing)
     }
 
     @ViewBuilder

--- a/Sources/App/ShortcutSettingsView.swift
+++ b/Sources/App/ShortcutSettingsView.swift
@@ -4,7 +4,8 @@ import MacToolsPluginKit
 private enum ShortcutSettingsLayout {
     static let standardRecorderWidth: CGFloat = 126
     static let groupedRecorderWidth: CGFloat = 126
-    static let groupedControlWidth: CGFloat = 192
+    static let groupedControlMinWidth: CGFloat = 192
+    static let groupedControlMaxWidth: CGFloat = 240
     static let groupedIconWidth: CGFloat = 22
     static let actionButtonSize: CGFloat = 22
     static let actionButtonsWidth: CGFloat = 50
@@ -204,7 +205,10 @@ private struct ShortcutSettingsStandardRow: View {
 
 private struct GroupedShortcutSettingsRow: View {
     private enum Layout {
-        static let controlWidth = ShortcutSettingsLayout.groupedControlWidth
+        static let spacing = PluginSettingsTheme.Spacing.rowContentControl
+        static let summaryMinWidth: CGFloat = 220
+        static let controlMinWidth = ShortcutSettingsLayout.groupedControlMinWidth
+        static let controlMaxWidth = ShortcutSettingsLayout.groupedControlMaxWidth
     }
 
     let group: ShortcutSettingsGroup
@@ -214,48 +218,93 @@ private struct GroupedShortcutSettingsRow: View {
     let onReset: (ShortcutSettingsItem) -> Void
 
     var body: some View {
-        HStack(alignment: .center, spacing: 16) {
-            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
-                Text(group.title)
-                    .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .help(group.title)
-
-                if !supportingText.isEmpty {
-                    Text(supportingText)
-                        .font(PluginSettingsTheme.Typography.rowDescription)
-                        .foregroundStyle(supportingColor)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .help(supportingText)
-                }
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .center, spacing: 16) {
+                groupSummary
+                fixedWidthControls
             }
-            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
 
-            HStack(alignment: .center, spacing: 10) {
-                ForEach(group.items) { item in
-                    ShortcutBindingControl(
-                        item: item,
-                        onRecord: { binding in
-                            PluginShortcutRecordingResult.from(
-                                errorMessage: recordShortcut(item, binding)
-                            )
-                        },
-                        onBeginRecording: { onBeginRecording(item) },
-                        onConfigure: { onBeginRecording(item) },
-                        onReset: { onReset(item) },
-                        onClear: { onClear(item) },
-                        title: item.settingsControlTitle ?? item.title,
-                        systemImage: item.settingsControlSystemImage,
-                        layout: .stacked
-                    )
-                    .frame(width: Layout.controlWidth, alignment: .leading)
-                }
+            VStack(alignment: .leading, spacing: Layout.spacing) {
+                groupSummary
+                adaptiveControls
             }
         }
         .pluginSettingsListRowPadding(interactive: true)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var groupSummary: some View {
+        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+            Text(group.title)
+                .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .help(group.title)
+
+            if !supportingText.isEmpty {
+                Text(supportingText)
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(supportingColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .help(supportingText)
+            }
+        }
+        .frame(
+            minWidth: Layout.summaryMinWidth,
+            maxWidth: .infinity,
+            alignment: .leading
+        )
+    }
+
+    private var fixedWidthControls: some View {
+        HStack(alignment: .center, spacing: Layout.spacing) {
+            ForEach(group.items) { item in
+                shortcutControl(for: item)
+                    .frame(width: Layout.controlMaxWidth, alignment: .leading)
+            }
+        }
+    }
+
+    private var adaptiveControls: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(
+                    .adaptive(
+                        minimum: Layout.controlMinWidth,
+                        maximum: Layout.controlMaxWidth
+                    ),
+                    spacing: Layout.spacing,
+                    alignment: .leading
+                )
+            ],
+            alignment: .leading,
+            spacing: Layout.spacing
+        ) {
+            ForEach(group.items) { item in
+                shortcutControl(for: item)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func shortcutControl(for item: ShortcutSettingsItem) -> some View {
+        ShortcutBindingControl(
+            item: item,
+            onRecord: { binding in
+                PluginShortcutRecordingResult.from(
+                    errorMessage: recordShortcut(item, binding)
+                )
+            },
+            onBeginRecording: { onBeginRecording(item) },
+            onConfigure: { onBeginRecording(item) },
+            onReset: { onReset(item) },
+            onClear: { onClear(item) },
+            title: item.settingsControlTitle ?? item.title,
+            systemImage: item.settingsControlSystemImage,
+            layout: .stacked
+        )
     }
 
     private var supportingText: String {
@@ -296,10 +345,13 @@ private struct ShortcutBindingControl: View {
                 actionButtons
             }
         case .stacked:
-            HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.controlCluster) {
+            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
                 controlLabel
-                recorderButton
-                actionButtons
+
+                HStack(alignment: .center, spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                    recorderButton
+                    actionButtons
+                }
             }
         }
     }
@@ -319,7 +371,8 @@ private struct ShortcutBindingControl: View {
                 .font(PluginSettingsTheme.Typography.secondaryLabel)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .help(title)
         }
     }

--- a/Sources/Core/Plugins/PluginHost.swift
+++ b/Sources/Core/Plugins/PluginHost.swift
@@ -1056,7 +1056,25 @@ final class PluginHost: ObservableObject {
             return PluginConfigurationViewItem(id: pluginID, content: AnyView(EmptyView()))
         }
 
-        let context = PluginConfigurationContext(pluginID: pluginID)
+        let context = PluginConfigurationContext(
+            pluginID: pluginID,
+            shortcutItems: shortcutItems.filter { $0.pluginID == pluginID },
+            recordShortcut: { [weak self] itemID, binding in
+                self?.clearShortcutError(for: itemID)
+                return self?.setShortcutBindingAndReturnError(binding, for: itemID)
+            },
+            beginShortcutRecording: { [weak self] itemID in
+                self?.clearShortcutError(for: itemID)
+            },
+            clearShortcut: { [weak self] itemID in
+                self?.clearShortcutError(for: itemID)
+                self?.clearShortcut(for: itemID)
+            },
+            resetShortcut: { [weak self] itemID in
+                self?.clearShortcutError(for: itemID)
+                self?.resetShortcut(for: itemID)
+            }
+        )
         let content: AnyView
 
         switch configurations.count {
@@ -1986,7 +2004,7 @@ final class PluginHost: ObservableObject {
             let pluginID = descriptor.metadata.id
             let matchingSettingsCards = settingsCards.filter { $0.pluginID == pluginID }
             let matchingPermissionCards = permissionCards.filter { $0.pluginID == pluginID }
-            let matchingShortcutItems = shortcutItems.filter { $0.pluginID == pluginID }
+            let allMatchingShortcutItems = shortcutItems.filter { $0.pluginID == pluginID }
             let configurations: [PluginConfiguration]
             if descriptor.hasConfiguration,
                let configuration = guardedOptionalValue(
@@ -1997,6 +2015,13 @@ final class PluginHost: ObservableObject {
                 configurations = [configuration]
             } else {
                 configurations = []
+            }
+            let integratedShortcutGroupIDs = Set(
+                configurations.flatMap(\.integratedShortcutGroupIDs)
+            )
+            let matchingShortcutItems = allMatchingShortcutItems.filter { item in
+                guard let groupID = item.settingsGroupID else { return true }
+                return !integratedShortcutGroupIDs.contains(groupID)
             }
             let hasConfigurationSurface = !matchingSettingsCards.isEmpty
                 || !matchingPermissionCards.isEmpty

--- a/Sources/MacToolsPluginKit/PluginModels.swift
+++ b/Sources/MacToolsPluginKit/PluginModels.swift
@@ -272,24 +272,70 @@ public enum MenuBarControlItemDefaults {
 
 public struct PluginConfigurationContext {
     public let pluginID: String
+    public let shortcutItems: [ShortcutSettingsItem]
 
-    public init(pluginID: String) {
+    private let recordShortcutHandler: (String, ShortcutBinding) -> String?
+    private let beginShortcutRecordingHandler: (String) -> Void
+    private let clearShortcutHandler: (String) -> Void
+    private let resetShortcutHandler: (String) -> Void
+
+    public init(
+        pluginID: String,
+        shortcutItems: [ShortcutSettingsItem] = [],
+        recordShortcut: @escaping (String, ShortcutBinding) -> String? = { _, _ in nil },
+        beginShortcutRecording: @escaping (String) -> Void = { _ in },
+        clearShortcut: @escaping (String) -> Void = { _ in },
+        resetShortcut: @escaping (String) -> Void = { _ in }
+    ) {
         self.pluginID = pluginID
+        self.shortcutItems = shortcutItems
+        self.recordShortcutHandler = recordShortcut
+        self.beginShortcutRecordingHandler = beginShortcutRecording
+        self.clearShortcutHandler = clearShortcut
+        self.resetShortcutHandler = resetShortcut
+    }
+
+    public func shortcutItem(definitionID: String) -> ShortcutSettingsItem? {
+        shortcutItems.first { $0.id == "\(pluginID).shortcut.\(definitionID)" }
+    }
+
+    public func recordShortcut(
+        _ binding: ShortcutBinding,
+        for itemID: String
+    ) -> PluginShortcutRecordingResult {
+        PluginShortcutRecordingResult.from(
+            errorMessage: recordShortcutHandler(itemID, binding)
+        )
+    }
+
+    public func beginShortcutRecording(for itemID: String) {
+        beginShortcutRecordingHandler(itemID)
+    }
+
+    public func clearShortcut(for itemID: String) {
+        clearShortcutHandler(itemID)
+    }
+
+    public func resetShortcut(for itemID: String) {
+        resetShortcutHandler(itemID)
     }
 }
 
 public struct PluginConfiguration {
     public let description: String?
     public let prefersFullHeight: Bool
+    public let integratedShortcutGroupIDs: Set<String>
     public let makeView: (PluginConfigurationContext) -> AnyView
 
     public init<Content: View>(
         description: String? = nil,
         prefersFullHeight: Bool = false,
+        integratedShortcutGroupIDs: Set<String> = [],
         @ViewBuilder content: @escaping (PluginConfigurationContext) -> Content
     ) {
         self.description = description
         self.prefersFullHeight = prefersFullHeight
+        self.integratedShortcutGroupIDs = integratedShortcutGroupIDs
         self.makeView = { context in
             AnyView(content(context))
         }

--- a/Tests/Core/Plugins/PluginHostComponentSupportTests.swift
+++ b/Tests/Core/Plugins/PluginHostComponentSupportTests.swift
@@ -193,6 +193,61 @@ final class PluginHostComponentSupportTests: XCTestCase {
         XCTAssertEqual(item?.settingsControlSystemImage, "sun.min.fill")
     }
 
+    func testIntegratedShortcutGroupIsRenderedByCustomConfigurationContext() throws {
+        let configurationCounter = ConfigurationRenderCounter()
+        let inlineDefinition = PluginShortcutDefinition(
+            id: "inline",
+            title: "Inline shortcut",
+            description: "Rendered with the custom configuration.",
+            actionID: "inline",
+            scope: .global,
+            defaultBinding: nil,
+            isRequired: false,
+            settingsGroupID: "devices"
+        )
+        let globalDefinition = PluginShortcutDefinition(
+            id: "global",
+            title: "Global shortcut",
+            description: "Rendered by the host shortcut section.",
+            actionID: "global",
+            scope: .global,
+            defaultBinding: nil,
+            isRequired: false,
+            settingsGroupID: "global"
+        )
+        let plugin = MockComponentPanelPlugin(
+            id: "component",
+            shortcutDefinitions: [inlineDefinition, globalDefinition],
+            configuration: PluginConfiguration(
+                description: "Custom configuration",
+                integratedShortcutGroupIDs: ["devices"]
+            ) { context in
+                configurationCounter.makeView(context: context)
+            }
+        )
+        let host = makeHost(plugins: [plugin])
+
+        XCTAssertEqual(
+            host.pluginConfigurationItems.first?.shortcutItems.map(\.settingsGroupID),
+            ["global"]
+        )
+
+        _ = host.pluginConfigurationViewItem(for: "component")
+        let context = try XCTUnwrap(configurationCounter.lastContext)
+        XCTAssertEqual(context.shortcutItems.map(\.settingsGroupID), ["devices", "global"])
+
+        let inlineItem = try XCTUnwrap(context.shortcutItem(definitionID: "inline"))
+        let binding = ShortcutBinding(keyCode: 18, modifiers: [.command, .option])
+        XCTAssertEqual(context.recordShortcut(binding, for: inlineItem.id), .accepted)
+        XCTAssertEqual(
+            host.shortcutItems.first(where: { $0.id == inlineItem.id })?.bindingText,
+            ShortcutFormatter.displayString(for: binding)
+        )
+
+        context.clearShortcut(for: inlineItem.id)
+        XCTAssertFalse(host.shortcutItems.first(where: { $0.id == inlineItem.id })?.canClear ?? true)
+    }
+
     func testShortcutsInSameSharedBindingGroupCanUseSameBinding() {
         let binding = ShortcutBinding(keyCode: 18, modifiers: [.command, .option])
         let componentPanelPlugin = MockComponentPanelPlugin(
@@ -1506,9 +1561,11 @@ private final class MutableComponentPanelPlugin: MacToolsPlugin, PluginComponent
 @MainActor
 private final class ConfigurationRenderCounter {
     private(set) var callCount = 0
+    private(set) var lastContext: PluginConfigurationContext?
 
     func makeView(context: PluginConfigurationContext) -> AnyView {
         callCount += 1
+        lastContext = context
         return AnyView(Text(context.pluginID))
     }
 }

--- a/changes/unreleased/fix-grouped-shortcut-layout.md
+++ b/changes/unreleased/fix-grouped-shortcut-layout.md
@@ -1,0 +1,7 @@
+---
+release: app
+type: fixed
+area: Settings
+---
+
+Grouped shortcut controls now stay readable and inside their settings card when labels are long or many actions are shown.

--- a/changes/unreleased/sidecar-inline-device-shortcuts.md
+++ b/changes/unreleased/sidecar-inline-device-shortcuts.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: fixed
+area: Sidecar
+---
+
+Sidecar device settings now keep connection options and shortcuts readable in narrow Settings windows.


### PR DESCRIPTION
## Summary

- keep grouped shortcut labels and recorders within their settings card at narrow widths
- place each Sidecar device’s connection policy, shortcut binding, and action in one self-contained two-line row
- present the shortcut recorder before its secondary action picker
- align both rows to one trailing edge and give both menu pickers the same stable width
- use tight spacing inside each label/control pair with a wider gap between the Shortcut and Action groups
- label the row-level controls directly and remove the detached table header
- use a lighter inset divider inside each device while retaining stronger device-to-device separators
- keep shortcut persistence, validation, conflict detection, and registration owned by the host
- leave Toggle as the default while preserving explicit Connect and Disconnect choices

## Root cause

Grouped shortcut controls were constrained to narrow cells while their labels, recorders, and action buttons were forced into one horizontal row. Sidecar also split each device’s connection options into its custom table and the corresponding shortcut recorder into a separate host section, making related controls harder to associate and causing the bottom card to overflow.

## User impact

Sidecar settings remain readable in narrow Settings windows, and each device now has a clear two-line hierarchy: device identity and connection policy first, then the primary shortcut binding followed by its secondary action. Labels sit close to their controls, while the distinct setting groups retain clear separation. Both control lines share a consistent trailing edge, and the two menu pickers use the same stable width. Subtle inner dividers separate the two concerns without competing with the stronger device boundaries. The two global Sidecar shortcuts remain in the shared Shortcuts section.

Existing behavior is unchanged: each device has one shortcut, Toggle is the default action, and Connect or Disconnect can be selected explicitly. The shared grouped-shortcut layout also adapts cleanly for other plugins such as Display Brightness and Window Switcher.

## Validation

- built the Sidecar plugin package with Xcode beta
- passed all 36 tests in SidecarPluginTests
- passed PluginHostComponentSupportTests.testIntegratedShortcutGroupIsRenderedByCustomConfigurationContext
- completed a signing-disabled Debug app build
- rebuilt, synced, and relaunched the local Debug app with the final Sidecar package
- validated the string catalog and git diff formatting

## Screenshots

### Before

<img width="1152" height="916" alt="Sidecar shortcut controls overlapping before the fix" src="https://github.com/user-attachments/assets/dee388d6-d564-40a7-b3e0-df06bd18ddbb" />

### After — compact width

<img width="853" height="916" alt="Sidecar settings after the fix at compact width" src="https://github.com/user-attachments/assets/e3068329-13d6-470f-a31f-1a4636a05b05" />

### After — wide width

<img width="1152" height="916" alt="Sidecar settings after the fix at wide width" src="https://github.com/user-attachments/assets/b74216c3-550f-4fa2-a87f-98eb3886f8a8" />