### PR TITLE
fix(device-battery): dispatch Bluetooth callbacks safely

### DIFF
--- a/Plugins/DeviceBattery/Sources/DeviceBatteryEventObservers.swift
+++ b/Plugins/DeviceBattery/Sources/DeviceBatteryEventObservers.swift
@@ -53,31 +53,154 @@ protocol DeviceBatteryBluetoothConnectionObserving: AnyObject {
 }
 
 @MainActor
-final class SystemDeviceBatteryBluetoothConnectionObserver: NSObject,
+final class SystemDeviceBatteryBluetoothConnectionObserver:
     DeviceBatteryBluetoothConnectionObserving {
     var onConnectionChange: (() -> Void)?
 
-    private var connectionNotification: IOBluetoothUserNotification?
-    private nonisolated let disconnectRegistry = DeviceBatteryBluetoothDisconnectRegistry()
+    private let worker: DeviceBatteryBluetoothConnectionWorker
+    private var isStarted = false
+
+    init(
+        registrationBackend: any DeviceBatteryBluetoothConnectionRegistering =
+            SystemDeviceBatteryBluetoothConnectionRegistrationBackend()
+    ) {
+        worker = DeviceBatteryBluetoothConnectionWorker(
+            registrationBackend: registrationBackend
+        )
+    }
 
     func start() {
-        guard connectionNotification == nil else { return }
-        disconnectRegistry.start()
-        connectionNotification = IOBluetoothDevice.register(
-            forConnectNotifications: self,
-            selector: #selector(deviceDidConnect(notification:device:))
-        )
-
-        let pairedDevices = IOBluetoothDevice.pairedDevices() as? [IOBluetoothDevice] ?? []
-        for device in pairedDevices where device.isConnected() {
-            registerForDisconnect(of: device)
+        guard !isStarted else { return }
+        isStarted = true
+        worker.start { [weak self] in
+            Task { @MainActor in
+                guard let self, self.isStarted else { return }
+                self.onConnectionChange?()
+            }
         }
     }
 
     func stop() {
+        guard isStarted else { return }
+        isStarted = false
+        worker.stop()
+    }
+
+    isolated deinit {
+        worker.stop()
+    }
+}
+
+protocol DeviceBatteryBluetoothConnectionRegistering: Sendable {
+    func registerForConnect(
+        observer: Any,
+        selector: Selector
+    ) -> IOBluetoothUserNotification?
+    func connectedPairedDevices() -> [IOBluetoothDevice]
+}
+
+struct SystemDeviceBatteryBluetoothConnectionRegistrationBackend:
+    DeviceBatteryBluetoothConnectionRegistering,
+    @unchecked Sendable {
+    func registerForConnect(
+        observer: Any,
+        selector: Selector
+    ) -> IOBluetoothUserNotification? {
+        IOBluetoothDevice.register(
+            forConnectNotifications: observer,
+            selector: selector
+        )
+    }
+
+    func connectedPairedDevices() -> [IOBluetoothDevice] {
+        let pairedDevices = IOBluetoothDevice.pairedDevices() as? [IOBluetoothDevice] ?? []
+        return pairedDevices.filter { $0.isConnected() }
+    }
+}
+
+private final class DeviceBatteryBluetoothConnectionWorker: NSObject, @unchecked Sendable {
+    typealias Delivery = @Sendable () -> Void
+
+    private struct RequestState {
+        var generation: UInt = 0
+        var isActive = false
+        var delivery: Delivery?
+    }
+
+    private let queue = DispatchQueue(
+        label: "cc.ggbond.mactools.device-battery.bluetooth-observer",
+        qos: .utility
+    )
+    private let stateLock = NSLock()
+    private let registrationBackend: any DeviceBatteryBluetoothConnectionRegistering
+    private let disconnectRegistry = DeviceBatteryBluetoothDisconnectRegistry()
+    private var requestState = RequestState()
+    private var connectionNotification: IOBluetoothUserNotification?
+
+    init(registrationBackend: any DeviceBatteryBluetoothConnectionRegistering) {
+        self.registrationBackend = registrationBackend
+    }
+
+    func start(delivery: @escaping Delivery) {
+        stateLock.lock()
+        requestState.delivery = delivery
+        guard !requestState.isActive else {
+            stateLock.unlock()
+            return
+        }
+        requestState.isActive = true
+        requestState.generation &+= 1
+        let generation = requestState.generation
+        stateLock.unlock()
+
+        queue.async { [self] in
+            install(generation: generation)
+        }
+    }
+
+    func stop() {
+        stateLock.lock()
+        requestState.delivery = nil
+        requestState.isActive = false
+        requestState.generation &+= 1
+        stateLock.unlock()
+
+        queue.async { [self] in
+            uninstall()
+        }
+    }
+
+    private func install(generation: UInt) {
+        guard connectionNotification == nil else { return }
+        disconnectRegistry.start()
+        let notification = registrationBackend.registerForConnect(
+            observer: self,
+            selector: #selector(deviceDidConnect(notification:device:))
+        )
+
+        guard isCurrent(generation: generation) else {
+            notification?.unregister()
+            disconnectRegistry.stop()
+            return
+        }
+
+        connectionNotification = notification
+        for device in registrationBackend.connectedPairedDevices() {
+            registerForDisconnect(of: device)
+        }
+    }
+
+    private func uninstall() {
         connectionNotification?.unregister()
         connectionNotification = nil
         disconnectRegistry.stop()
+    }
+
+    private func isCurrent(generation: UInt) -> Bool {
+        stateLock.lock()
+        let isCurrent = requestState.isActive && requestState.generation == generation
+        stateLock.unlock()
+        return isCurrent
     }
 
     @objc nonisolated private func deviceDidConnect(
@@ -105,13 +228,10 @@ final class SystemDeviceBatteryBluetoothConnectionObserver: NSObject,
     }
 
     nonisolated private func publishConnectionChange() {
-        Task { @MainActor [weak self] in
-            self?.onConnectionChange?()
-        }
-    }
-
-    isolated deinit {
-        stop()
+        stateLock.lock()
+        let delivery = requestState.isActive ? requestState.delivery : nil
+        stateLock.unlock()
+        delivery?()
     }
 }
 

--- a/Plugins/DeviceBattery/Sources/RapooBatteryMonitor.swift
+++ b/Plugins/DeviceBattery/Sources/RapooBatteryMonitor.swift
@@ -552,7 +552,7 @@ private func rapooHIDDeviceMatchedCallback(
     }
 
     let monitor = Unmanaged<RapooHIDBatteryMonitor>.fromOpaque(context).takeUnretainedValue()
-    MainActor.assumeIsolated {
+    DispatchQueue.main.async {
         monitor.handleDeviceMatched(device)
     }
 }
@@ -568,7 +568,7 @@ private func rapooHIDDeviceRemovedCallback(
     }
 
     let monitor = Unmanaged<RapooHIDBatteryMonitor>.fromOpaque(context).takeUnretainedValue()
-    MainActor.assumeIsolated {
+    DispatchQueue.main.async {
         monitor.handleDeviceRemoved(device)
     }
 }
@@ -588,7 +588,7 @@ private func rapooHIDInputReportCallback(
 
     let session = Unmanaged<RapooHIDDeviceSession>.fromOpaque(context).takeUnretainedValue()
     let bytes = Array(UnsafeBufferPointer(start: report, count: reportLength))
-    MainActor.assumeIsolated {
+    DispatchQueue.main.async {
         session.monitor?.handleInputReport(
             session: session,
             result: result,

--- a/Plugins/DeviceBattery/Tests/DeviceBatteryEventObserversTests.swift
+++ b/Plugins/DeviceBattery/Tests/DeviceBatteryEventObserversTests.swift
@@ -1,0 +1,57 @@
+import IOBluetooth
+import XCTest
+@testable import DeviceBatteryPlugin
+
+@MainActor
+final class DeviceBatteryEventObserversTests: XCTestCase {
+    func testBluetoothObserverStartAndStopDoNotBlockMainActorDuringRegistration() async {
+        let backend = BlockingBluetoothConnectionRegistrationBackend()
+        let observer = SystemDeviceBatteryBluetoothConnectionObserver(
+            registrationBackend: backend
+        )
+
+        observer.start()
+        await fulfillment(of: [backend.registrationStarted], timeout: 1)
+
+        XCTAssertFalse(backend.registrationRanOnMainThread)
+        observer.stop()
+        backend.allowRegistrationToFinish.signal()
+
+        await fulfillment(of: [backend.registrationFinished], timeout: 1)
+    }
+}
+
+private final class BlockingBluetoothConnectionRegistrationBackend:
+    DeviceBatteryBluetoothConnectionRegistering,
+    @unchecked Sendable {
+    let registrationStarted = XCTestExpectation(description: "Bluetooth registration started")
+    let registrationFinished = XCTestExpectation(description: "Bluetooth registration finished")
+    let allowRegistrationToFinish = DispatchSemaphore(value: 0)
+
+    private let lock = NSLock()
+    private var didRunOnMainThread = false
+
+    var registrationRanOnMainThread: Bool {
+        lock.lock()
+        let value = didRunOnMainThread
+        lock.unlock()
+        return value
+    }
+
+    func registerForConnect(
+        observer: Any,
+        selector: Selector
+    ) -> IOBluetoothUserNotification? {
+        lock.lock()
+        didRunOnMainThread = Thread.isMainThread
+        lock.unlock()
+        registrationStarted.fulfill()
+        allowRegistrationToFinish.wait()
+        registrationFinished.fulfill()
+        return nil
+    }
+
+    func connectedPairedDevices() -> [IOBluetoothDevice] {
+        []
+    }
+}

--- a/changes/unreleased/device-battery-bluetooth-observer.md
+++ b/changes/unreleased/device-battery-bluetooth-observer.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: fixed
+area: Device Battery
+---
+
+Opening Dashboard no longer becomes unresponsive while Bluetooth battery monitoring starts.


### PR DESCRIPTION
## Summary

- move Bluetooth connection discovery and registration off the main actor
- deliver connection changes back to the plugin on the main actor
- dispatch Rapoo HID match, removal, and input-report callbacks asynchronously to the main queue instead of assuming callback isolation
- make observer start/stop idempotent and reject callbacks from superseded registrations
- add a focused regression test for non-blocking registration and lifecycle cleanup

## Root cause

The Device Battery plugin registered for Bluetooth connection notifications and enumerated connected paired devices synchronously from its main-actor observer. Its Rapoo HID callbacks also used `MainActor.assumeIsolated` even though IOKit does not guarantee delivery on the main actor. Opening Dashboard could therefore block during Bluetooth setup, while Rapoo callbacks could violate the actor-isolation contract.

The observer worker now owns Bluetooth registration on a utility queue, tracks lifecycle generations under a lock, and only publishes callbacks while the current registration remains active. Rapoo callbacks copy required data and enqueue plugin-state work on the main queue.

## User impact

Opening Dashboard no longer becomes unresponsive while Bluetooth battery monitoring starts, and Rapoo device updates cross the callback boundary safely. Plugin state updates still occur on the main actor.

## Verification

- `DeviceBatteryEventObserversTests` passed
- refreshed CI passed for the complete isolated observer and Rapoo callback fix
- the PR contains only Device Battery observer/callback code, its regression test, and its changelog fragment
