### PR TITLE
docs: document macOS/Xcode requirement for Cursor Cloud (Linux VM cannot build)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,11 @@
 - Large product/interaction changes may add date-prefixed documents under `docs/superpowers/specs/` or `docs/superpowers/plans/`.
 - Icons, asset catalogs, `LocalConfig.xcconfig`, and release env files are usually maintained by the user or generation flow; avoid unrelated changes.
 
+## Cursor Cloud specific instructions
+- This project is a native macOS app (Swift 6 + SwiftUI/AppKit, `platform: macOS`, deploymentTarget 14.0) built with Xcode via XcodeGen. It depends on Apple-only frameworks (AppKit, SwiftUI, IOKit, CoreGraphics, EventKit, Sparkle) and requires `xcodebuild` + `xcodegen`.
+- The default Cursor Cloud Agent VM is Linux (Ubuntu x86_64) and CANNOT build, test, or run this repo: no Xcode/`xcodebuild`, no `xcodegen`, no Swift/Apple SDKs, and those SDKs are not installable on Linux. The open-source Swift-on-Linux toolchain lacks AppKit/SwiftUI/IOKit, so even installing it does not help.
+- There is no update script that can make this buildable on Linux; do not add one. Full setup, build (`make build`), tests (`xcodebuild ... test`), and run (`make run`) require a macOS host with Xcode. Use the standard commands in `## Build And Run` / `## Testing Requirements` on a Mac.
+
 ## Agent Workflow
 - Before modifying code, use `rg`/`rg --files` to quickly locate existing patterns and prefer adjacent implementations.
 - Keep changes focused. Do not opportunistically refactor unrelated modules or overwrite existing user edits.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting that this repository is a native macOS app and cannot be built, tested, or run on the default Linux Cursor Cloud Agent VM.

## Why

While attempting to set up the development environment, the Cloud Agent VM was found to be Linux (Ubuntu 24.04 x86_64). This project:
- Is a native macOS app (Swift 6 + SwiftUI/AppKit, `platform: macOS`, deploymentTarget 14.0), built with Xcode via XcodeGen (`project.yml` → `MacTools.xcodeproj` → `xcodebuild`).
- Depends on Apple-only frameworks (AppKit, SwiftUI, IOKit, CoreGraphics, EventKit, Sparkle) that are not available/installable on Linux.
- Requires `xcodebuild` and `xcodegen`, neither of which exists on the Linux VM.

There is no Linux-installable dependency set (no update script) that can make `make build` / `xcodebuild test` / `make run` succeed here. Full setup requires a macOS host with Xcode.

## Change
- `AGENTS.md`: new `## Cursor Cloud specific instructions` section capturing this durable, non-obvious constraint for future cloud agents.

No source or build configuration changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cf772c3-d32d-43e0-98f4-4c7e757323e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cf772c3-d32d-43e0-98f4-4c7e757323e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

