### PR TITLE
feat(app): show Dock icon for settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@
 - If a closer `AGENTS.md` appears in a subdirectory in the future, the closer file takes precedence.
 - `CLAUDE.md` and `GEMINI.md` are compatibility entry points only; shared rules should be maintained here first.
 
+## Language
+- Code, code comments, and Markdown documentation added or modified by Codex must be written in English.
+- User-facing app copy remains subject to the project’s localization guidelines.
+
 ## Project Overview
 - MacTools is a native macOS menu-bar utility collection for frequent, lightweight, non-disruptive system tasks.
 - The stack is Swift 6 with SwiftUI + AppKit, targeting macOS 14.0 or later.

--- a/Sources/App/AppWindowRouter.swift
+++ b/Sources/App/AppWindowRouter.swift
@@ -141,6 +141,14 @@ enum AppWindowPresentation {
     }
 }
 
+enum AppDockVisibilityPolicy {
+    static func activationPolicy(
+        hasVisibleSettingsWindow: Bool
+    ) -> NSApplication.ActivationPolicy {
+        hasVisibleSettingsWindow ? .regular : .accessory
+    }
+}
+
 @MainActor
 final class StandaloneCommandPaletteState: ObservableObject {
     @Published private(set) var presentationOrigin: UnifiedSearchPresentationOrigin?
@@ -591,6 +599,9 @@ final class AppWindowRouter: NSObject, NSWindowDelegate {
 
         let contentSize = window.contentView?.bounds.size ?? SettingsWindowLayout.defaultContentSize
         settingsWindow = window
+        NSApplication.shared.setActivationPolicy(
+            AppDockVisibilityPolicy.activationPolicy(hasVisibleSettingsWindow: true)
+        )
         show(window)
         // SwiftUI installs its toolbar when the window becomes visible. Finish that
         // layout before restoring the content size.
@@ -687,5 +698,8 @@ final class AppWindowRouter: NSObject, NSWindowDelegate {
         window.contentView = nil
         settingsWindow = nil
         settingsNavigationCoordinator = nil
+        NSApplication.shared.setActivationPolicy(
+            AppDockVisibilityPolicy.activationPolicy(hasVisibleSettingsWindow: false)
+        )
     }
 }

--- a/Tests/App/AppWindowRouterTests.swift
+++ b/Tests/App/AppWindowRouterTests.swift
@@ -95,6 +95,17 @@ final class AppWindowRouterTests: XCTestCase {
         XCTAssertEqual(events, ["activate", "deminiaturize", "orderFront"])
     }
 
+    func testDockVisibilityPolicyUsesRegularActivationOnlyForVisibleSettings() {
+        XCTAssertEqual(
+            AppDockVisibilityPolicy.activationPolicy(hasVisibleSettingsWindow: true),
+            .regular
+        )
+        XCTAssertEqual(
+            AppDockVisibilityPolicy.activationPolicy(hasVisibleSettingsWindow: false),
+            .accessory
+        )
+    }
+
     func testSettingsPaletteVisibilityPolicyRejectsMiniaturizedAndInactiveSpaceWindows() {
         XCTAssertTrue(
             CommandPaletteTogglePolicy.settingsPaletteIsVisible(

--- a/changes/unreleased/dock-icon-settings-window.md
+++ b/changes/unreleased/dock-icon-settings-window.md
@@ -1,0 +1,6 @@
+---
+release: app
+type: changed
+---
+
+MacTools now appears in the Dock while its Settings window is open.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -1,3 +1,4 @@
 # Features
 
 - [Dock Lock](dock-lock.md)
+- [Dock Icon for Settings Window](dock-icon-for-settings-window.md)

--- a/docs/features/dock-icon-for-settings-window.md
+++ b/docs/features/dock-icon-for-settings-window.md
@@ -1,0 +1,66 @@
+# Feature — Dock Icon for Settings Window
+
+Last verified: 2026-08-13
+
+Status: implemented
+Source of truth: yes
+
+## Summary
+
+- Settings open → MacTools appears in the Dock.
+- Settings close → MacTools returns to menu-bar-only mode.
+
+## User flow
+
+- The user opens MacTools Settings.
+- MacTools becomes a regular app and its Dock icon appears.
+- The user closes Settings.
+- MacTools returns to accessory mode; its Dock icon disappears.
+
+## Business rules
+
+| Rule | Markdown | Central code | Consumption |
+|---|---|---|---|
+| No durable business rule | — | — | — |
+
+## Decisions
+
+| Date | Decision | Reason | Impact |
+|---|---|---|---|
+| 2026-08-13 | Only Settings controls Dock presence | It is MacTools’s persistent AppKit window; menu-bar panels remain transient | Open Settings shows the icon; closing Settings hides it |
+
+## Plan
+
+- [x] P001 — Define the Dock visibility lifecycle.
+- [x] P002 — Switch activation policy with the Settings window lifecycle.
+- [x] P003 — Add targeted coverage and release note.
+
+## TODO
+
+- [x] F001 — Define acceptance contract — files: `docs/user-stories/app/dock-icon-for-settings-window.md` — status: done
+- [x] F002 — Manage activation policy — files: `Sources/App/AppWindowRouter.swift` — status: done
+- [x] F003 — Cover visibility policy — files: `Tests/App/AppWindowRouterTests.swift` — status: done
+
+## Codex implementation journal
+
+- 2026-08-13 — `AppWindowRouter` selects `.regular` before presenting Settings and restores `.accessory` after its close. `AppDockVisibilityPolicy` makes the lifecycle decision unit-testable. User-story validation and `AppWindowRouterTests` passed; the test build emits pre-existing DiskClean Swift 6 concurrency warnings outside this change.
+
+## Current files
+
+| Area | Files |
+|---|---|
+| Window lifecycle | `Sources/App/AppWindowRouter.swift` |
+| Tests | `Tests/App/AppWindowRouterTests.swift` |
+| User story | `docs/user-stories/app/dock-icon-for-settings-window.md` |
+
+## Tests / QA
+
+- [x] Opening Settings selects `.regular` activation policy.
+- [x] Closing Settings selects `.accessory` activation policy.
+
+## History
+
+<!-- Read only for a bug, regression, audit, or explicit request. -->
+
+| Date | Commit | Type | Notes |
+|---|---|---|---|

--- a/docs/user-stories/INDEX.md
+++ b/docs/user-stories/INDEX.md
@@ -1,0 +1,3 @@
+# User stories
+
+- [US-app-dock-icon-for-settings-window](app/dock-icon-for-settings-window.md)

--- a/docs/user-stories/app/dock-icon-for-settings-window.md
+++ b/docs/user-stories/app/dock-icon-for-settings-window.md
@@ -1,0 +1,36 @@
+# US-app-dock-icon-for-settings-window — Dock Icon for Settings
+
+Last verified: 2026-08-13
+
+| Field | Value |
+| --- | --- |
+| ID | `US-app-dock-icon-for-settings-window` |
+| Status | `implemented` |
+| Domain | `app` |
+| Actor | `MacTools user` |
+
+## User Story
+
+> As a MacTools user, when the Settings window is open, I want to see the MacTools icon in the Dock so that I can identify and return to the active app.
+
+## Acceptance
+
+- Given MacTools runs as a menu-bar app
+- When the user opens Settings
+- Then the app uses the `.regular` activation policy and appears in the Dock
+- And closing Settings restores `.accessory`; menu-bar panels do not affect Dock visibility
+
+## References
+
+| Type | Source |
+| --- | --- |
+| Feature | `docs/features/dock-icon-for-settings-window.md` |
+| Code | `Sources/App/AppWindowRouter.swift` |
+| Test | `Tests/App/AppWindowRouterTests.swift` |
+
+## History
+
+| Date | Type | Previous | New | Source |
+| --- | --- | --- | --- |
+| 2026-08-13 | created | — | Initial contract | User prompt |
+| 2026-08-13 | implementation | `draft` | `implemented` | `Sources/App/AppWindowRouter.swift` |


### PR DESCRIPTION
## Summary

- Show the MacTools Dock icon while the Settings window is open.
- Return to menu-bar-only mode when the Settings window closes.
- Add a targeted activation-policy test for the activation-policy transition.
- Document the behavior and require English for Codex-authored code, comments, and Markdown documentation.

## Validation

- `xcodebuild ... -only-testing:MacToolsTests/AppWindowRouterTests`
- `make build`
- `git diff --check`