### PR TITLE
feat(keep-awake): show behavior modes as visible choices

### DIFF
--- a/Plugins/KeepAwake/Resources/Localizable.xcstrings
+++ b/Plugins/KeepAwake/Resources/Localizable.xcstrings
@@ -290,17 +290,17 @@
     "settings.mode.screenTools.description": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "يبقي الشاشة نشطة ويمنع القفل التلقائي لاستخدام Codex Computer Use والأتمتة ومشاركة الشاشة والتحكم عن بُعد." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Hält das Display aktiv und verhindert automatische Sperren für Codex Computer Use, Automatisierung, Bildschirmfreigabe und Fernsteuerung." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Keeps the display active and prevents automatic locking for Codex Computer Use, automation, screen sharing, and remote control." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Mantiene la pantalla activa e impide el bloqueo automático para Codex Computer Use, automatización, pantalla compartida y control remoto." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Maintient l’écran actif et empêche le verrouillage automatique pour Codex Computer Use, l’automatisation, le partage d’écran et le contrôle à distance." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "画面をオンに保ち、Codex Computer Use、オートメーション、画面共有、リモート操作中の自動ロックを防止します。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "화면을 켜진 상태로 유지하고 Codex Computer Use, 자동화, 화면 공유 및 원격 제어 중 자동 잠금을 방지합니다." } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Mantém a tela ativa e impede o bloqueio automático para Codex Computer Use, automação, compartilhamento de tela e controle remoto." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Сохраняет экран активным и предотвращает автоблокировку для Codex Computer Use, автоматизации, демонстрации экрана и удалённого управления." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保持屏幕可用并防止自动锁定，适用于 Codex Computer Use、桌面自动化、屏幕共享和远程控制。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "保持螢幕可用並防止自動鎖定，適用於 Codex Computer Use、桌面自動化、螢幕共享和遠端控制。" } }
+        "ar": { "stringUnit": { "state": "translated", "value": "يمنع إيقاف الشاشة والقفل التلقائي. استخدمه فقط عندما تحتاج Codex Computer Use أو الأتمتة أو مشاركة الشاشة أو التحكم عن بُعد إلى شاشة نشطة." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Verhindert den Ruhezustand des Displays und die automatische Sperre. Nur verwenden, wenn Codex Computer Use, Automatisierung, Bildschirmfreigabe oder Fernsteuerung einen aktiven Bildschirm benötigen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Prevents display sleep and automatic locking. Use only while Codex Computer Use, automation, screen sharing, or remote control needs an active screen." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Evita el reposo de la pantalla y el bloqueo automático. Úsalo solo cuando Codex Computer Use, la automatización, la pantalla compartida o el control remoto necesiten una pantalla activa." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Empêche la mise en veille de l’écran et le verrouillage automatique. À utiliser seulement lorsque Codex Computer Use, l’automatisation, le partage d’écran ou le contrôle à distance nécessitent un écran actif." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "画面のスリープと自動ロックを防ぎます。Codex Computer Use、オートメーション、画面共有、リモート操作で画面を有効に保つ必要がある場合にのみ使用してください。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "화면 잠자기와 자동 잠금을 방지합니다. Codex Computer Use, 자동화, 화면 공유 또는 원격 제어에 활성 화면이 필요한 경우에만 사용하세요." } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Impede o repouso da tela e o bloqueio automático. Use apenas quando Codex Computer Use, automação, compartilhamento de tela ou controle remoto precisarem de uma tela ativa." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Предотвращает переход дисплея в режим сна и автоблокировку. Используйте только когда Codex Computer Use, автоматизации, демонстрации экрана или удалённому управлению нужен активный экран." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "阻止屏幕休眠和自动锁定。仅在 Codex Computer Use、桌面自动化、屏幕共享或远程控制需要保持屏幕可用时使用。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "阻止螢幕休眠和自動鎖定。僅在 Codex Computer Use、桌面自動化、螢幕共享或遠端控制需要保持螢幕可用時使用。" } }
       }
     },
     "settings.mode.screenTools.title": {
@@ -335,6 +335,22 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "行為" } }
       }
     },
