### PR TITLE
Reduce and release Apple Shortcuts icon cache memory

### DIFF
--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsController.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsController.swift
@@ -77,6 +77,10 @@ final class AppleShortcutsController: ObservableObject {
     private var settingsLibraryRevision: Int?
     private var queuedIconIDs: [UUID] = []
     private var queuedIconIDSet: Set<UUID> = []
+    /// Shortcuts whose icon failed to load (or decoded to nothing) during the current settings
+    /// session, so they aren't retried on every re-appearance (e.g. list scrolling) until the
+    /// next settings-scope refresh. Holds only identifiers, not icon bytes.
+    private var failedIconIDs: Set<UUID> = []
     private var activeIconTasks: [UUID: Task<Void, Never>] = [:]
     private var activeRuns: [UUID: ActiveRun] = [:]
     private var activeViews: [UUID: ActiveView] = [:]
@@ -180,6 +184,7 @@ final class AppleShortcutsController: ObservableObject {
         if case .settings = scope {
             cancelIconLoads()
             discardCachedIcons()
+            failedIconIDs.removeAll()
         }
         let token = UUID()
         let generation = lifecycleGeneration
@@ -444,6 +449,7 @@ final class AppleShortcutsController: ObservableObject {
         guard isSettingsVisible,
               snapshot.discovery.shortcuts.contains(where: { $0.id == shortcutID && $0.visualMetadata != nil }),
               iconCache.data(for: shortcutID) == nil,
+              !failedIconIDs.contains(shortcutID),
               activeIconTasks[shortcutID] == nil,
               queuedIconIDSet.insert(shortcutID).inserted
         else { return }
@@ -536,6 +542,7 @@ final class AppleShortcutsController: ObservableObject {
             queuedIconIDSet.remove(shortcutID)
             guard snapshot.discovery.shortcuts.contains(where: { $0.id == shortcutID }),
                   iconCache.data(for: shortcutID) == nil,
+                  !failedIconIDs.contains(shortcutID),
                   activeIconTasks[shortcutID] == nil
             else { continue }
             return shortcutID
@@ -552,10 +559,14 @@ final class AppleShortcutsController: ObservableObject {
         defer { startQueuedIconLoads() }
         guard isSettingsVisible,
               settingsVisibilityGeneration == visibilityGeneration,
-              !Task.isCancelled,
-              case let .success(iconData) = result,
-              let iconData
+              !Task.isCancelled
         else { return }
+        guard case let .success(iconData) = result, let iconData else {
+            // Remember the failure so a permanently broken icon isn't retried every time its
+            // row reappears (e.g. list scrolling); a settings-scope refresh gives it another try.
+            failedIconIDs.insert(shortcutID)
+            return
+        }
         iconCache.store(iconData, for: shortcutID)
         iconCacheRevision &+= 1
         onStateChange?()

--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsController.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsController.swift
@@ -54,12 +54,16 @@ final class AppleShortcutsController: ObservableObject {
     static let maximumConcurrentIconLoads = 2
 
     @Published private(set) var snapshot = AppleShortcutsSnapshot()
+    /// Bumped whenever the icon cache changes so observers (e.g. the settings list) can react
+    /// without icon bytes needing to live in `snapshot` itself.
+    @Published private(set) var iconCacheRevision = 0
 
     let executionStore: AppleShortcutsExecutionStore
     var onStateChange: (() -> Void)?
 
     private let runner: any AppleShortcutsCommandRunning
     private let visualMetadataLoader: any AppleShortcutsVisualMetadataLoading
+    private let iconCache: AppleShortcutsIconCache
     private let localization: PluginLocalization
     private let now: () -> Date
     private var refreshTask: Task<Void, Never>?
@@ -73,8 +77,6 @@ final class AppleShortcutsController: ObservableObject {
     private var settingsLibraryRevision: Int?
     private var queuedIconIDs: [UUID] = []
     private var queuedIconIDSet: Set<UUID> = []
-    private var loadedIconIDs: Set<UUID> = []
-    private var iconAccessOrder: [UUID] = []
     private var activeIconTasks: [UUID: Task<Void, Never>] = [:]
     private var activeRuns: [UUID: ActiveRun] = [:]
     private var activeViews: [UUID: ActiveView] = [:]
@@ -85,12 +87,14 @@ final class AppleShortcutsController: ObservableObject {
         executionStore: AppleShortcutsExecutionStore = AppleShortcutsExecutionStore(),
         runner: any AppleShortcutsCommandRunning,
         visualMetadataLoader: any AppleShortcutsVisualMetadataLoading = AppleShortcutsVisualMetadataLoader(),
+        iconCache: AppleShortcutsIconCache = AppleShortcutsIconCache(),
         localization: PluginLocalization,
         now: @escaping () -> Date = { .now }
     ) {
         self.executionStore = executionStore
         self.runner = runner
         self.visualMetadataLoader = visualMetadataLoader
+        self.iconCache = iconCache
         self.localization = localization
         self.now = now
     }
@@ -142,9 +146,16 @@ final class AppleShortcutsController: ObservableObject {
             pendingSettingsRefresh = false
             cancelSettingsRefresh()
             cancelIconLoads()
+            discardCachedIcons()
             return
         }
         refreshForSettings(force: false)
+    }
+
+    /// Returns the cached icon bitmap for a shortcut, if one has been loaded, without triggering
+    /// a fetch. Views should pair this with `requestIcon(for:)` in a `.task` to load on demand.
+    func cachedIconData(for shortcutID: UUID) -> Data? {
+        iconCache.data(for: shortcutID)
     }
 
     private var isLibraryFresh: Bool {
@@ -168,8 +179,7 @@ final class AppleShortcutsController: ObservableObject {
         guard force || !isLibraryFresh else { return }
         if case .settings = scope {
             cancelIconLoads()
-            loadedIconIDs.removeAll()
-            iconAccessOrder.removeAll()
+            discardCachedIcons()
         }
         let token = UUID()
         let generation = lifecycleGeneration
@@ -432,15 +442,8 @@ final class AppleShortcutsController: ObservableObject {
 
     func requestIcon(for shortcutID: UUID) {
         guard isSettingsVisible,
-              let shortcut = snapshot.discovery.shortcuts.first(where: { $0.id == shortcutID }),
-              shortcut.visualMetadata != nil
-        else { return }
-        if shortcut.visualMetadata?.iconTIFFData != nil {
-            markIconAsRecentlyUsed(shortcutID)
-            return
-        }
-        guard
-              !loadedIconIDs.contains(shortcutID),
+              snapshot.discovery.shortcuts.contains(where: { $0.id == shortcutID && $0.visualMetadata != nil }),
+              iconCache.data(for: shortcutID) == nil,
               activeIconTasks[shortcutID] == nil,
               queuedIconIDSet.insert(shortcutID).inserted
         else { return }
@@ -459,6 +462,7 @@ final class AppleShortcutsController: ObservableObject {
         isSettingsVisible = false
         pendingSettingsRefresh = false
         cancelIconLoads()
+        discardCachedIcons()
         snapshot.isRefreshing = false
         snapshot.errorMessage = nil
         snapshot.operationMessage = nil
@@ -531,7 +535,7 @@ final class AppleShortcutsController: ObservableObject {
             let shortcutID = queuedIconIDs.removeFirst()
             queuedIconIDSet.remove(shortcutID)
             guard snapshot.discovery.shortcuts.contains(where: { $0.id == shortcutID }),
-                  !loadedIconIDs.contains(shortcutID),
+                  iconCache.data(for: shortcutID) == nil,
                   activeIconTasks[shortcutID] == nil
             else { continue }
             return shortcutID
@@ -548,61 +552,19 @@ final class AppleShortcutsController: ObservableObject {
         defer { startQueuedIconLoads() }
         guard isSettingsVisible,
               settingsVisibilityGeneration == visibilityGeneration,
-              !Task.isCancelled
+              !Task.isCancelled,
+              case let .success(iconData) = result,
+              let iconData
         else { return }
-        loadedIconIDs.insert(shortcutID)
-        guard case let .success(iconData) = result,
-              let iconData,
-              retainIconData(iconData, for: shortcutID)
-        else { return }
-        guard let index = snapshot.discovery.shortcuts.firstIndex(where: { $0.id == shortcutID }),
-              let metadata = snapshot.discovery.shortcuts[index].visualMetadata
-        else { return }
-        snapshot.discovery.shortcuts[index].visualMetadata = AppleShortcutVisualMetadata(
-            color: metadata.color,
-            iconTIFFData: iconData
-        )
+        iconCache.store(iconData, for: shortcutID)
+        iconCacheRevision &+= 1
         onStateChange?()
     }
 
-    private func retainIconData(_ iconData: Data, for shortcutID: UUID) -> Bool {
-        guard iconData.count <= AppleShortcutsVisualMetadataLoader.maximumIconByteCount else {
-            return false
-        }
-        while retainedIconByteCount + iconData.count
-            > AppleShortcutsVisualMetadataLoader.maximumTotalIconByteCount,
-            let leastRecentlyUsedID = iconAccessOrder.first
-        {
-            removeRetainedIcon(for: leastRecentlyUsedID)
-        }
-        guard retainedIconByteCount + iconData.count
-            <= AppleShortcutsVisualMetadataLoader.maximumTotalIconByteCount
-        else { return false }
-        markIconAsRecentlyUsed(shortcutID)
-        return true
-    }
-
-    private var retainedIconByteCount: Int {
-        snapshot.discovery.shortcuts.reduce(into: 0) { total, item in
-            total += item.visualMetadata?.iconTIFFData?.count ?? 0
-        }
-    }
-
-    private func markIconAsRecentlyUsed(_ shortcutID: UUID) {
-        iconAccessOrder.removeAll { $0 == shortcutID }
-        iconAccessOrder.append(shortcutID)
-    }
-
-    private func removeRetainedIcon(for shortcutID: UUID) {
-        iconAccessOrder.removeAll { $0 == shortcutID }
-        loadedIconIDs.remove(shortcutID)
-        guard let index = snapshot.discovery.shortcuts.firstIndex(where: { $0.id == shortcutID }),
-              let metadata = snapshot.discovery.shortcuts[index].visualMetadata
-        else { return }
-        snapshot.discovery.shortcuts[index].visualMetadata = AppleShortcutVisualMetadata(
-            color: metadata.color,
-            iconTIFFData: nil
-        )
+    /// Frees every cached icon bitmap. Safe to call even when nothing is cached.
+    private func discardCachedIcons() {
+        iconCache.removeAll()
+        iconCacheRevision &+= 1
     }
 
     private func execute(

--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsIconCache.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsIconCache.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A bounded, memory-pressure-aware cache for Apple Shortcuts icon bitmaps.
+///
+/// Icon bytes are intentionally kept out of `AppleShortcutItem`/`AppleShortcutVisualMetadata`
+/// because they are only needed while the settings workspace is visible; storing them in the
+/// cache instead of the discovery snapshot keeps that snapshot cheap to copy and lets callers
+/// discard every cached icon in one step when the settings page closes.
+@MainActor
+final class AppleShortcutsIconCache {
+    /// Icons are downscaled and re-encoded before being cached (see
+    /// `AppleShortcutsVisualMetadataLoader`), so this budget only needs to comfortably cover the
+    /// settings list without letting a pathological icon inflate the app's resident memory.
+    static let defaultTotalCostLimit = 16 * 1_024 * 1_024
+
+    private let cache = NSCache<NSUUID, NSData>()
+
+    init(totalCostLimit: Int = Self.defaultTotalCostLimit) {
+        cache.totalCostLimit = totalCostLimit
+    }
+
+    func data(for shortcutID: UUID) -> Data? {
+        cache.object(forKey: shortcutID as NSUUID) as Data?
+    }
+
+    func store(_ data: Data, for shortcutID: UUID) {
+        cache.setObject(data as NSData, forKey: shortcutID as NSUUID, cost: data.count)
+    }
+
+    func removeAll() {
+        cache.removeAllObjects()
+    }
+}

--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsIconCache.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsIconCache.swift
@@ -15,7 +15,7 @@ final class AppleShortcutsIconCache {
 
     private let cache = NSCache<NSUUID, NSData>()
 
-    init(totalCostLimit: Int = Self.defaultTotalCostLimit) {
+    init(totalCostLimit: Int = AppleShortcutsIconCache.defaultTotalCostLimit) {
         cache.totalCostLimit = totalCostLimit
     }
 

--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsIconCache.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsIconCache.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A bounded, memory-pressure-aware cache for Apple Shortcuts icon bitmaps.
+/// A memory-pressure-aware cache for Apple Shortcuts icon bitmaps.
 ///
 /// Icon bytes are intentionally kept out of `AppleShortcutItem`/`AppleShortcutVisualMetadata`
 /// because they are only needed while the settings workspace is visible; storing them in the
@@ -9,8 +9,9 @@ import Foundation
 @MainActor
 final class AppleShortcutsIconCache {
     /// Icons are downscaled and re-encoded before being cached (see
-    /// `AppleShortcutsVisualMetadataLoader`), so this budget only needs to comfortably cover the
-    /// settings list without letting a pathological icon inflate the app's resident memory.
+    /// `AppleShortcutsVisualMetadataLoader`), so this advisory budget should comfortably cover the
+    /// settings list. `NSCache` may temporarily exceed its total-cost limit; cached icons are
+    /// removed explicitly when the settings workspace closes.
     static let defaultTotalCostLimit = 16 * 1_024 * 1_024
 
     private let cache = NSCache<NSUUID, NSData>()

--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsModels.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsModels.swift
@@ -37,7 +37,6 @@ struct AppleShortcutVisualMetadata: Codable, Equatable, Hashable, Sendable {
     }
 
     let color: Color
-    let iconTIFFData: Data?
 }
 
 struct AppleShortcutFolder: Codable, Equatable, Hashable, Identifiable, Sendable {

--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsSettingsView.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsSettingsView.swift
@@ -248,7 +248,8 @@ struct AppleShortcutsSettingsView: View {
         HStack(spacing: 10) {
             AppleShortcutIcon(
                 shortcutID: row.id,
-                metadata: row.item.visualMetadata,
+                color: row.item.visualMetadata?.color,
+                iconData: controller.cachedIconData(for: row.id),
                 size: 30,
                 requestIcon: controller.requestIcon
             )
@@ -283,7 +284,8 @@ struct AppleShortcutsSettingsView: View {
                     HStack(alignment: .top, spacing: 14) {
                         AppleShortcutIcon(
                             shortcutID: row.id,
-                            metadata: row.item.visualMetadata,
+                            color: row.item.visualMetadata?.color,
+                            iconData: controller.cachedIconData(for: row.id),
                             size: 56,
                             requestIcon: controller.requestIcon
                         )
@@ -487,16 +489,16 @@ struct AppleShortcutsSettingsView: View {
 
 private struct AppleShortcutIcon: View {
     let shortcutID: UUID
-    let metadata: AppleShortcutVisualMetadata?
+    let color: AppleShortcutVisualMetadata.Color?
+    let iconData: Data?
     let size: CGFloat
     let requestIcon: (UUID) -> Void
 
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: size * 0.23, style: .continuous)
-                .fill(color)
-            if let iconData = metadata?.iconTIFFData,
-               let icon = NSImage(data: iconData) {
+                .fill(fillColor)
+            if let iconData, let icon = NSImage(data: iconData) {
                 Image(nsImage: icon)
                     .resizable()
                     .interpolation(.high)
@@ -510,14 +512,14 @@ private struct AppleShortcutIcon: View {
         }
         .frame(width: size, height: size)
         .accessibilityHidden(true)
-        .task(id: metadata?.iconTIFFData == nil) {
-            guard metadata != nil else { return }
+        .task(id: iconData == nil) {
+            guard color != nil else { return }
             requestIcon(shortcutID)
         }
     }
 
-    private var color: Color {
-        guard let color = metadata?.color else { return .purple }
+    private var fillColor: Color {
+        guard let color else { return .purple }
         return Color(
             red: color.red.clamped(to: 0 ... 1),
             green: color.green.clamped(to: 0 ... 1),

--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsVisualMetadataLoader.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsVisualMetadataLoader.swift
@@ -14,8 +14,13 @@ protocol AppleShortcutsVisualMetadataLoading: Sendable {
 
 struct AppleShortcutsVisualMetadataLoader: AppleShortcutsVisualMetadataLoading {
     static let scriptTimeoutSeconds = 10
+    /// Safety net on the raw AppleScript reply, before it is decoded and downscaled.
     static let maximumIconByteCount = 4 * 1_024 * 1_024
-    static let maximumTotalIconByteCount = 128 * 1_024 * 1_024
+    /// Icons only ever render at small sizes in the settings list/detail panes, so downscaling
+    /// them before caching avoids retaining full-resolution artwork for no visual benefit.
+    static let maximumIconDimension: CGFloat = 128
+    /// Safety net on the re-encoded bitmap actually handed to the cache.
+    static let maximumEncodedIconByteCount = 512 * 1_024
 
     private static let scriptSource = """
     with timeout of \(scriptTimeoutSeconds) seconds
@@ -92,11 +97,44 @@ struct AppleShortcutsVisualMetadataLoader: AppleShortcutsVisualMetadataLoading {
         guard error == nil else {
             return .failure(.automationUnavailable)
         }
-        let iconData = result.data
-        guard iconData.count <= maximumIconByteCount else {
+        let rawIconData = result.data
+        guard rawIconData.count <= maximumIconByteCount else {
             return .success(nil)
         }
-        return .success(iconData)
+        return .success(downscaledIconData(rawIconData, maximumDimension: maximumIconDimension))
+    }
+
+    /// Re-encodes an icon bitmap as a small, bounded-size PNG so cached icons stay cheap in memory.
+    /// Returns `nil` when the source data cannot be decoded or the result still exceeds the budget.
+    static func downscaledIconData(_ data: Data, maximumDimension: CGFloat) -> Data? {
+        guard let image = NSImage(data: data) else { return nil }
+        let sourceSize = image.size
+        guard sourceSize.width > 0, sourceSize.height > 0 else { return nil }
+
+        let scale = min(1, maximumDimension / max(sourceSize.width, sourceSize.height))
+        let targetSize = NSSize(
+            width: max(1, sourceSize.width * scale),
+            height: max(1, sourceSize.height * scale)
+        )
+
+        let resized = NSImage(size: targetSize)
+        resized.lockFocus()
+        image.draw(
+            in: NSRect(origin: .zero, size: targetSize),
+            from: NSRect(origin: .zero, size: sourceSize),
+            operation: .copy,
+            fraction: 1
+        )
+        resized.unlockFocus()
+
+        guard let tiffData = resized.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]),
+              pngData.count <= maximumEncodedIconByteCount
+        else {
+            return nil
+        }
+        return pngData
     }
 
     static func parse(
@@ -114,24 +152,8 @@ struct AppleShortcutsVisualMetadataLoader: AppleShortcutsVisualMetadataLoading {
                   let color = color(red: red, green: green, blue: blue) else {
                 return .failure(.malformedReply)
             }
-            metadataByID[id] = AppleShortcutVisualMetadata(
-                color: color,
-                iconTIFFData: nil
-            )
+            metadataByID[id] = AppleShortcutVisualMetadata(color: color)
         }
         return .success(metadataByID)
-    }
-
-    static func retainedIconData(
-        _ rawIconData: Data?,
-        remainingByteCount: inout Int
-    ) -> Data? {
-        guard let rawIconData,
-              rawIconData.count <= maximumIconByteCount,
-              rawIconData.count <= remainingByteCount else {
-            return nil
-        }
-        remainingByteCount -= rawIconData.count
-        return rawIconData
     }
 }

--- a/Plugins/AppleShortcuts/Tests/AppleShortcutsControllerTests.swift
+++ b/Plugins/AppleShortcuts/Tests/AppleShortcutsControllerTests.swift
@@ -322,6 +322,40 @@ final class AppleShortcutsControllerTests: XCTestCase {
         XCTAssertNil(controller.cachedIconData(for: item.id))
     }
 
+    func testFailedIconLoadIsNotRetriedUntilSettingsRefresh() async throws {
+        let item = AppleShortcutItem(id: UUID(), name: "Broken")
+        let metadata = AppleShortcutVisualMetadata(color: .init(red: 0.25, green: 0.5, blue: 0.75))
+        let visualMetadataLoader = AppleShortcutsVisualMetadataCountingStub(
+            result: .success([item.id: metadata]),
+            iconResult: .failure(.automationUnavailable)
+        )
+        let controller = makeController(
+            runner: AppleShortcutsRunnerStub(shortcuts: [item]),
+            visualMetadataLoader: visualMetadataLoader
+        )
+
+        controller.setSettingsVisible(true)
+        for _ in 0 ..< 100 {
+            if controller.snapshot.discovery.shortcuts.first?.visualMetadata == metadata { break }
+            await Task.yield()
+        }
+        controller.requestIcon(for: item.id)
+        for _ in 0 ..< 100 {
+            if await visualMetadataLoader.observedIconCallCount() == 1 { break }
+            await Task.yield()
+        }
+
+        // Simulates a list row disappearing and reappearing (e.g. scrolling), which recreates the
+        // icon view and re-triggers its `.task`.
+        controller.requestIcon(for: item.id)
+        controller.requestIcon(for: item.id)
+        for _ in 0 ..< 20 { await Task.yield() }
+
+        let iconCallCount = await visualMetadataLoader.observedIconCallCount()
+        XCTAssertEqual(iconCallCount, 1)
+        XCTAssertNil(controller.cachedIconData(for: item.id))
+    }
+
     func testMembershipQueriesRespectConcurrencyLimit() async throws {
         let folders = (0 ..< 9).map {
             AppleShortcutFolder(id: UUID(), name: "Folder \($0)")

--- a/Plugins/AppleShortcuts/Tests/AppleShortcutsControllerTests.swift
+++ b/Plugins/AppleShortcuts/Tests/AppleShortcutsControllerTests.swift
@@ -28,10 +28,7 @@ final class AppleShortcutsControllerTests: XCTestCase {
 
     func testRefreshAppliesVisualMetadataToDiscoveredShortcut() async throws {
         let item = AppleShortcutItem(id: UUID(), name: "Colored")
-        let metadata = AppleShortcutVisualMetadata(
-            color: .init(red: 0.25, green: 0.5, blue: 0.75),
-            iconTIFFData: Data([0x01])
-        )
+        let metadata = AppleShortcutVisualMetadata(color: .init(red: 0.25, green: 0.5, blue: 0.75))
         let controller = makeController(
             runner: AppleShortcutsRunnerStub(shortcuts: [item]),
             visualMetadataLoader: AppleShortcutsVisualMetadataStub(result: .success([item.id: metadata]))
@@ -169,10 +166,7 @@ final class AppleShortcutsControllerTests: XCTestCase {
 
     func testSettingsRefreshLoadsFoldersAndVisualMetadataAfterBackgroundRefresh() async throws {
         let item = AppleShortcutItem(id: UUID(), name: "Visual")
-        let metadata = AppleShortcutVisualMetadata(
-            color: .init(red: 0.25, green: 0.5, blue: 0.75),
-            iconTIFFData: Data([0x01])
-        )
+        let metadata = AppleShortcutVisualMetadata(color: .init(red: 0.25, green: 0.5, blue: 0.75))
         let runner = AppleShortcutsRunnerStub(shortcuts: [item])
         let visualMetadataLoader = AppleShortcutsVisualMetadataCountingStub(
             result: .success([item.id: metadata])
@@ -206,10 +200,7 @@ final class AppleShortcutsControllerTests: XCTestCase {
         var currentDate = Date(timeIntervalSince1970: 1_000)
         let first = AppleShortcutItem(id: UUID(), name: "First")
         let second = AppleShortcutItem(id: UUID(), name: "Second")
-        let metadata = AppleShortcutVisualMetadata(
-            color: .init(red: 0.25, green: 0.5, blue: 0.75),
-            iconTIFFData: nil
-        )
+        let metadata = AppleShortcutVisualMetadata(color: .init(red: 0.25, green: 0.5, blue: 0.75))
         let runner = AppleShortcutsRunnerStub(shortcuts: [first])
         let visualMetadataLoader = AppleShortcutsVisualMetadataCountingStub(
             result: .success([first.id: metadata, second.id: metadata])
@@ -249,10 +240,7 @@ final class AppleShortcutsControllerTests: XCTestCase {
 
     func testHidingSettingsCancelsRichRefreshAndDiscardsItsResult() async throws {
         let item = AppleShortcutItem(id: UUID(), name: "Hidden")
-        let metadata = AppleShortcutVisualMetadata(
-            color: .init(red: 0.25, green: 0.5, blue: 0.75),
-            iconTIFFData: nil
-        )
+        let metadata = AppleShortcutVisualMetadata(color: .init(red: 0.25, green: 0.5, blue: 0.75))
         let visualMetadataLoader = AppleShortcutsVisualMetadataDelayedStub(
             result: .success([item.id: metadata]),
             delay: .milliseconds(100)
@@ -277,10 +265,7 @@ final class AppleShortcutsControllerTests: XCTestCase {
 
     func testVisibleSettingsLoadsIconsOnDemand() async throws {
         let item = AppleShortcutItem(id: UUID(), name: "Icon")
-        let metadata = AppleShortcutVisualMetadata(
-            color: .init(red: 0.25, green: 0.5, blue: 0.75),
-            iconTIFFData: nil
-        )
+        let metadata = AppleShortcutVisualMetadata(color: .init(red: 0.25, green: 0.5, blue: 0.75))
         let iconData = Data([0x01, 0x02])
         let visualMetadataLoader = AppleShortcutsVisualMetadataCountingStub(
             result: .success([item.id: metadata]),
@@ -298,13 +283,43 @@ final class AppleShortcutsControllerTests: XCTestCase {
         }
         controller.requestIcon(for: item.id)
         for _ in 0 ..< 100 {
-            if controller.snapshot.discovery.shortcuts.first?.visualMetadata?.iconTIFFData == iconData { break }
+            if controller.cachedIconData(for: item.id) == iconData { break }
             await Task.yield()
         }
 
         let iconCallCount = await visualMetadataLoader.observedIconCallCount()
         XCTAssertEqual(iconCallCount, 1)
-        XCTAssertEqual(controller.snapshot.discovery.shortcuts.first?.visualMetadata?.iconTIFFData, iconData)
+        XCTAssertEqual(controller.cachedIconData(for: item.id), iconData)
+    }
+
+    func testHidingSettingsDiscardsCachedIcons() async throws {
+        let item = AppleShortcutItem(id: UUID(), name: "Icon")
+        let metadata = AppleShortcutVisualMetadata(color: .init(red: 0.25, green: 0.5, blue: 0.75))
+        let iconData = Data([0x01, 0x02])
+        let visualMetadataLoader = AppleShortcutsVisualMetadataCountingStub(
+            result: .success([item.id: metadata]),
+            iconResult: .success(iconData)
+        )
+        let controller = makeController(
+            runner: AppleShortcutsRunnerStub(shortcuts: [item]),
+            visualMetadataLoader: visualMetadataLoader
+        )
+
+        controller.setSettingsVisible(true)
+        for _ in 0 ..< 100 {
+            if controller.snapshot.discovery.shortcuts.first?.visualMetadata == metadata { break }
+            await Task.yield()
+        }
+        controller.requestIcon(for: item.id)
+        for _ in 0 ..< 100 {
+            if controller.cachedIconData(for: item.id) == iconData { break }
+            await Task.yield()
+        }
+        XCTAssertEqual(controller.cachedIconData(for: item.id), iconData)
+
+        controller.setSettingsVisible(false)
+
+        XCTAssertNil(controller.cachedIconData(for: item.id))
     }
 
     func testMembershipQueriesRespectConcurrencyLimit() async throws {

--- a/Plugins/AppleShortcuts/Tests/AppleShortcutsIconCacheTests.swift
+++ b/Plugins/AppleShortcuts/Tests/AppleShortcutsIconCacheTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import XCTest
+@testable import AppleShortcutsPlugin
+
+@MainActor
+final class AppleShortcutsIconCacheTests: XCTestCase {
+    func testStoresAndReturnsIconData() {
+        let cache = AppleShortcutsIconCache()
+        let shortcutID = UUID()
+        let iconData = Data([0x01, 0x02, 0x03])
+
+        XCTAssertNil(cache.data(for: shortcutID))
+        cache.store(iconData, for: shortcutID)
+
+        XCTAssertEqual(cache.data(for: shortcutID), iconData)
+    }
+
+    func testRemoveAllDiscardsEveryCachedIcon() {
+        let cache = AppleShortcutsIconCache()
+        let firstID = UUID()
+        let secondID = UUID()
+        cache.store(Data([0x01]), for: firstID)
+        cache.store(Data([0x02]), for: secondID)
+
+        cache.removeAll()
+
+        XCTAssertNil(cache.data(for: firstID))
+        XCTAssertNil(cache.data(for: secondID))
+    }
+
+    func testEvictsEntriesOnceTheCostLimitIsExceeded() {
+        let cache = AppleShortcutsIconCache(totalCostLimit: 10)
+        let firstID = UUID()
+        let secondID = UUID()
+
+        cache.store(Data(repeating: 0, count: 8), for: firstID)
+        cache.store(Data(repeating: 0, count: 8), for: secondID)
+
+        // NSCache doesn't guarantee eviction order, only that it enforces the cost budget.
+        let remaining = [firstID, secondID].compactMap { cache.data(for: $0) }
+        XCTAssertLessThan(remaining.count, 2, "exceeding the cost limit should evict at least one entry")
+    }
+}

--- a/Plugins/AppleShortcuts/Tests/AppleShortcutsIconCacheTests.swift
+++ b/Plugins/AppleShortcuts/Tests/AppleShortcutsIconCacheTests.swift
@@ -27,17 +27,4 @@ final class AppleShortcutsIconCacheTests: XCTestCase {
         XCTAssertNil(cache.data(for: firstID))
         XCTAssertNil(cache.data(for: secondID))
     }
-
-    func testEvictsEntriesOnceTheCostLimitIsExceeded() {
-        let cache = AppleShortcutsIconCache(totalCostLimit: 10)
-        let firstID = UUID()
-        let secondID = UUID()
-
-        cache.store(Data(repeating: 0, count: 8), for: firstID)
-        cache.store(Data(repeating: 0, count: 8), for: secondID)
-
-        // NSCache doesn't guarantee eviction order, only that it enforces the cost budget.
-        let remaining = [firstID, secondID].compactMap { cache.data(for: $0) }
-        XCTAssertLessThan(remaining.count, 2, "exceeding the cost limit should evict at least one entry")
-    }
 }

--- a/Plugins/AppleShortcuts/Tests/AppleShortcutsVisualMetadataLoaderTests.swift
+++ b/Plugins/AppleShortcuts/Tests/AppleShortcutsVisualMetadataLoaderTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import XCTest
 @testable import AppleShortcutsPlugin
@@ -24,21 +25,40 @@ final class AppleShortcutsVisualMetadataLoaderTests: XCTestCase {
         ))
     }
 
-    func testRetainsIconsOnlyWithinTheTotalMemoryBudget() {
-        var remainingByteCount = 2
-        let firstIcon = Data([0x01, 0x02])
+    func testDownscalesLargeIconsBelowTheEncodedByteBudget() throws {
+        let largeIcon = try XCTUnwrap(Self.makePNGData(size: NSSize(width: 1_024, height: 1_024)))
 
-        XCTAssertEqual(
-            AppleShortcutsVisualMetadataLoader.retainedIconData(
-                firstIcon,
-                remainingByteCount: &remainingByteCount
-            ),
-            firstIcon
-        )
-        XCTAssertEqual(remainingByteCount, 0)
-        XCTAssertNil(AppleShortcutsVisualMetadataLoader.retainedIconData(
-            Data([0x03]),
-            remainingByteCount: &remainingByteCount
+        let downscaled = try XCTUnwrap(AppleShortcutsVisualMetadataLoader.downscaledIconData(
+            largeIcon,
+            maximumDimension: AppleShortcutsVisualMetadataLoader.maximumIconDimension
         ))
+        let image = try XCTUnwrap(NSImage(data: downscaled))
+
+        XCTAssertLessThanOrEqual(
+            downscaled.count,
+            AppleShortcutsVisualMetadataLoader.maximumEncodedIconByteCount
+        )
+        XCTAssertLessThanOrEqual(image.size.width, AppleShortcutsVisualMetadataLoader.maximumIconDimension)
+        XCTAssertLessThanOrEqual(image.size.height, AppleShortcutsVisualMetadataLoader.maximumIconDimension)
+    }
+
+    func testDownscalingReturnsNilForUndecodableData() {
+        XCTAssertNil(AppleShortcutsVisualMetadataLoader.downscaledIconData(
+            Data([0x00, 0x01, 0x02]),
+            maximumDimension: AppleShortcutsVisualMetadataLoader.maximumIconDimension
+        ))
+    }
+
+    private static func makePNGData(size: NSSize) -> Data? {
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        image.unlockFocus()
+        guard let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData) else {
+            return nil
+        }
+        return bitmap.representation(using: .png, properties: [:])
     }
 }

--- a/changes/unreleased/apple-shortcuts-icon-memory.md
+++ b/changes/unreleased/apple-shortcuts-icon-memory.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: fixed
+area: Productivity
+---
+
+Apple Shortcuts icon thumbnails are now downscaled before caching and released as soon as the settings page closes, keeping the plugin's memory footprint small.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follows up on `AppleShortcutsController`'s icon-loading path (introduced in #285) to fix a memory issue: once the settings page loads an icon, the bytes stayed resident for the whole app session (up to a 128MB budget) even after the settings page closed, even though icons are only ever rendered there.

## Changes

1. **Free cached icons when settings close.** `setSettingsVisible(false)` and `deactivate()` now discard every cached icon immediately, instead of only cancelling in-flight loads.
2. **Use a smaller advisory cache budget.** `NSCache` is configured with a 16MB total-cost target. This is intentionally a soft budget rather than a strict memory ceiling; explicit removal when settings close provides deterministic release.
3. **Downscale before caching.** Icons are resized to a maximum 128pt dimension and re-encoded as PNG before being retained, so a typical cached icon is a few KB instead of a multi-representation TIFF.
4. **Use `NSCache`.** A new `AppleShortcutsIconCache` wraps `NSCache`, replacing the hand-rolled LRU/byte-budget bookkeeping (`loadedIconIDs`, `iconAccessOrder`, `retainIconData`, etc.) with a system cache that can also respond to memory pressure automatically.

As part of this, icon bytes moved out of `AppleShortcutVisualMetadata`/the discovery snapshot into the dedicated cache, since they're a settings-UI-only concern — this also keeps the snapshot cheap to copy/diff.

## Self-review fix

While re-reviewing the diff for correctness, found that the refactor had dropped a subtle protection from the original code: `loadedIconIDs` used to mark a shortcut as "attempted" regardless of success or failure, so a permanently failing icon load (e.g. automation unavailable, icon too large) wouldn't be retried every time its row reappears (e.g. scrolling the list). The new cache-based version only recorded successes, so failures would be retried indefinitely. Fixed by adding a small `failedIconIDs` set (identifiers only, negligible memory) that's checked alongside the cache and cleared on the next settings-scope refresh — restoring the original negative-caching behavior without bringing back the byte-budget bookkeeping.

## Performance

- Downscaling/re-encoding runs on the same background `.utility` queue the icon fetch already used (unchanged threading model), gated by the existing `maximumConcurrentIconLoads = 2` limit — no main-thread work added.
- After downscaling, a typical cached icon is a few KB, so the 16MB advisory budget should comfortably cover typical shortcut libraries.
- `NSCache` manages eviction under memory pressure, but its total-cost target is not a strict limit; cached icons are explicitly removed when the settings page closes.
- SwiftUI re-render frequency/granularity is unchanged: the new `iconCacheRevision` `@Published` property replaces a mutation that used to live inside `snapshot`, both firing `objectWillChange` at the same points.
- Known accepted trade-off: since icons are now discarded whenever the user navigates away from the Apple Shortcuts settings page, revisiting it re-triggers on-demand icon loads (same pop-in behavior as a first-time visit) instead of showing instantly from a long-lived cache. This was requested explicitly to reduce retained memory.

## Testing

Verified locally with:

```sh
xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug \
  -destination platform=macOS \
  -derivedDataPath build/DerivedData \
  CODE_SIGNING_ALLOWED=NO \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGN_IDENTITY= \
  test -quiet \
  -only-testing:MacToolsTests/AppleShortcutsControllerTests \
  -only-testing:MacToolsTests/AppleShortcutsVisualMetadataLoaderTests \
  -only-testing:MacToolsTests/AppleShortcutsIconCacheTests
```

Updated/added tests:
- `AppleShortcutsControllerTests`: updated icon-related tests to read from `controller.cachedIconData(for:)` instead of `visualMetadata.iconTIFFData`; added `testHidingSettingsDiscardsCachedIcons` and `testFailedIconLoadIsNotRetriedUntilSettingsRefresh`.
- `AppleShortcutsVisualMetadataLoaderTests`: replaced the obsolete manual byte-budget test with tests for the new `downscaledIconData` helper.
- `AppleShortcutsIconCacheTests` (new): store/retrieve and `removeAll`. It intentionally does not assert `NSCache` eviction timing because the total-cost target is advisory.

Added a changelog fragment under `changes/unreleased/`.
<!-- CURSOR_AGENT_PR_BODY_END -->
