### PR TITLE
fix(plugins): validate manifest paths before sync mutations

### DIFF
--- a/scripts/plugins/sync-debug-plugins.sh
+++ b/scripts/plugins/sync-debug-plugins.sh
@@ -90,17 +90,13 @@ if [[ -z "$SOURCE_DIR" || ! -d "$SOURCE_DIR" ]]; then
     exit 1
 fi
 
-PRODUCTS_DIR="$(cd "$PRODUCTS_DIR" 2>/dev/null && pwd || true)"
+PRODUCTS_DIR="$(cd "$PRODUCTS_DIR" 2>/dev/null && pwd -P || true)"
 if [[ -z "$PRODUCTS_DIR" || ! -d "$PRODUCTS_DIR" ]]; then
     echo "Debug build products directory not found. Run 'make build' first: $PRODUCTS_DIR" >&2
     exit 1
 fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-OUTPUT_DIR="$(mkdir -p "$OUTPUT_DIR" && cd "$OUTPUT_DIR" && pwd)"
-PACKAGES_DIR="$OUTPUT_DIR/Packages"
-CATALOG_PATH="$OUTPUT_DIR/catalog.dev.json"
-STATE_DIR="$OUTPUT_DIR/.sync-state"
 MANIFEST_COPY_SCRIPT="$REPO_ROOT/scripts/plugins/copy-plugin-manifest.py"
 APP_VERSION_CONFIG="$REPO_ROOT/Configs/AppVersion.xcconfig"
 DEVELOPMENT_HOST_VERSION="$(
@@ -108,17 +104,65 @@ DEVELOPMENT_HOST_VERSION="$(
         --app-version-config "$APP_VERSION_CONFIG"
 )"
 