+    "settings.mode.screenTools.warning.experimental": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "الشاشة البرمجية مع الغطاء المغلق تجريبية وقد تتوقف بعد تحديثات macOS." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Der Softwarebildschirm bei geschlossenem Deckel ist experimentell und kann nach macOS-Updates ausfallen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "The closed-lid software display is experimental and may stop working after macOS updates." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La pantalla por software con tapa cerrada es experimental y puede dejar de funcionar tras actualizar macOS." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "L’écran logiciel couvercle fermé est expérimental et peut cesser de fonctionner après une mise à jour de macOS." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイを閉じた状態のソフトウェアディスプレイは試験的機能で、macOSのアップデート後に動作しない場合があります。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "덮개를 닫은 상태의 소프트웨어 디스플레이는 실험적 기능이며 macOS 업데이트 후 작동하지 않을 수 있습니다." } },
+        "pt": { "stringUnit": { "state": "translated", "value": "A tela de software com a tampa fechada é experimental e pode parar após atualizações do macOS." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Программный дисплей при закрытой крышке — экспериментальная функция и может перестать работать после обновления macOS." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "合盖软件显示器为实验性功能，macOS 更新后可能失效。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "闔蓋軟體顯示器為實驗性功能，macOS 更新後可能失效。" } }
+      }
+    },
     "settings.mode.screenTools.warning.manualLock": {
       "extractionState": "manual",
       "localizations": {
@@ -349,6 +365,22 @@
         "ru": { "stringUnit": { "state": "translated", "value": "Ручная блокировка продолжает работать; заблокированный сеанс не будет разблокирован." } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "手动锁定仍然有效；不会解锁已锁定的会话。" } },
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "手動鎖定仍然有效；不會解鎖已鎖定的工作階段。" } }
+      }
+    },
+    "settings.mode.screenTools.warning.unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "لا تتضمن حزمة المكوّن الحالية مكوّن الشاشة البرمجية للغطاء المغلق." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Dieses Plug-in-Paket enthält keine Softwarebildschirm-Komponente für den geschlossenen Deckel." } },
+        "en": { "stringUnit": { "state": "translated", "value": "This plugin package does not include the closed-lid software display component." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Este paquete del plugin no incluye el componente de pantalla por software para tapa cerrada." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Ce paquet d’extension ne contient pas le composant d’écran logiciel pour couvercle fermé." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "現在のプラグインパッケージには、ディスプレイを閉じた状態のソフトウェアディスプレイ機能が含まれていません。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "현재 플러그인 패키지에 덮개를 닫은 상태의 소프트웨어 디스플레이 구성요소가 없습니다." } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Este pacote do plugin não inclui o componente de tela de software para tampa fechada." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "В этом пакете плагина нет компонента программного дисплея для закрытой крышки." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "当前插件包不包含合盖软件显示器组件。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "目前外掛套件不包含闔蓋軟體顯示器元件。" } }
       }
     },
     "settings.mode.screenTools.warning.ventilation": {

--- a/Plugins/KeepAwake/Sources/KeepAwakePlugin.swift
+++ b/Plugins/KeepAwake/Sources/KeepAwakePlugin.swift
@@ -427,7 +427,6 @@ final class KeepAwakePlugin:
                         PluginSettingsRow(
                             id: KeepAwakeSettingsSearchEntryID.behavior,
                             title: localization.string("settings.mode.section", defaultValue: "行为"),
-                            description: settingsBehaviorDescription(preferences.behavior),
                             systemImage: "moon.zzz",
                             help: settingsBehaviorHelp,
                             control: .picker(
@@ -435,10 +434,11 @@ final class KeepAwakePlugin:
                                 options: KeepAwakeBehavior.allCases.map {
                                     PluginSettingsOption(
                                         id: $0.rawValue,
-                                        title: settingsBehaviorTitle($0)
+                                        title: settingsBehaviorTitle($0),
+                                        description: settingsBehaviorDescription($0)
                                     )
                                 },
-                                style: .menu
+                                style: .radioGroup
                             )
                         )
                     ]

