### PR TITLE
Restore built-in display after wake topology changes

### DIFF
--- a/Plugins/DisplayBrightness/Tests/DisplayDisableCoordinatorRecoveryTests.swift
+++ b/Plugins/DisplayBrightness/Tests/DisplayDisableCoordinatorRecoveryTests.swift
@@ -1,0 +1,127 @@
+import CoreGraphics
+import Foundation
+import XCTest
+import MacToolsPluginKit
+@testable import DisplayBrightnessPlugin
+
+@MainActor
+final class DisplayDisableCoordinatorRecoveryTests: XCTestCase {
+    func testTopologyReconcileRestoresBuiltInDisplayAfterExternalDisconnect() async {
+        let fixture = makeDisabledDisplayFixture()
+
+        fixture.service.onlineDisplays = [fixture.disabledBuiltIn]
+        await fixture.coordinator.reconcileTopology()
+
+        XCTAssertEqual(
+            fixture.service.setEnabledCalls,
+            [.init(displayID: fixture.disabledBuiltIn.id, enabled: true)]
+        )
+        XCTAssertNil(fixture.store.snapshot)
+    }
+
+    private func makeDisabledDisplayFixture() -> DisabledDisplayFixture {
+        let disabledBuiltIn = DisplayDisableDisplay(
+            id: 1,
+            name: "Built-in Display",
+            isBuiltin: true,
+            isActive: false,
+            isInMirrorSet: false,
+            isVisibleToAppKit: false,
+            vendorNumber: 0x610,
+            modelNumber: 0xA050,
+            serialNumber: 0x01
+        )
+        let external = DisplayDisableDisplay(
+            id: 2,
+            name: "External Display",
+            isBuiltin: false,
+            isActive: true,
+            isInMirrorSet: false,
+            isVisibleToAppKit: true,
+            vendorNumber: 0x610,
+            modelNumber: 0xA035,
+            serialNumber: 0x99
+        )
+        let recoverySnapshot = DisplayDisableRecoverySnapshot(
+            createdAt: Date(timeIntervalSince1970: 1),
+            builtInDisplayID: disabledBuiltIn.id,
+            vendorNumber: disabledBuiltIn.vendorNumber,
+            modelNumber: disabledBuiltIn.modelNumber,
+            serialNumber: disabledBuiltIn.serialNumber,
+            survivorDisplayIDs: [external.id],
+            survivorIdentities: [
+                DisplaySurvivorIdentity(
+                    id: external.id,
+                    vendorNumber: external.vendorNumber,
+                    modelNumber: external.modelNumber,
+                    serialNumber: external.serialNumber
+                )
+            ],
+            originalMainDisplayID: external.id
+        )
+        let service = WakeRecoveryDisplayDisableService(
+            onlineDisplays: [disabledBuiltIn, external]
+        )
+        let store = WakeRecoveryDisplayDisableStore(snapshot: recoverySnapshot)
+        let coordinator = DisplayDisableCoordinator(
+            service: service,
+            store: store,
+            verificationSettleDelay: .zero,
+            presentationPreparation: {}
+        )
+
+        return DisabledDisplayFixture(
+            disabledBuiltIn: disabledBuiltIn,
+            service: service,
+            store: store,
+            coordinator: coordinator
+        )
+    }
+}
+
+@MainActor
+private struct DisabledDisplayFixture {
+    let disabledBuiltIn: DisplayDisableDisplay
+    let service: WakeRecoveryDisplayDisableService
+    let store: WakeRecoveryDisplayDisableStore
+    let coordinator: DisplayDisableCoordinator
+}
+
+@MainActor
+private final class WakeRecoveryDisplayDisableStore: DisplayDisableStateStoring {
+    var snapshot: DisplayDisableRecoverySnapshot?
+
+    init(snapshot: DisplayDisableRecoverySnapshot?) {
+        self.snapshot = snapshot
+    }
+}
+
+@MainActor
+private final class WakeRecoveryDisplayDisableService: DisplayDisableServicing {
+    struct SetEnabledCall: Equatable {
+        let displayID: CGDirectDisplayID
+        let enabled: Bool
+    }
+
+    let isSupported = true
+    var onlineDisplays: [DisplayDisableDisplay]
+    private(set) var setEnabledCalls: [SetEnabledCall] = []
+
+    init(onlineDisplays: [DisplayDisableDisplay]) {
+        self.onlineDisplays = onlineDisplays
+    }
+
+    func listDisplays() -> [DisplayDisableDisplay] {
+        onlineDisplays
+    }
+
+    func setDisplay(_ displayID: CGDirectDisplayID, enabled: Bool) throws {
+        setEnabledCalls.append(SetEnabledCall(displayID: displayID, enabled: enabled))
+        onlineDisplays = onlineDisplays.map { display in
+            guard display.id == displayID else { return display }
+            return display
+                .withActive(enabled)
+                .withVisibleToAppKit(enabled)
+        }
+    }
+}