-mkdir -p "$PACKAGES_DIR"
-mkdir -p "$STATE_DIR"
-if [[ "$SKIP_INSTALL" != "1" ]]; then
-    mkdir -p "$INSTALL_DIR"
-fi
+# Resolve a path to its canonical form, following symlinks in every existing
+# component. The path may not exist yet: the deepest existing directory
+# ancestor is resolved and the remaining components are appended verbatim.
+# A symlink component (even a dangling one) stops the walk so it is resolved
+# or refused instead of being silently appended to a different location.
+resolve_path() {
+    local path="$1"
+    local current="$path"
+    local suffix=""
+    local parent=""
+    while [[ -n "$current" && "$current" != "/" && ! -d "$current" && ! -L "$current" ]]; do
+        suffix="/${current##*/}${suffix}"
+        parent="${current%/*}"
+        if [[ "$parent" == "$current" ]]; then
+            current="/"
+            break
+        fi
+        current="$parent"
+    done
+    if [[ -z "$current" ]]; then
+        current="/"
+    fi
+    local resolved
+    resolved="$(cd -P -- "$current" 2>/dev/null && pwd -P 2>/dev/null)" || true
+    if [[ -z "$resolved" ]]; then
+        printf '%s' ""
+        return 1
+    fi
+    printf '%s%s' "$resolved" "$suffix"
+}
+
+# Refuse operations on a destination that resolves outside its intended root,
+# including when an intermediate component (e.g. a pre-existing Packages
+# symlink) would redirect the real location elsewhere.
+assert_path_within_root() {
+    local path="$1"
+    local root="$2"
+    local resolved_root resolved_path
+    resolved_root="$(resolve_path "$root" 2>/dev/null)" || true
+    resolved_path="$(resolve_path "$path" 2>/dev/null)" || true
+    if [[ -z "$resolved_root" || -z "$resolved_path" ]]; then
+        echo "Refusing to operate on unresolvable path outside $root: $path" >&2
+        exit 1
+    fi
+    local root_with_slash="${resolved_root%/}/"
+    if [[ "$resolved_path" != "${resolved_root%/}" && "$resolved_path" != "$root_with_slash"* ]]; then
+        echo "Refusing to operate outside $resolved_root: $path (resolves to $resolved_path)" >&2
+        exit 1
+    fi
+}
 
 copy_package_to_installed_store() {
     local package_path="$1"
     local plugin_id="$2"
     local destination="$INSTALL_DIR/$plugin_id.mactoolsplugin"
     local staging="$INSTALL_DIR/.$plugin_id.syncing.$$.mactoolsplugin"
+
+    assert_path_within_root "$destination" "$INSTALL_DIR"
+    assert_path_within_root "$staging" "$INSTALL_DIR"
 
     rm -rf "$staging"
     ditto "$package_path" "$staging"
@@ -137,6 +181,7 @@ import hashlib
 import json
 import os
 import pathlib
+import re
 import sys
 
 source_dir = pathlib.Path(sys.argv[1])
@@ -153,6 +198,39 @@ def validate_field(value: str) -> str:
     if "\t" in value or "\n" in value:
         emit_error(f"Unsupported tab or newline in plugin sync field: {value!r}")
     return value
+
+PLUGIN_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{1,126}[A-Za-z0-9]\Z")
+RESERVED_PLUGIN_ID = "marketplace"
+INVALID_PATH_COMPONENTS = frozenset({"", ".", ".."})
+
+def validate_plugin_identity(
+    plugin_id: str,
+    bundle_relative_path: str,
+    manifest: pathlib.Path,
+) -> None:
+    if (
+        plugin_id == RESERVED_PLUGIN_ID
+        or PLUGIN_ID_PATTERN.fullmatch(plugin_id) is None
+    ):
+        emit_error(
+            f"Invalid plugin id {plugin_id!r} in {manifest}: must match the "
+            "PluginPackageManifestLoader grammar "
+            "([A-Za-z0-9][A-Za-z0-9._-]{1,126}[A-Za-z0-9], not 'marketplace')"
+        )
+
+    if (
+        not bundle_relative_path
+        or bundle_relative_path.startswith("/")
+        or any(
+            part in INVALID_PATH_COMPONENTS
+            for part in bundle_relative_path.split("/")
+        )
+    ):
+        emit_error(
+            f"Invalid bundleRelativePath {bundle_relative_path!r} in {manifest}: "
+            "must be a normalized relative path with no absolute, empty, '.', "
+            "or '..' components"
+        )
 
 def discover_candidates() -> list[pathlib.Path]:
     if (source_dir / "plugin.json").is_file():
@@ -227,6 +305,8 @@ for plugin_root in discover_candidates():
     if filters and plugin_root.name not in filters and plugin_id not in filters:
         continue
 
+    validate_plugin_identity(plugin_id, bundle_relative_path, manifest)
+
     bundle_name = pathlib.Path(bundle_relative_path).name
     bundle_path = products_dir / bundle_name
     if not bundle_path.is_dir():
@@ -281,12 +361,74 @@ else
     exit "$discovery_status"
 fi
 
+# Preflight: canonicalize the roots without creating anything, then validate
+# every destination the sync could touch for all records. Nothing on disk is
+# created or changed until every check passes, so a rejected destination (e.g.
+# a symlink redirecting Output/Packages or the install path outside its root)
+# aborts with a pristine filesystem: no output/state/install directories, no
+# rebuilt package, no fingerprint.
+if OUTPUT_DIR="$(resolve_path "$OUTPUT_DIR")"; then
+    :
+else
+    echo "Refusing to operate on unresolvable output directory: $OUTPUT_DIR" >&2
+    exit 1
+fi
+PACKAGES_DIR="$OUTPUT_DIR/Packages"
+CATALOG_PATH="$OUTPUT_DIR/catalog.dev.json"
+STATE_DIR="$OUTPUT_DIR/.sync-state"
+
+if [[ "$SKIP_INSTALL" != "1" ]]; then
+    if INSTALL_DIR="$(resolve_path "$INSTALL_DIR")"; then
+        :
+    else
+        echo "Refusing to operate on unresolvable install directory: $INSTALL_DIR" >&2
+        exit 1
+    fi
+fi
+
+while IFS=$'\t' read -r plugin_root manifest plugin_id bundle_relative_path bundle_path fingerprint; do
+    [[ -n "$plugin_root" ]] || continue
+
+    package_path="$PACKAGES_DIR/$plugin_id.mactoolsplugin"
+    # The package and state checks use OUTPUT_DIR as the root (not PACKAGES_DIR
+    # or STATE_DIR) so a pre-existing symlink at Output/Packages or
+    # Output/.sync-state cannot redirect writes outside the output root.
+    assert_path_within_root "$package_path" "$OUTPUT_DIR"
+    assert_path_within_root "$bundle_path" "$PRODUCTS_DIR"
+    bundle_destination="$package_path/$bundle_relative_path"
+    assert_path_within_root "$bundle_destination" "$OUTPUT_DIR"
+    state_path="$(state_file_for_plugin "$plugin_id")"
+    assert_path_within_root "$state_path" "$OUTPUT_DIR"
+    if [[ "$SKIP_INSTALL" != "1" ]]; then
+        install_path="$INSTALL_DIR/$plugin_id.mactoolsplugin"
+        assert_path_within_root "$install_path" "$INSTALL_DIR"
+        staging_path="$INSTALL_DIR/.$plugin_id.syncing.$$.mactoolsplugin"
+        assert_path_within_root "$staging_path" "$INSTALL_DIR"
+    fi
+done <<< "$plugin_records"
+assert_path_within_root "$CATALOG_PATH" "$OUTPUT_DIR"
+
+# Preflight passed: create the sync directories and run.
+mkdir -p "$OUTPUT_DIR" "$PACKAGES_DIR" "$STATE_DIR"
+if [[ "$SKIP_INSTALL" != "1" ]]; then
+    mkdir -p "$INSTALL_DIR"
+fi
+
 echo "Synchronizing Debug plugin packages..."
 while IFS=$'\t' read -r plugin_root manifest plugin_id bundle_relative_path bundle_path fingerprint; do
     [[ -n "$plugin_root" ]] || continue
 
     package_path="$PACKAGES_DIR/$plugin_id.mactoolsplugin"
+    # Validate every mutation destination before any rm/mkdir/ditto/mv. The
+    # package and state checks use OUTPUT_DIR as the root (not PACKAGES_DIR or
+    # STATE_DIR) so a pre-existing symlink at Output/Packages or
+    # Output/.sync-state cannot redirect writes outside the output root.
+    assert_path_within_root "$package_path" "$OUTPUT_DIR"
+    assert_path_within_root "$bundle_path" "$PRODUCTS_DIR"
+    bundle_destination="$package_path/$bundle_relative_path"
+    assert_path_within_root "$bundle_destination" "$OUTPUT_DIR"
     state_path="$(state_file_for_plugin "$plugin_id")"
+    assert_path_within_root "$state_path" "$OUTPUT_DIR"
     previous_fingerprint=""
     package_synced=0
     if [[ -f "$state_path" ]]; then
@@ -311,6 +453,7 @@ while IFS=$'\t' read -r plugin_root manifest plugin_id bundle_relative_path bund
 
     if [[ "$SKIP_INSTALL" != "1" ]]; then
         install_path="$INSTALL_DIR/$plugin_id.mactoolsplugin"
+        assert_path_within_root "$install_path" "$INSTALL_DIR"
         if [[ "$package_synced" == "1" || ! -d "$install_path" ]]; then
             copy_package_to_installed_store "$package_path" "$plugin_id"
             installed_count=$((installed_count + 1))
@@ -340,6 +483,7 @@ for package in "${packages[@]}"; do
 done
 
 if [[ "$synced_count" -gt 0 || ! -f "$CATALOG_PATH" ]]; then
+    assert_path_within_root "$CATALOG_PATH" "$OUTPUT_DIR"
     echo "Generating local plugin catalog..."
     "$REPO_ROOT/scripts/plugins/generate-plugin-catalog.sh" \
         --mode debug \

--- a/scripts/tests/test_sync_debug_plugins.py
+++ b/scripts/tests/test_sync_debug_plugins.py
@@ -1,0 +1,346 @@
+import json
+import os
+import pathlib
+import re
+import subprocess
+import tempfile
+import unittest
+from typing import Optional
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SYNC_SCRIPT = REPO_ROOT / "scripts/plugins/sync-debug-plugins.sh"
+
+
+def write_manifest(source: pathlib.Path, plugin_id: str, bundle_relative_path: str) -> None:
+    (source / "plugin.json").write_text(
+        json.dumps(
+            {
+                "id": plugin_id,
+                "displayName": "Example",
+                "version": "1.0.0",
+                "minHostVersion": "99.0.0",
+                "pluginKitVersion": 3,
+                "bundleRelativePath": bundle_relative_path,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def run_sync(
+    root: pathlib.Path,
+    plugin_id: str,
+    bundle_relative_path: str,
+) -> subprocess.CompletedProcess:
+    source = root / "Source"
+    products = root / "Products"
+    output = root / "Output"
+    install = root / "Install/Installed"
+    bundle = products / "Example.bundle"
+    source.mkdir()
+    bundle.mkdir(parents=True)
+    (bundle / "payload").write_text("debug bundle", encoding="utf-8")
+    write_manifest(source, plugin_id, bundle_relative_path)
+
+    return subprocess.run(
+        [
+            str(SYNC_SCRIPT),
+            "--source-dir", str(source),
+            "--products-dir", str(products),
+            "--output-dir", str(output),
+            "--install-dir", str(install),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def mutation_targets(
+    root: pathlib.Path,
+    plugin_id: str,
+    bundle_relative_path: str,
+) -> list[pathlib.Path]:
+    """The exact paths the script's mutations would touch for these manifest
+    values if validation were bypassed, normalized the way the OS resolves
+    `..` and `.` components during a real filesystem operation."""
+    output = root / "Output"
+    install = root / "Install/Installed"
+    safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", plugin_id)
+
+    package_path = str(output / "Packages" / f"{plugin_id}.mactoolsplugin")
+    install_path = str(install / f"{plugin_id}.mactoolsplugin")
+    # The script builds the bundle destination by string concatenation
+    # ("$package_path/$bundle_relative_path"), so mirror that rather than
+    # pathlib's absolute-RHS replacement semantics.
+    bundle_destination = f"{package_path}/{bundle_relative_path}"
+    state_path = str(output / ".sync-state" / f"{safe_name}.sha256")
+
+    return [
+        pathlib.Path(os.path.normpath(path))
+        for path in (package_path, install_path, bundle_destination, state_path)
+    ]
+
+
+def place_sentinels(root: pathlib.Path, targets: list[pathlib.Path]) -> list[pathlib.Path]:
+    """Drop a sentinel file at each target path. Shallowest first, and a target
+    nested inside an already-guarded one is skipped since the outer sentinel
+    would already catch any rm/mkdir/mv at that location."""
+    placed: list[pathlib.Path] = []
+    for target in sorted(targets, key=lambda path: len(path.parts)):
+        if any(
+            str(target) == str(guarded) or str(target).startswith(str(guarded) + os.sep)
+            for guarded in placed
+        ):
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("sentinel", encoding="utf-8")
+        placed.append(target)
+    return placed
+
+
+def tree_snapshot(root: pathlib.Path) -> dict[str, tuple[str, Optional[str]]]:
+    """Every relative path under root with its type and file content, so an
+    unchanged snapshot proves the script created, deleted, or modified nothing."""
+    snapshot: dict[str, tuple[str, str | None]] = {}
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            snapshot[relative] = ("symlink", os.readlink(path))
+        elif path.is_dir():
+            snapshot[relative] = ("dir", None)
+        else:
+            snapshot[relative] = ("file", path.read_text(encoding="utf-8"))
+    return snapshot
+
+
+class MaliciousManifestValidationTests(unittest.TestCase):
+    def assert_rejected_without_mutation(
+        self,
+        root: pathlib.Path,
+        plugin_id: str,
+        bundle_relative_path: str,
+        expected_error: str,
+    ) -> None:
+        source = root / "Source"
+        products = root / "Products"
+        source.mkdir()
+        (products / "Example.bundle").mkdir(parents=True)
+        (products / "Example.bundle" / "payload").write_text(
+            "debug bundle", encoding="utf-8"
+        )
+        write_manifest(source, plugin_id, bundle_relative_path)
+
+        # Sentinels sit exactly where the unsafe values would land if the
+        # validation were bypassed (e.g. Output/evil.mactoolsplugin for the
+        # id "../evil", Output/escape.bundle for "../../escape.bundle").
+        place_sentinels(root, mutation_targets(root, plugin_id, bundle_relative_path))
+        before = tree_snapshot(root)
+
+        result = subprocess.run(
+            [
+                str(SYNC_SCRIPT),
+                "--source-dir", str(source),
+                "--products-dir", str(products),
+                "--output-dir", str(root / "Output"),
+                "--install-dir", str(root / "Install/Installed"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(expected_error, result.stderr)
+        # Discovery validates the manifest before any OUTPUT_DIR/Packages/state/
+        # install directory is created, so the whole temp tree must be untouched.
+        self.assertEqual(tree_snapshot(root), before)
+
+    def test_malicious_id_with_path_traversal_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_rejected_without_mutation(
+                pathlib.Path(temporary_directory),
+                "../evil",
+                "Example.bundle",
+                "Invalid plugin id",
+            )
+
+    def test_reserved_marketplace_id_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_rejected_without_mutation(
+                pathlib.Path(temporary_directory),
+                "marketplace",
+                "Example.bundle",
+                "Invalid plugin id",
+            )
+
+    def test_id_outside_manifest_grammar_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_rejected_without_mutation(
+                pathlib.Path(temporary_directory),
+                "a/b",
+                "Example.bundle",
+                "Invalid plugin id",
+            )
+
+    def test_bundle_path_with_dot_dot_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_rejected_without_mutation(
+                pathlib.Path(temporary_directory),
+                "example-debug-plugin",
+                "../../escape.bundle",
+                "Invalid bundleRelativePath",
+            )
+
+    def test_absolute_bundle_path_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_rejected_without_mutation(
+                pathlib.Path(temporary_directory),
+                "example-debug-plugin",
+                "/etc/escape.bundle",
+                "Invalid bundleRelativePath",
+            )
+
+    def test_bundle_path_with_dot_component_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_rejected_without_mutation(
+                pathlib.Path(temporary_directory),
+                "example-debug-plugin",
+                "Sub/./escape.bundle",
+                "Invalid bundleRelativePath",
+            )
+
+    def test_bundle_path_with_empty_component_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_rejected_without_mutation(
+                pathlib.Path(temporary_directory),
+                "example-debug-plugin",
+                "Sub//escape.bundle",
+                "Invalid bundleRelativePath",
+            )
+
+    def test_valid_manifest_still_syncs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = run_sync(
+                pathlib.Path(temporary_directory),
+                "example-debug-plugin",
+                "Example.bundle",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Synced 1 changed", result.stdout)
+
+
+class SymlinkEscapeTests(unittest.TestCase):
+    def setup_valid_sync(
+        self,
+        root: pathlib.Path,
+        bundle_relative_path: str = "Example.bundle",
+    ) -> None:
+        """Create the source manifest and built bundle the sync would consume."""
+        source = root / "Source"
+        products = root / "Products"
+        bundle = products / "Example.bundle"
+        source.mkdir()
+        bundle.mkdir(parents=True)
+        (bundle / "payload").write_text("debug bundle", encoding="utf-8")
+        write_manifest(source, "example-debug-plugin", bundle_relative_path)
+
+    def run_valid_sync(
+        self,
+        root: pathlib.Path,
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                str(SYNC_SCRIPT),
+                "--source-dir", str(root / "Source"),
+                "--products-dir", str(root / "Products"),
+                "--output-dir", str(root / "Output"),
+                "--install-dir", str(root / "Install/Installed"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_rejected_with_untouched_tree(
+        self,
+        root: pathlib.Path,
+        result: subprocess.CompletedProcess,
+        before: dict[str, tuple[str, Optional[str]]],
+    ) -> None:
+        """The preflight phase resolves and validates every destination before
+        any directory creation or file change, so a rejected run must leave the
+        whole temporary tree byte-for-byte identical: no Output/Packages/
+        .sync-state/install directories, no rebuilt package, no fingerprint."""
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Refusing to operate outside", result.stderr)
+        self.assertEqual(tree_snapshot(root), before)
+
+    def test_symlinked_packages_dir_cannot_redirect_package_writes(self) -> None:
+        """A pre-existing Output/Packages symlink must not let package_path
+        escape OUTPUT_DIR: the preflight refuses before creating Output,
+        .sync-state, or the install store."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = pathlib.Path(temporary_directory)
+            output = root / "Output"
+            external = root / "ExternalPackages"
+            output.mkdir()
+            external.mkdir()
+            sentinel = external / "precious.bundle"
+            sentinel.write_text("precious", encoding="utf-8")
+            (output / "Packages").symlink_to(external, target_is_directory=True)
+            self.setup_valid_sync(root)
+            before = tree_snapshot(root)
+
+            result = self.run_valid_sync(root)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "precious")
+            self.assert_rejected_with_untouched_tree(root, result, before)
+
+    def test_symlinked_bundle_subdir_cannot_redirect_bundle_writes(self) -> None:
+        """A pre-existing symlink inside the package path must not let the
+        bundle destination escape OUTPUT_DIR: the preflight refuses before
+        anything is built."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = pathlib.Path(temporary_directory)
+            output = root / "Output"
+            package = output / "Packages/example-debug-plugin.mactoolsplugin"
+            external = root / "ExternalBundle"
+            output.mkdir(parents=True)
+            package.mkdir(parents=True)
+            external.mkdir()
+            sentinel = external / "Example.bundle"
+            sentinel.write_text("precious", encoding="utf-8")
+            (package / "Sub").symlink_to(external, target_is_directory=True)
+            self.setup_valid_sync(root, bundle_relative_path="Sub/Example.bundle")
+            before = tree_snapshot(root)
+
+            result = self.run_valid_sync(root)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "precious")
+            self.assert_rejected_with_untouched_tree(root, result, before)
+
+    def test_symlinked_install_destination_cannot_redirect_installs(self) -> None:
+        """A pre-existing symlink at the installed package path must not let
+        ditto/mv write outside the install root: the preflight refuses before
+        the output package is rebuilt or its fingerprint is written."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = pathlib.Path(temporary_directory)
+            install = root / "Install/Installed"
+            external = root / "ExternalInstall"
+            install.mkdir(parents=True)
+            external.mkdir()
+            sentinel = external / "precious.bundle"
+            sentinel.write_text("precious", encoding="utf-8")
+            (install / "example-debug-plugin.mactoolsplugin").symlink_to(
+                external, target_is_directory=True
+            )
+            self.setup_valid_sync(root)
+            before = tree_snapshot(root)
+
+            result = self.run_valid_sync(root)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "precious")
+            self.assert_rejected_with_untouched_tree(root, result, before)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`scripts/plugins/sync-debug-plugins.sh` trusts `plugin.json` `id` and `bundleRelativePath` after checking only that they are non-empty, then uses them raw in `rm -rf`, `mkdir -p`, `ditto`, and `mv`. Because the script accepts an arbitrary `--source-dir`, a malformed local manifest can use `../` components or an absolute bundle path to escape the package and install roots (dev-time destructive operations).

## Fix

- **Validate during discovery, before any filesystem mutation.** Discovery (and its manifest validation) now runs before `OUTPUT_DIR`/`Packages`/state/install directories are created, so an invalid manifest aborts the sync without changing anything on disk.
- **Plugin IDs must match the `PluginPackageManifestLoader` grammar**: `[A-Za-z0-9][A-Za-z0-9._-]{1,126}[A-Za-z0-9]`, with the reserved `marketplace` value rejected.
- **`bundleRelativePath` must be a normalized relative path**: no absolute paths, and no empty, `.`, or `..` components.
- **Defensive destination containment**: package, staging, and install destinations are asserted to stay within their intended roots before any `rm`/`mkdir`/`ditto`/`mv` runs.

## Verification

- 7 new malicious-manifest regression tests (traversal `id`, reserved `marketplace` id, non-grammar id, `..`/absolute/`.`/empty-component bundle paths) with sentinel files placed directly outside the package and install roots: each run fails, reports the offending field, and leaves the sentinels untouched with no directory created outside the roots.
- Positive control: a valid manifest still syncs and installs end to end.
- Full script suite (`python3 -m unittest discover -s scripts/tests`): 18/18 pass.

Fixes #262