--- a/Plugins/KeepAwake/Sources/KeepAwakePlugin.swift
+++ b/Plugins/KeepAwake/Sources/KeepAwakePlugin.swift
@@ -428,17 +428,20 @@ final class KeepAwakePlugin:
                             id: KeepAwakeSettingsSearchEntryID.behavior,
                             title: localization.string("settings.mode.section", defaultValue: "行为"),
                             systemImage: "moon.zzz",
-                            help: settingsBehaviorHelp,
-                            control: .picker(
+                            helpItems: settingsBehaviorWarnings,
+                            helpTone: .caution,
+                            control: .choiceGroup(
                                 selectionID: preferences.behavior.rawValue,
                                 options: KeepAwakeBehavior.allCases.map {
                                     PluginSettingsOption(
                                         id: $0.rawValue,
                                         title: settingsBehaviorTitle($0),
-                                        description: settingsBehaviorDescription($0)
+                                        description: settingsBehaviorDescription($0),
+                                        descriptionTone: $0 == .keepScreenBasedToolsWorking
+                                            ? .caution
+                                            : .neutral
                                     )
-                                },
-                                style: .radioGroup
+                                }
                             )
                         )
                     ]
@@ -782,8 +785,8 @@ final class KeepAwakePlugin:
         }
     }
 