--- a/Sources/Core/Plugins/PluginHost.swift
+++ b/Sources/Core/Plugins/PluginHost.swift
@@ -2638,8 +2638,18 @@ final class PluginHost: ObservableObject {
     private func handleApplicationActivityStateChange(
         _ state: PluginApplicationActivityState
     ) {
-        guard applicationActivityState != state else { return }
+        let previousState = applicationActivityState
+        guard previousState != state else { return }
         applicationActivityState = state
+
+        if previousState == .waking {
+            switch state {
+            case .interactive, .sessionInactive, .displayAsleep:
+                scheduleDisplayTopologyRefresh()
+            case .systemSleeping, .waking:
+                break
+            }
+        }
 
         for plugin in activePlugins {
             guard let activityStateHandling = plugin as? any PluginApplicationActivityStateHandling else {

--- a/Tests/Core/Plugins/PluginHostApplicationActivityTests.swift
+++ b/Tests/Core/Plugins/PluginHostApplicationActivityTests.swift
@@ -26,6 +26,71 @@ final class PluginHostApplicationActivityTests: XCTestCase {
         XCTAssertEqual(plugin.states, [.displayAsleep, .interactive])
         withExtendedLifetime(host) {}
     }
+
+    func testHostRefreshesDisplayTopologyAfterWakeSettles() async {
+        let observer = StubApplicationActivityObserver(state: .systemSleeping)
+        let plugin = RecordingDisplayTopologyPlugin()
+        let suiteName = "PluginHostApplicationActivityTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let host = PluginHost(
+            plugins: [plugin],
+            shortcutStore: ShortcutStore(userDefaults: defaults),
+            pluginDisplayPreferencesStore: PluginDisplayPreferencesStore(userDefaults: defaults),
+            preferencesBackupStore: PreferencesBackupStore(userDefaults: defaults),
+            globalShortcutManager: GlobalShortcutManager(),
+            applicationActivityObserver: observer,
+            displayTopologyRefreshDelay: .zero
+        )
+
+        observer.send(.waking)
+        await Task.yield()
+        XCTAssertEqual(plugin.displayTopologyRefreshCount, 0)
+
+        observer.send(.displayAsleep)
+        await waitUntil { plugin.displayTopologyRefreshCount == 1 }
+
+        XCTAssertEqual(plugin.displayTopologyRefreshCount, 1)
+        withExtendedLifetime(host) {}
+    }
+
+    func testHostDoesNotRefreshDisplayTopologyWhenWakeReturnsToSleep() async {
+        let observer = StubApplicationActivityObserver(state: .systemSleeping)
+        let plugin = RecordingDisplayTopologyPlugin()
+        let suiteName = "PluginHostApplicationActivityTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let host = PluginHost(
+            plugins: [plugin],
+            shortcutStore: ShortcutStore(userDefaults: defaults),
+            pluginDisplayPreferencesStore: PluginDisplayPreferencesStore(userDefaults: defaults),
+            preferencesBackupStore: PreferencesBackupStore(userDefaults: defaults),
+            globalShortcutManager: GlobalShortcutManager(),
+            applicationActivityObserver: observer,
+            displayTopologyRefreshDelay: .zero
+        )
+
+        observer.send(.waking)
+        observer.send(.systemSleeping)
+        for _ in 0..<3 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(plugin.displayTopologyRefreshCount, 0)
+        withExtendedLifetime(host) {}
+    }
+
+    private func waitUntil(
+        _ condition: @escaping @MainActor () -> Bool
+    ) async {
+        let deadline = ContinuousClock().now.advanced(by: .seconds(1))
+        while !condition(), ContinuousClock().now < deadline {
+            await Task.yield()
+        }
+        XCTAssertTrue(condition())
+    }
 }
 
 @MainActor
@@ -61,5 +126,25 @@ private final class RecordingApplicationActivityPlugin: MacToolsPlugin,
 
     func applicationActivityStateDidChange(_ state: PluginApplicationActivityState) {
         states.append(state)
+    }
+}
+
+@MainActor
+private final class RecordingDisplayTopologyPlugin: MacToolsPlugin, DisplayTopologyRefreshing {
+    let metadata = PluginMetadata(
+        id: "display-topology-recorder",
+        title: "Display Topology Recorder",
+        iconName: "display",
+        iconTint: Color.primary,
+        order: 0,
+        defaultDescription: ""
+    )
+    var onStateChange: (() -> Void)?
+    var requestPermissionGuidance: ((String) -> Void)?
+    var shortcutBindingResolver: ((String) -> ShortcutBinding?)?
+    private(set) var displayTopologyRefreshCount = 0
+
+    func refreshDisplayTopology() {
+        displayTopologyRefreshCount += 1
     }
 }

--- a/changes/unreleased/restore-built-in-display-after-wake.md
+++ b/changes/unreleased/restore-built-in-display-after-wake.md
@@ -1,0 +1,7 @@
+---
+release: app
+type: fixed
+area: Displays
+---
+
+The built-in display is now restored after wake when the external display was disconnected during sleep.


### PR DESCRIPTION
## Summary

- schedule the existing display-topology refresh after application activity settles from `.waking`
- avoid refreshing when the Mac immediately returns from `.waking` to `.systemSleeping`
- verify that display-disable recovery restores the built-in display after the recorded external survivor disconnects
- add an app changelog entry for the recovery fix

The refresh runs only after the existing wake settlement and then uses the existing topology debounce. This avoids reconciling against the transient WindowServer topology visible during `.waking`, while giving every `DisplayTopologyRefreshing` plugin a post-wake refresh.

## Tests

- `PluginHostApplicationActivityTests`
- `DisplayDisableCoordinatorRecoveryTests`
- `python3 scripts/changelog.py validate --release app --require-pending`
- `xcodebuild ... -scheme MacTools -configuration Debug ... build -quiet`

Fixes #298
