### PR TITLE
fix(plugin): stabilize zsh editor highlighting

### DIFF
--- a/Plugins/ZshConfig/Sources/ZshSyntaxHighlightingEditor.swift
+++ b/Plugins/ZshConfig/Sources/ZshSyntaxHighlightingEditor.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 /// NSTextView-based code editor with zsh/shell syntax highlighting.
 /// Supports comments, keywords, quoted strings, and variable references.
+@MainActor
 struct ZshSyntaxHighlightingEditor: NSViewRepresentable {
     @Binding var text: String
     var isEditable: Bool = true
@@ -14,6 +15,10 @@ struct ZshSyntaxHighlightingEditor: NSViewRepresentable {
     var scrollToBottomID: Int = 0
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
+        coordinator.cancelPendingHighlighting()
+    }
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSTextView.scrollableTextView()
@@ -53,6 +58,7 @@ struct ZshSyntaxHighlightingEditor: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
         guard let textView = nsView.documentView as? NSTextView else { return }
         guard !context.coordinator.isHighlighting else { return }
 
@@ -61,6 +67,7 @@ struct ZshSyntaxHighlightingEditor: NSViewRepresentable {
         // emits `objectWillChange` in `willSet`, so `updateNSView` can observe the old value and
         // incorrectly reset the editor, clearing the undo stack.
         if text != context.coordinator.lastTextFedToBinding {
+            context.coordinator.cancelPendingHighlighting()
             context.coordinator.lastTextFedToBinding = text
             let sel = textView.selectedRange()
             textView.string = text
@@ -108,6 +115,9 @@ struct ZshSyntaxHighlightingEditor: NSViewRepresentable {
         guard let storage = textView.textStorage else { return }
         let string = textView.string
         let fullRange = NSRange(location: 0, length: (string as NSString).length)
+        let selectedRange = textView.selectedRange()
+        let scrollView = textView.enclosingScrollView
+        let scrollOrigin = scrollView?.contentView.bounds.origin
 
         // Syntax highlighting attributes must not enter the undo stack, or Cmd-Z would undo
         // highlighting instead of text edits.
@@ -138,19 +148,38 @@ struct ZshSyntaxHighlightingEditor: NSViewRepresentable {
 
         // Keep typing attributes consistent so new characters start with base style
         textView.typingAttributes = baseAttributes
+        textView.setSelectedRange(selectedRange)
+        if let scrollView, let scrollOrigin {
+            scrollView.contentView.scroll(to: scrollOrigin)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
     }
 
     // MARK: - Coordinator
 
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
+        typealias Highlighter = @MainActor (NSTextView) -> Void
+
+        static let highlightingDelay: TimeInterval = 0.1
+
         var parent: ZshSyntaxHighlightingEditor
         var isHighlighting = false
         var lastScrollToBottomID: Int = 0
         /// Last text pushed to the binding by `textDidChange`, used to distinguish user input from external assignment.
         var lastTextFedToBinding: String = ""
+        private let highlightingDelay: TimeInterval
+        private let highlighter: Highlighter
+        private var pendingHighlightingWork: DispatchWorkItem?
 
-        init(_ parent: ZshSyntaxHighlightingEditor) {
+        init(
+            _ parent: ZshSyntaxHighlightingEditor,
+            highlightingDelay: TimeInterval = Coordinator.highlightingDelay,
+            highlighter: @escaping Highlighter = ZshSyntaxHighlightingEditor.applyHighlighting
+        ) {
             self.parent = parent
+            self.highlightingDelay = highlightingDelay
+            self.highlighter = highlighter
         }
 
         func textDidChange(_ notification: Notification) {
@@ -158,9 +187,28 @@ struct ZshSyntaxHighlightingEditor: NSViewRepresentable {
             lastTextFedToBinding = textView.string
             parent.text = textView.string
             parent.onChange?()
-            isHighlighting = true
-            ZshSyntaxHighlightingEditor.applyHighlighting(to: textView)
-            isHighlighting = false
+
+            scheduleHighlighting(for: textView)
+        }
+
+        func cancelPendingHighlighting() {
+            pendingHighlightingWork?.cancel()
+            pendingHighlightingWork = nil
+        }
+
+        private func scheduleHighlighting(for textView: NSTextView) {
+            cancelPendingHighlighting()
+
+            let work = DispatchWorkItem { [weak self, weak textView] in
+                guard let self, let textView else { return }
+                self.pendingHighlightingWork = nil
+                guard !textView.hasMarkedText() else { return }
+                self.isHighlighting = true
+                defer { self.isHighlighting = false }
+                self.highlighter(textView)
+            }
+            pendingHighlightingWork = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + highlightingDelay, execute: work)
         }
     }
 }

--- a/Plugins/ZshConfig/Tests/ZshSyntaxHighlightingEditorTests.swift
+++ b/Plugins/ZshConfig/Tests/ZshSyntaxHighlightingEditorTests.swift
@@ -1,0 +1,120 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import ZshConfigPlugin
+
+@MainActor
+final class ZshSyntaxHighlightingEditorTests: XCTestCase {
+    private var bindingValue = ""
+
+    func testTextChangeDefersHighlightingUntilTypingPauses() {
+        bindingValue = "alias ll='ls -la'"
+        var highlightCount = 0
+        let editor = makeEditor()
+        let coordinator = ZshSyntaxHighlightingEditor.Coordinator(
+            editor,
+            highlightingDelay: 0.01,
+            highlighter: { _ in highlightCount += 1 }
+        )
+        let textView = NSTextView()
+        textView.string = bindingValue
+
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+
+        XCTAssertEqual(bindingValue, "alias ll='ls -la'")
+        XCTAssertEqual(highlightCount, 0)
+
+        let expectation = expectation(description: "highlighting completes")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(highlightCount, 1)
+    }
+
+    func testRapidTextChangesCoalesceIntoOneHighlightingPass() {
+        bindingValue = "alias first='echo first'"
+        var highlightedText: [String] = []
+        let editor = makeEditor()
+        let coordinator = ZshSyntaxHighlightingEditor.Coordinator(
+            editor,
+            highlightingDelay: 0.01,
+            highlighter: { highlightedText.append($0.string) }
+        )
+        let textView = NSTextView()
+
+        textView.string = "alias first='echo first'"
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        textView.string = "alias second='echo second'"
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+
+        let expectation = expectation(description: "coalesced highlighting completes")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(highlightedText, ["alias second='echo second'"])
+        XCTAssertEqual(bindingValue, "alias second='echo second'")
+    }
+
+    func testCancellingPendingHighlightingPreventsThePass() {
+        bindingValue = "export PATH=/usr/local/bin"
+        var highlightCount = 0
+        let editor = makeEditor()
+        let coordinator = ZshSyntaxHighlightingEditor.Coordinator(
+            editor,
+            highlightingDelay: 0.01,
+            highlighter: { _ in highlightCount += 1 }
+        )
+        let textView = NSTextView()
+        textView.string = bindingValue
+
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        coordinator.cancelPendingHighlighting()
+
+        let expectation = expectation(description: "cancelled highlighting would have completed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(highlightCount, 0)
+    }
+
+    func testHighlightingPreservesSelection() {
+        let textView = NSTextView()
+        textView.string = "alias ll='ls -la'\n# comment"
+        let selection = NSRange(location: 7, length: 2)
+        textView.setSelectedRange(selection)
+
+        ZshSyntaxHighlightingEditor.applyHighlighting(to: textView)
+
+        XCTAssertEqual(textView.selectedRange(), selection)
+    }
+
+    func testHighlightingPreservesScrollOrigin() throws {
+        let scrollView = NSTextView.scrollableTextView()
+        scrollView.frame = NSRect(x: 0, y: 0, width: 240, height: 160)
+        let textView = try XCTUnwrap(scrollView.documentView as? NSTextView)
+        textView.string = (0 ..< 200).map { "alias item\($0)='echo \($0)'" }.joined(separator: "\n")
+        textView.frame = NSRect(x: 0, y: 0, width: 240, height: 4_000)
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 300))
+        let origin = scrollView.contentView.bounds.origin
+
+        ZshSyntaxHighlightingEditor.applyHighlighting(to: textView)
+
+        XCTAssertEqual(scrollView.contentView.bounds.origin.x, origin.x, accuracy: 0.001)
+        XCTAssertEqual(scrollView.contentView.bounds.origin.y, origin.y, accuracy: 0.001)
+    }
+
+    private func makeEditor() -> ZshSyntaxHighlightingEditor {
+        ZshSyntaxHighlightingEditor(
+            text: Binding(
+                get: { self.bindingValue },
+                set: { self.bindingValue = $0 }
+            )
+        )
+    }
+}

--- a/changes/unreleased/zsh-config-editor-stability.md
+++ b/changes/unreleased/zsh-config-editor-stability.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: fixed
+area: zsh Config
+---
+
+Improved inline editing stability for large zsh configuration files.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -4,3 +4,4 @@
 - [Dock Icon for Settings Window](dock-icon-for-settings-window.md)
 - [App Reopen Recovery](app-reopen-recovery.md)
 - [Input Remapping](input-remapping.md)
+- [zsh Config Editor Stability](zsh-config-editor-stability.md)

--- a/docs/features/zsh-config-editor-stability.md
+++ b/docs/features/zsh-config-editor-stability.md
@@ -1,0 +1,85 @@
+# Feature — zsh Config Editor Stability
+
+Last verified: 2026-08-20
+
+Status: in-review
+Source of truth: yes
+
+## Summary
+
+- Fix issue #110.
+- Keep caret, focus, and viewport stable while editing zsh configuration files.
+- Defer full-document syntax highlighting until typing pauses.
+
+## User flow
+
+- User edits a long zsh configuration file in the inline editor.
+- Text and unsaved-change state update immediately.
+- Syntax highlighting refreshes shortly after typing stops.
+- Selection and viewport stay unchanged by the highlighting pass.
+
+## Business rules
+
+| Rule | Markdown | Centralized code | Consumers |
+|---|---|---|---|
+| No durable business rule | — | — | — |
+
+## Decisions
+
+| Date | Decision | Reason | Impact |
+|---|---|---|---|
+| 2026-08-20 | Use a 100 ms coalesced delay for full-document highlighting | Avoid synchronous layout invalidation on every keystroke without removing highlighting | Editor only |
+| 2026-08-20 | Keep highlighting on the main queue | NSTextView and NSTextStorage are AppKit UI state | Editor only |
+
+## Plan
+
+- [x] P001 — Define the focused correction and acceptance contract.
+- [x] P002 — Add coordinator-level regression tests for delayed, coalesced, and cancelled highlighting.
+- [x] P003 — Defer highlighting and preserve editor selection and viewport.
+- [x] P004 — Run targeted checks and a separate review.
+- [x] P005 — Commit and open the PR for issue #110.
+
+## TODO
+
+- [x] F001 — Add delayed highlighting coordinator behavior — files: `Plugins/ZshConfig/Sources/ZshSyntaxHighlightingEditor.swift` — status: done
+- [x] F002 — Add editor regression tests — files: `Plugins/ZshConfig/Tests/ZshSyntaxHighlightingEditorTests.swift` — status: done
+- [x] F003 — Add release note — files: `changes/unreleased/zsh-config-editor-stability.md` — status: done
+- [x] F004 — Verify the focused diff — files: `Plugins/ZshConfig/`, `docs/features/zsh-config-editor-stability.md` — status: done
+- [x] F005 — Complete the separate review — files: `Plugins/ZshConfig/`, `docs/features/zsh-config-editor-stability.md` — status: done
+
+## Acceptance / DoD
+
+- [x] Text binding updates immediately after an edit.
+- [x] Rapid edits result in one delayed highlighting pass.
+- [x] Replaced content cancels a pending highlighting pass.
+- [x] Highlighting preserves the current selection and viewport.
+- [x] Targeted XCTest and plugin build pass.
+- [ ] Manual QA confirms no focus or viewport jump in a long `.zshrc`.
+- [x] Separate review completed.
+
+## Implementation journal
+
+- 2026-08-20 — Added a 100 ms main-queue debounce in the NSTextView coordinator. Pending work is cancelled for external replacements and view teardown. Highlighting now restores the selection and scroll origin without taking first responder status. Added focused coordinator tests and a plugin release-note fragment. No manifest, registry, or inventory change is required because this changes existing plugin source and tests only.
+- 2026-08-20 — Checks passed: Swift parse for ZshConfig source and tests; `MacToolsTests/ZshSyntaxHighlightingEditorTests` (5 tests); and `make build-plugin PLUGIN=ZshConfig`. The targeted MacTools test build emitted existing Swift 6 warnings in DiskClean test support, outside this feature's diff.
+- 2026-08-20 — Separate review completed. Checked coordinator lifecycle, main-actor isolation, cancelled work, selection/viewport restoration, undo protection, and tests. No actionable finding. UI automation opened the editor but could not click the offscreen accessibility element; the AppKit viewport test covers that invariant, while a human long-file typing pass remains recommended.
+- 2026-08-20 — Commit `682d29c9` created and PR #319 opened. Scope check against `upstream/main` confirms one commit and only the five ZshConfig/documentation/changelog files.
+
+## Files
+
+- `Plugins/ZshConfig/Sources/ZshSyntaxHighlightingEditor.swift`
+- `Plugins/ZshConfig/Tests/ZshSyntaxHighlightingEditorTests.swift`
+- `changes/unreleased/zsh-config-editor-stability.md`
+- `docs/features/zsh-config-editor-stability.md`
+
+## Test / QA commands
+
+- `xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug -derivedDataPath build/DerivedData test -quiet -only-testing:MacToolsTests/ZshSyntaxHighlightingEditorTests`
+- `make build-plugin PLUGIN=ZshConfig`
+- Manual: edit a long `.zshrc`, rapidly type in the middle and near the end, use undo/redo, change file, and resize the settings window.
+
+## History
+
+<!-- Read only for bugs, regressions, audits, or explicit requests. -->
+
+| Date | Commit | Type | Notes |
+| 2026-08-20 | `682d29c9` | Fix | Deferred and coalesced zsh editor highlighting for #110 |


### PR DESCRIPTION
## Summary
- defer full-document zsh syntax highlighting until typing pauses
- coalesce pending passes and cancel stale work when content is replaced or the editor is removed
- preserve selection and viewport during the highlighting pass
- add focused AppKit regression coverage

## Verification
- `swiftc -parse Plugins/ZshConfig/Sources/*.swift Plugins/ZshConfig/Tests/*.swift`
- `MacToolsTests/ZshSyntaxHighlightingEditorTests` (5 tests)
- `make build-plugin PLUGIN=ZshConfig`
- `git diff --check upstream/main...codex/fix-zsh-config-editor-focus`

The targeted MacTools test build still emits pre-existing Swift 6 warnings from DiskClean test support, outside this PR.

Fixes #110