-    private var settingsBehaviorHelp: String? {
-        guard preferences.behavior == .keepScreenBasedToolsWorking else { return nil }
+    private var settingsBehaviorWarnings: [String] {
+        guard preferences.behavior == .keepScreenBasedToolsWorking else { return [] }
 
         var messages: [String] = []
         if powerSourceState.isPortableMac {
@@ -808,7 +811,7 @@ final class KeepAwakePlugin:
             "settings.mode.screenTools.warning.manualLock",
             defaultValue: "手动锁定仍然有效；不会解锁已锁定的会话。"
         ))
-        return messages.joined(separator: "\n")
+        return messages
     }
 
     private func applyKeepAwakeConfiguration() {

--- a/Plugins/KeepAwake/Tests/KeepAwakePreferenceTests.swift
+++ b/Plugins/KeepAwake/Tests/KeepAwakePreferenceTests.swift
@@ -1220,9 +1220,9 @@ final class KeepAwakePreferenceTests: XCTestCase {
 
         XCTAssertEqual(rows.map(\.id), [KeepAwakeSettingsSearchEntryID.behavior])
         guard case let .picker(_, options, style) = rows[0].control,
-              case .menu = style
+              case .radioGroup = style
         else {
-            return XCTFail("Expected the long behavior choices to use a menu picker")
+            return XCTFail("Expected the behavior choices to use a radio group")
         }
         XCTAssertEqual(options.count, KeepAwakeBehavior.allCases.count)
     }

--- a/Plugins/KeepAwake/Tests/KeepAwakePreferenceTests.swift
+++ b/Plugins/KeepAwake/Tests/KeepAwakePreferenceTests.swift
@@ -1219,12 +1219,30 @@ final class KeepAwakePreferenceTests: XCTestCase {
         }
 
         XCTAssertEqual(rows.map(\.id), [KeepAwakeSettingsSearchEntryID.behavior])
-        guard case let .picker(_, options, style) = rows[0].control,
-              case .radioGroup = style
+        guard case let .choiceGroup(_, options) = rows[0].control
         else {
-            return XCTFail("Expected the behavior choices to use a radio group")
+            return XCTFail("Expected the behavior choices to use a visible choice group")
         }
         XCTAssertEqual(options.count, KeepAwakeBehavior.allCases.count)
+        XCTAssertEqual(options.map(\.descriptionTone), [.neutral, .neutral, .caution])
+    }
+
+    func testScreenToolsSettingsExposeCautionWarningsAsSeparateItems() throws {
+        let plugin = KeepAwakeSessionFactory()
+            .makePlugin(storage: KeepAwakeMemoryStorage())
+        plugin.setBehavior(.keepScreenBasedToolsWorking)
+
+        guard case let .form(sections) = try XCTUnwrap(plugin.settingsPage).body,
+              case let .rows(rows) = try XCTUnwrap(sections.first?.content)
+        else {
+            return XCTFail("Expected declarative settings rows")
+        }
+        let row = try XCTUnwrap(rows.first)
+
+        XCTAssertNil(row.help)
+        XCTAssertEqual(row.helpTone, .caution)
+        XCTAssertEqual(row.helpItems.count, 4)
+        XCTAssertTrue(row.helpItems.allSatisfy { !$0.contains("\n") })
     }
 
     func testFeaturePanelOnlyShowsDurationControl() throws {

--- a/Sources/App/MacToolsSearch.swift
+++ b/Sources/App/MacToolsSearch.swift
@@ -752,12 +752,14 @@ enum MacToolsSearchIndexBuilder {
             }
 
             return rows.filter(\.isVisible).map { row in
+                let helpText = row.help ?? row.helpItems.joined(separator: " ")
                 let optionKeywords: [String]
-                if case let .picker(_, options, _) = row.control {
+                switch row.control {
+                case let .picker(_, options, _), let .choiceGroup(_, options):
                     optionKeywords = options.flatMap { option in
                         [option.title, option.description].compactMap { $0 }
                     }
-                } else {
+                default:
                     optionKeywords = []
                 }
 
@@ -765,10 +767,10 @@ enum MacToolsSearchIndexBuilder {
                     id: "setting-row.\(item.pluginID).\(row.id)",
                     item: item,
                     title: row.title,
-                    detail: row.description ?? row.help ?? "",
+                    detail: row.description ?? helpText,
                     keywords: row.keywords
                         + optionKeywords
-                        + [section.title, row.help, row.error].compactMap { $0 },
+                        + [section.title, helpText, row.error].compactMap { $0 },
                     systemImage: row.systemImage ?? section.systemImage ?? "slider.horizontal.3",
                     entryID: row.id
                 )

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -2970,6 +2970,40 @@ private struct PluginSettingsRowView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+            rowContent
+
+            if let error = row.error {
+                Text(error)
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if !row.helpItems.isEmpty {
+                PluginSettingsHelpList(
+                    items: row.helpItems,
+                    tone: row.helpTone
+                )
+            } else if let help = row.help {
+                Text(help)
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(statusColor(for: row.helpTone))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .disabled(!row.isEnabled)
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var rowContent: some View {
+        if case let .choiceGroup(selectionID, options) = row.control {
+            PluginSettingsChoiceGroupControl(
+                selectionID: selectionID,
+                options: options,
+                onSelect: {
+                    onAction(.setSelection(controlID: row.id, optionID: $0))
+                }
+            )
+        } else {
             HStack(alignment: .center, spacing: 0) {
                 HStack(
                     alignment: .center,
@@ -3002,21 +3036,7 @@ private struct PluginSettingsRowView: View {
                 control
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-
-            if let error = row.error {
-                Text(error)
-                    .font(PluginSettingsTheme.Typography.rowDescription)
-                    .foregroundStyle(.red)
-                    .fixedSize(horizontal: false, vertical: true)
-            } else if let help = row.help {
-                Text(help)
-                    .font(PluginSettingsTheme.Typography.rowDescription)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
         }
-        .disabled(!row.isEnabled)
-        .accessibilityElement(children: .contain)
     }
 
     @ViewBuilder
@@ -3041,6 +3061,8 @@ private struct PluginSettingsRowView: View {
                     onAction(.setSelection(controlID: row.id, optionID: $0))
                 }
             )
+        case .choiceGroup:
+            EmptyView()
         case let .slider(value, range, step, valueFormat):
             PluginSettingsSliderControl(
                 controlID: row.id,
@@ -3091,6 +3113,28 @@ private struct PluginSettingsRowView: View {
     }
 }
 
+private struct PluginSettingsHelpList: View {
+    let items: [String]
+    let tone: PluginStatusTone
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text("•")
+                        .accessibilityHidden(true)
+
+                    Text(item)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .font(PluginSettingsTheme.Typography.rowDescription)
+        .foregroundStyle(statusColor(for: tone))
+        .accessibilityElement(children: .contain)
+    }
+}
+
 private struct PluginSettingsPickerControl: View {
     let selectionID: String
     let options: [PluginSettingsOption]
@@ -3105,12 +3149,6 @@ private struct PluginSettingsPickerControl: View {
             picker.pickerStyle(.menu)
         case .segmented:
             picker.pickerStyle(.segmented)
-        case .radioGroup:
-            PluginSettingsRadioGroupControl(
-                selectionID: selectionID,
-                options: options,
-                onSelect: onSelect
-            )
         }
     }
 
@@ -3131,57 +3169,99 @@ private struct PluginSettingsPickerControl: View {
     }
 }
 
-private struct PluginSettingsRadioGroupControl: View {
+private struct PluginSettingsChoiceGroupControl: View {
     let selectionID: String
     let options: [PluginSettingsOption]
     let onSelect: (String) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowVertical) {
-            ForEach(options) { option in
-                radioRow(option: option)
+        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            ViewThatFits(in: .horizontal) {
+                horizontalChoices
+                verticalChoices
+            }
+
+            if let description = selectedOption?.description {
+                Text(description)
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(statusColor(for: selectedOption?.descriptionTone ?? .neutral))
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .contain)
     }
 
+    private var horizontalChoices: some View {
+        HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+            ForEach(options) { option in
+                choiceButton(option: option)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var verticalChoices: some View {
+        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.controlCluster) {
+            ForEach(options) { option in
+                choiceButton(option: option)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var selectedOption: PluginSettingsOption? {
+        options.first { $0.id == selectionID }
+    }
+
     @ViewBuilder
-    private func radioRow(option: PluginSettingsOption) -> some View {
+    private func choiceButton(option: PluginSettingsOption) -> some View {
         let isSelected = selectionID == option.id
         Button {
             onSelect(option.id)
-         } label: {
-            HStack(alignment: .top, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-                Circle()
-                     .fill(isSelected ? Color.accentColor : Color.clear)
-                     .overlay(
-                        Circle()
-                             .stroke(PluginSettingsTheme.Palette.cardBorder, lineWidth: PluginSettingsTheme.Stroke.hairline)
-                     )
-                     .frame(width: 16, height: 16)
-                     .overlay(
-                        Circle()
-                             .fill(Color.white)
-                             .frame(width: 8, height: 8)
-                     )
-                     .opacity(isSelected ? 1 : 0)
+        } label: {
+            HStack(spacing: 6) {
+                Text(option.title)
+                    .font(PluginSettingsTheme.Typography.rowTitle)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity)
 
-                VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
-                    Text(option.title)
-                         .font(PluginSettingsTheme.Typography.controlLabel)
-                         .foregroundStyle(isSelected ? .primary : .secondary)
-
-                    if let description = option.description {
-                        Text(description)
-                             .font(PluginSettingsTheme.Typography.rowDescription)
-                             .foregroundStyle(.secondary)
-                             .fixedSize(horizontal: false, vertical: true)
-                     }
-                 }
-             }
-         }
-         .buttonStyle(.plain)
-         .accessibilityAddTraits(isSelected ? .isSelected : [])
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.caption.weight(.semibold))
+                        .accessibilityHidden(true)
+                }
+            }
+            .foregroundStyle(isSelected ? Color.white : Color.primary)
+            .frame(minWidth: 132, maxWidth: .infinity, minHeight: PluginSettingsTheme.Size.controlHeight + 8)
+            .padding(.horizontal, PluginSettingsTheme.Spacing.controlCluster)
+            .background {
+                RoundedRectangle(
+                    cornerRadius: PluginSettingsTheme.Radius.control,
+                    style: .continuous
+                )
+                .fill(
+                    isSelected
+                        ? Color.accentColor
+                        : PluginSettingsTheme.Palette.recessedControlBackground
+                )
+            }
+            .overlay {
+                RoundedRectangle(
+                    cornerRadius: PluginSettingsTheme.Radius.control,
+                    style: .continuous
+                )
+                .stroke(
+                    isSelected ? Color.accentColor : PluginSettingsTheme.Palette.separator,
+                    lineWidth: PluginSettingsTheme.Stroke.hairline
+                )
+            }
+            .contentShape(RoundedRectangle(cornerRadius: PluginSettingsTheme.Radius.control))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option.title)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }
 

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -3106,7 +3106,11 @@ private struct PluginSettingsPickerControl: View {
         case .segmented:
             picker.pickerStyle(.segmented)
         case .radioGroup:
-            picker.pickerStyle(.radioGroup)
+            PluginSettingsRadioGroupControl(
+                selectionID: selectionID,
+                options: options,
+                onSelect: onSelect
+            )
         }
     }
 
@@ -3126,6 +3130,61 @@ private struct PluginSettingsPickerControl: View {
         .frame(minWidth: 120, idealWidth: 180, maxWidth: 240)
     }
 }
+
+private struct PluginSettingsRadioGroupControl: View {
+    let selectionID: String
+    let options: [PluginSettingsOption]
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowVertical) {
+            ForEach(options) { option in
+                radioRow(option: option)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private func radioRow(option: PluginSettingsOption) -> some View {
+        let isSelected = selectionID == option.id
+        Button {
+            onSelect(option.id)
+         } label: {
+            HStack(alignment: .top, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                Circle()
+                     .fill(isSelected ? Color.accentColor : Color.clear)
+                     .overlay(
+                        Circle()
+                             .stroke(PluginSettingsTheme.Palette.cardBorder, lineWidth: PluginSettingsTheme.Stroke.hairline)
+                     )
+                     .frame(width: 16, height: 16)
+                     .overlay(
+                        Circle()
+                             .fill(Color.white)
+                             .frame(width: 8, height: 8)
+                     )
+                     .opacity(isSelected ? 1 : 0)
+
+                VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+                    Text(option.title)
+                         .font(PluginSettingsTheme.Typography.controlLabel)
+                         .foregroundStyle(isSelected ? .primary : .secondary)
+
+                    if let description = option.description {
+                        Text(description)
+                             .font(PluginSettingsTheme.Typography.rowDescription)
+                             .foregroundStyle(.secondary)
+                             .fixedSize(horizontal: false, vertical: true)
+                     }
+                 }
+             }
+         }
+         .buttonStyle(.plain)
+         .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
 
 private struct PluginSettingsSliderControl: View {
     let controlID: String

--- a/Sources/MacToolsPluginKit/PluginModels.swift
+++ b/Sources/MacToolsPluginKit/PluginModels.swift
@@ -58,7 +58,7 @@ public enum PluginMenuActionBehavior {
     case dismissBeforeHandling
 }
 
-public enum PluginStatusTone {
+public enum PluginStatusTone: Equatable, Sendable {
     case neutral
     case positive
     case caution

--- a/Sources/MacToolsPluginKit/PluginSettingsModels.swift
+++ b/Sources/MacToolsPluginKit/PluginSettingsModels.swift
@@ -270,6 +270,8 @@ public struct PluginSettingsRow: Identifiable {
     public let systemImage: String?
     public let keywords: [String]
     public let help: String?
+    public let helpItems: [String]
+    public let helpTone: PluginStatusTone
     public let error: String?
     public let isEnabled: Bool
     public let isVisible: Bool
@@ -282,6 +284,8 @@ public struct PluginSettingsRow: Identifiable {
         systemImage: String? = nil,
         keywords: [String] = [],
         help: String? = nil,
+        helpItems: [String] = [],
+        helpTone: PluginStatusTone = .neutral,
         error: String? = nil,
         isEnabled: Bool = true,
         isVisible: Bool = true,
@@ -293,6 +297,8 @@ public struct PluginSettingsRow: Identifiable {
         self.systemImage = systemImage
         self.keywords = keywords
         self.help = help
+        self.helpItems = helpItems
+        self.helpTone = helpTone
         self.error = error
         self.isEnabled = isEnabled
         self.isVisible = isVisible
@@ -307,6 +313,7 @@ public enum PluginSettingsControl {
         options: [PluginSettingsOption],
         style: PluginSettingsPickerStyle
     )
+    case choiceGroup(selectionID: String, options: [PluginSettingsOption])
     case slider(
         value: Double,
         range: ClosedRange<Double>,
@@ -328,11 +335,18 @@ public struct PluginSettingsOption: Identifiable, Equatable, Sendable {
     public let id: String
     public let title: String
     public let description: String?
+    public let descriptionTone: PluginStatusTone
 
-    public init(id: String, title: String, description: String? = nil) {
+    public init(
+        id: String,
+        title: String,
+        description: String? = nil,
+        descriptionTone: PluginStatusTone = .neutral
+    ) {
         self.id = id
         self.title = title
         self.description = description
+        self.descriptionTone = descriptionTone
     }
 }
 
@@ -340,7 +354,6 @@ public enum PluginSettingsPickerStyle: Sendable {
     case automatic
     case menu
     case segmented
-    case radioGroup
 }
 
 /// Describes a slider readout without freezing it to the page snapshot's value.
@@ -567,7 +580,8 @@ public enum PluginSettingsValidator {
 
     private static func validate(_ row: PluginSettingsRow) throws {
         switch row.control {
-        case let .picker(selectionID, options, _):
+        case let .picker(selectionID, options, _),
+             let .choiceGroup(selectionID, options):
             var optionIDs: Set<String> = []
             for option in options {
                 guard !option.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/Tests/Core/Plugins/PluginSettingsModelsTests.swift
+++ b/Tests/Core/Plugins/PluginSettingsModelsTests.swift
@@ -22,6 +22,17 @@ final class PluginSettingsModelsTests: XCTestCase {
                             )
                         ),
                         PluginSettingsRow(
+                            id: "visible-mode",
+                            title: "显示模式",
+                            control: .choiceGroup(
+                                selectionID: "automatic",
+                                options: [
+                                    PluginSettingsOption(id: "automatic", title: "自动"),
+                                    PluginSettingsOption(id: "manual", title: "手动")
+                                ]
+                            )
+                        ),
+                        PluginSettingsRow(
                             id: "level",
                             title: "级别",
                             control: .slider(

--- a/changes/unreleased/keep-awake-modes.md
+++ b/changes/unreleased/keep-awake-modes.md
@@ -4,4 +4,4 @@ type: changed
 area: System
 ---
 
-Show Keep Awake behavior modes as visible radio choices instead of a dropdown.
+Show Keep Awake behavior modes as visible choices instead of a dropdown.

--- a/changes/unreleased/keep-awake-modes.md
+++ b/changes/unreleased/keep-awake-modes.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: changed
+area: System
+---
+
+Show Keep Awake behavior modes as visible radio choices instead of a dropdown.


### PR DESCRIPTION
## Summary

Keep Awake now presents all three behavior modes as visible choices in PluginKit v4 settings, rather than hiding them in a dropdown.

## Changes

- Added a host-rendered adaptive choice group: it uses an equal-width button strip when space permits and stacks choices at narrower widths.
- Shows only the selected mode’s description, keeping the settings page compact while retaining visible alternatives.
- Highlights Screen-based Tools with localized caution copy and accessible warning bullets for its power, ventilation, experimental-display, and manual-lock constraints.
- Restored the missing localized experimental and unavailable display warnings, preventing fallback text in another language.
- Preserves existing KeepAwakeBehavior IDs, transitions, fallback handling, and settings search keywords.

## Validation

- `make build`
- Focused `KeepAwakePreferenceTests` and `PluginSettingsModelsTests`

Closes #266