### PR TITLE
feat(plugin): add vertical network menu bar rates

### DIFF
--- a/Plugins/SystemStatus/Resources/Localizable.xcstrings
+++ b/Plugins/SystemStatus/Resources/Localizable.xcstrings
@@ -4467,6 +4467,70 @@
         }
       }
     },
+    "settings.networkLayout.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "تخطيط سرعة الشبكة" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Netzwerkraten-Layout" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Network rate layout" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Diseño de velocidad de red" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Disposition du débit réseau" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ネットワーク速度のレイアウト" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "네트워크 속도 레이아웃" } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Layout da velocidade de rede" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Макет сетевой скорости" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "网络速率布局" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "網路速率佈局" } }
+      }
+    },
+    "settings.networkLayout.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "يُستخدم فقط لمؤشر الشبكة في شريط القائمة." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Gilt nur für die Netzwerkanzeige in der Menüleiste." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Only applies to the menu-bar network metric." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Solo se aplica al indicador de red de la barra de menús." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "S’applique uniquement à l’indicateur réseau de la barre des menus." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "メニューバーのネットワーク指標にのみ適用されます。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "메뉴 막대의 네트워크 지표에만 적용됩니다." } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Aplica-se apenas ao indicador de rede da barra de menus." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Применяется только к сетевому индикатору в строке меню." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "仅用于菜单栏中的网络指标。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "僅用於選單列中的網路指標。" } }
+      }
+    },
+    "settings.networkLayout.horizontal": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "أفقي" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Horizontal" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Horizontal" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Horizontal" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Horizontal" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "横" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "가로" } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Horizontal" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Горизонтально" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "横向" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "橫向" } }
+      }
+    },
+    "settings.networkLayout.vertical": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "عمودي" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Vertikal" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Vertical" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Vertical" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Vertical" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "縦" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "세로" } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Vertical" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Вертикально" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "上下" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "上下" } }
+      }
+    },
     "component.empty.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Plugins/SystemStatus/Sources/SystemStatusConfiguration.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusConfiguration.swift
@@ -8,9 +8,15 @@ struct SystemStatusMetricPreference: Codable, Equatable, Identifiable, Sendable 
     var id: String { kind.rawValue }
 }
 
+enum SystemStatusNetworkMenuBarLayout: String, Codable, CaseIterable, Sendable {
+    case horizontal
+    case vertical
+}
+
 struct SystemStatusConfiguration: Equatable, Sendable {
     var panelItems: [SystemStatusMetricPreference]
     var menuBarItems: [SystemStatusMetricPreference]
+    var networkMenuBarLayout: SystemStatusNetworkMenuBarLayout
 
     static let `default` = SystemStatusConfiguration(
         panelItems: SystemStatusComponentLayout.defaultPanelMetricKinds.map {
@@ -18,7 +24,8 @@ struct SystemStatusConfiguration: Equatable, Sendable {
         },
         menuBarItems: SystemStatusComponentLayout.defaultMenuBarMetricKinds.map {
             SystemStatusMetricPreference(kind: $0, isVisible: false)
-        }
+        },
+        networkMenuBarLayout: .horizontal
     )
 
     var visiblePanelMetricKinds: [SystemStatusMetricKind] {
@@ -43,6 +50,7 @@ final class SystemStatusPluginStorageConfigurationStore: SystemStatusConfigurati
         static let panelHidden = "settings.panel.hidden"
         static let menuBarOrder = "settings.menuBar.order"
         static let menuBarVisible = "settings.menuBar.visible"
+        static let networkMenuBarLayout = "settings.menuBar.network.layout"
     }
 
     private let storage: PluginStorage
@@ -56,6 +64,9 @@ final class SystemStatusPluginStorageConfigurationStore: SystemStatusConfigurati
         let panelHidden = storage.stringArray(forKey: Key.panelHidden)
         let menuBarOrder = storage.stringArray(forKey: Key.menuBarOrder)
         let menuBarVisible = storage.stringArray(forKey: Key.menuBarVisible)
+        let networkMenuBarLayout = storage.string(forKey: Key.networkMenuBarLayout)
+            .flatMap(SystemStatusNetworkMenuBarLayout.init(rawValue:))
+            ?? .horizontal
 
         return SystemStatusConfiguration(
             panelItems: Self.normalizedItems(
@@ -73,7 +84,8 @@ final class SystemStatusPluginStorageConfigurationStore: SystemStatusConfigurati
                 defaultVisibility: false,
                 visibilityMode: .visibleSet,
                 usesDefaultVisibility: menuBarVisible == nil
-            )
+            ),
+            networkMenuBarLayout: networkMenuBarLayout
         )
     }
 
@@ -93,6 +105,7 @@ final class SystemStatusPluginStorageConfigurationStore: SystemStatusConfigurati
         storage.set(panelItems.filter { !$0.isVisible }.map { $0.kind.rawValue }, forKey: Key.panelHidden)
         storage.set(menuBarItems.map { $0.kind.rawValue }, forKey: Key.menuBarOrder)
         storage.set(menuBarItems.filter(\.isVisible).map { $0.kind.rawValue }, forKey: Key.menuBarVisible)
+        storage.set(configuration.networkMenuBarLayout.rawValue, forKey: Key.networkMenuBarLayout)
     }
 
     private enum VisibilityMode {
@@ -194,6 +207,12 @@ final class SystemStatusSettingsController: ObservableObject {
             }
 
             configuration.menuBarItems[index].isVisible = isVisible
+        }
+    }
+
+    func setNetworkMenuBarLayout(_ layout: SystemStatusNetworkMenuBarLayout) {
+        update { configuration in
+            configuration.networkMenuBarLayout = layout
         }
     }
 

--- a/Plugins/SystemStatus/Sources/SystemStatusMenuBarMetricsController.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusMenuBarMetricsController.swift
@@ -2,18 +2,43 @@ import AppKit
 import Combine
 import MacToolsPluginKit
 
+enum SystemStatusMenuBarMetricBlockLayout: Equatable {
+    case standard
+    case verticalNetwork(upload: String, download: String)
+}
+
 struct SystemStatusMenuBarMetricBlock: Equatable {
     let kind: SystemStatusMetricKind
     let label: String
     let value: String
+    let layout: SystemStatusMenuBarMetricBlockLayout
+
+    init(
+        kind: SystemStatusMetricKind,
+        label: String,
+        value: String,
+        layout: SystemStatusMenuBarMetricBlockLayout = .standard
+    ) {
+        self.kind = kind
+        self.label = label
+        self.value = value
+        self.layout = layout
+    }
 }
 
 enum SystemStatusMenuBarMetricsFormatter {
     static func blocks(
         snapshot: SystemStatusSnapshot,
-        kinds: [SystemStatusMetricKind]
+        kinds: [SystemStatusMetricKind],
+        networkMenuBarLayout: SystemStatusNetworkMenuBarLayout = .horizontal
     ) -> [SystemStatusMenuBarMetricBlock] {
-        kinds.compactMap { block(for: $0, snapshot: snapshot) }
+        kinds.compactMap {
+            block(
+                for: $0,
+                snapshot: snapshot,
+                networkMenuBarLayout: networkMenuBarLayout
+            )
+        }
     }
 
     static func text(
@@ -40,7 +65,8 @@ enum SystemStatusMenuBarMetricsFormatter {
 
     private static func block(
         for kind: SystemStatusMetricKind,
-        snapshot: SystemStatusSnapshot
+        snapshot: SystemStatusSnapshot,
+        networkMenuBarLayout: SystemStatusNetworkMenuBarLayout
     ) -> SystemStatusMenuBarMetricBlock? {
         switch kind {
         case .cpu:
@@ -87,10 +113,15 @@ enum SystemStatusMenuBarMetricsFormatter {
                     : "—"
             )
         case .network:
+            let download = "↓\(compactSpeed(snapshot.network.downloadBytesPerSecond))"
+            let upload = "↑\(compactSpeed(snapshot.network.uploadBytesPerSecond))"
             return SystemStatusMenuBarMetricBlock(
                 kind: kind,
                 label: "NET",
-                value: "↓\(compactSpeed(snapshot.network.downloadBytesPerSecond)) ↑\(compactSpeed(snapshot.network.uploadBytesPerSecond))"
+                value: "\(download) \(upload)",
+                layout: networkMenuBarLayout == .vertical
+                    ? .verticalNetwork(upload: upload, download: download)
+                    : .standard
             )
         case .topProcesses:
             return nil
@@ -210,7 +241,20 @@ final class SystemStatusMenuBarMetricsView: NSView {
         NSFont.monospacedDigitSystemFont(ofSize: 10.5, weight: .regular)
     }
 
+    private var verticalValueFont: NSFont {
+        NSFont.monospacedDigitSystemFont(ofSize: 8.5, weight: .regular)
+    }
+
     private func draw(_ block: SystemStatusMenuBarMetricBlock, in rect: NSRect) {
+        switch block.layout {
+        case .standard:
+            drawStandard(block, in: rect)
+        case let .verticalNetwork(upload, download):
+            drawVerticalNetwork(upload: upload, download: download, in: rect)
+        }
+    }
+
+    private func drawStandard(_ block: SystemStatusMenuBarMetricBlock, in rect: NSRect) {
         let label = attributedText(
             block.label,
             font: labelFont,
@@ -242,7 +286,35 @@ final class SystemStatusMenuBarMetricsView: NSView {
         value.draw(in: valueRect)
     }
 
+    private func drawVerticalNetwork(upload: String, download: String, in rect: NSRect) {
+        let lines = [upload, download].map {
+            attributedText($0, font: verticalValueFont, color: .labelColor)
+        }
+        let lineHeights = lines.map { $0.size().height }
+        let totalHeight = lineHeights.reduce(0, +)
+        var y = rect.midY - totalHeight / 2
+
+        for (line, lineHeight) in zip(lines, lineHeights) {
+            let lineSize = line.size()
+            line.draw(in: NSRect(
+                x: rect.minX + (rect.width - lineSize.width) / 2,
+                y: y,
+                width: lineSize.width,
+                height: lineHeight
+            ))
+            y += lineHeight
+        }
+    }
+
     private func metricWidth(_ block: SystemStatusMenuBarMetricBlock) -> CGFloat {
+        if case let .verticalNetwork(upload, download) = block.layout {
+            return ceil(max(
+                Layout.minimumMetricWidth,
+                attributedText(upload, font: verticalValueFont, color: .labelColor).size().width,
+                attributedText(download, font: verticalValueFont, color: .labelColor).size().width
+            ))
+        }
+
         let labelWidth = attributedText(
             block.label,
             font: labelFont,
@@ -351,7 +423,8 @@ final class SystemStatusMenuBarMetricsController: NSObject {
         viewModel.startMenuBar(requiresSlowSampling: kinds.requiresMenuBarSlowSampling)
         let blocks = SystemStatusMenuBarMetricsFormatter.blocks(
             snapshot: snapshot,
-            kinds: kinds
+            kinds: kinds,
+            networkMenuBarLayout: configuration.networkMenuBarLayout
         )
         guard !blocks.isEmpty else {
             viewModel.stopMenuBar()

--- a/Plugins/SystemStatus/Sources/SystemStatusSettingsView.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusSettingsView.swift
@@ -38,18 +38,55 @@ struct SystemStatusSettingsView: View {
     }
 
     private var menuBarSection: some View {
-        metricSection(
-            systemName: "menubar.rectangle",
-            title: localization.string("settings.menuBar.title", defaultValue: "菜单栏指标"),
-            description: localization.string(
-                "settings.menuBar.description",
-                defaultValue: "选择要显示在菜单栏里的指标。"
-            ),
-            items: menuBarItems,
-            listID: "menu-bar",
-            onVisibilityChange: controller.setMenuBarMetric(_:visible:),
-            onMove: controller.moveMenuBarMetric(_:toOffset:)
-        )
+        VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
+            metricSection(
+                systemName: "menubar.rectangle",
+                title: localization.string("settings.menuBar.title", defaultValue: "菜单栏指标"),
+                description: localization.string(
+                    "settings.menuBar.description",
+                    defaultValue: "选择要显示在菜单栏里的指标。"
+                ),
+                items: menuBarItems,
+                listID: "menu-bar",
+                onVisibilityChange: controller.setMenuBarMetric(_:visible:),
+                onMove: controller.moveMenuBarMetric(_:toOffset:)
+            )
+
+            networkLayoutPicker
+                .padding(.horizontal, PluginSettingsTheme.Spacing.rowHorizontal)
+                .padding(.bottom, PluginSettingsTheme.Spacing.rowVertical)
+        }
+    }
+
+    private var networkLayoutPicker: some View {
+        HStack(spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+                Text(localization.string("settings.networkLayout.title", defaultValue: "网络速率布局"))
+                    .font(PluginSettingsTheme.Typography.rowTitle)
+                Text(localization.string("settings.networkLayout.description", defaultValue: "仅用于菜单栏中的网络指标。"))
+                    .font(PluginSettingsTheme.Typography.rowDescription)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 12)
+
+            Picker(String(), selection: Binding(
+                get: { controller.configuration.networkMenuBarLayout },
+                set: { layout in
+                    controller.setNetworkMenuBarLayout(layout)
+                }
+            )) {
+                Text(localization.string("settings.networkLayout.horizontal", defaultValue: "横向"))
+                    .tag(SystemStatusNetworkMenuBarLayout.horizontal)
+                Text(localization.string("settings.networkLayout.vertical", defaultValue: "上下"))
+                    .tag(SystemStatusNetworkMenuBarLayout.vertical)
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .controlSize(.small)
+            .frame(width: 118)
+            .accessibilityLabel(localization.string("settings.networkLayout.title", defaultValue: "网络速率布局"))
+        }
     }
 
     private func metricSection(

--- a/Plugins/SystemStatus/Tests/SystemStatusPluginTests.swift
+++ b/Plugins/SystemStatus/Tests/SystemStatusPluginTests.swift
@@ -42,6 +42,7 @@ final class SystemStatusPluginTests: XCTestCase {
         controller.setMenuBarMetric(.cpu, visible: true)
         controller.setMenuBarMetric(.memory, visible: true)
         controller.moveMenuBarMetric(.memory, toOffset: 0)
+        controller.setNetworkMenuBarLayout(.vertical)
 
         let restoredController = SystemStatusSettingsController(
             store: SystemStatusPluginStorageConfigurationStore(storage: storage)
@@ -50,6 +51,7 @@ final class SystemStatusPluginTests: XCTestCase {
         XCTAssertEqual(restoredController.configuration.panelItems.map(\.kind).first, .battery)
         XCTAssertFalse(restoredController.configuration.panelItems.first { $0.kind == .gpu }?.isVisible ?? true)
         XCTAssertEqual(restoredController.configuration.visibleMenuBarMetricKinds, [.memory, .cpu])
+        XCTAssertEqual(restoredController.configuration.networkMenuBarLayout, .vertical)
     }
 
     func testPluginDescriptorShrinksWhenPanelMetricsAreHidden() {
@@ -102,6 +104,35 @@ final class SystemStatusPluginTests: XCTestCase {
         XCTAssertEqual(
             SystemStatusMenuBarMetricsFormatter.text(snapshot: snapshot, kinds: [.memory, .cpu, .network]),
             "RAM 60% | CPU 13% 42° | NET ↓1K ↑2K"
+        )
+    }
+
+    func testMenuBarFormatterUsesVerticalNetworkLayoutWhenSelected() {
+        var snapshot = SystemStatusSnapshot.empty
+        snapshot.network = SystemStatusNetworkSnapshot(
+            interfaceName: "en0",
+            ipAddress: nil,
+            publicIPAddress: nil,
+            downloadBytesPerSecond: 1_024,
+            uploadBytesPerSecond: 2_048,
+            isConnected: true,
+            isCollecting: false
+        )
+
+        XCTAssertEqual(
+            SystemStatusMenuBarMetricsFormatter.blocks(
+                snapshot: snapshot,
+                kinds: [.network],
+                networkMenuBarLayout: .vertical
+            ),
+            [
+                SystemStatusMenuBarMetricBlock(
+                    kind: .network,
+                    label: "NET",
+                    value: "↓1K ↑2K",
+                    layout: .verticalNetwork(upload: "↑2K", download: "↓1K")
+                )
+            ]
         )
     }
 

--- a/changes/unreleased/network-menu-bar-vertical-rates.md
+++ b/changes/unreleased/network-menu-bar-vertical-rates.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: added
+area: System Status
+---
+
+Added an optional vertical upload and download rate layout for the System Status menu-bar network metric.

--- a/docs/features/network-menu-bar-vertical-rates.md
+++ b/docs/features/network-menu-bar-vertical-rates.md
@@ -1,0 +1,78 @@
+# Feature — Vertical Network Rates in Menu Bar
+
+Last verified: 2026-08-20
+
+Status: ready-for-review
+Source of truth: yes
+
+## Summary
+
+- Fix issue #275.
+- Add an optional vertical upload/download layout for the System Status network menu-bar metric.
+- Keep the current horizontal layout as the default.
+
+## User flow
+
+- User enables the Network metric in System Status menu-bar settings.
+- User selects Horizontal or Vertical network-rate layout.
+- The menu-bar metric updates immediately.
+- Vertical layout shows upload on the first line and download on the second line.
+
+## Business rules
+
+| Rule | Markdown | Centralized code | Consumers |
+|---|---|---|---|
+| Default layout remains horizontal | This record | `SystemStatusNetworkMenuBarLayout.horizontal` | Configuration storage, menu-bar renderer |
+| Vertical layout is opt-in | This record | `SystemStatusNetworkMenuBarLayout.vertical` | Settings picker, menu-bar renderer |
+
+## Decisions
+
+| Date | Decision | Reason | Impact |
+|---|---|---|---|
+| 2026-08-20 | Keep the existing horizontal layout as default | Issue feedback requests a choice; existing users must not have their menu bar changed | System Status network metric only |
+| 2026-08-20 | Render upload above download in vertical mode | Matches the issue reference image | System Status menu-bar renderer only |
+
+## Plan
+
+- [x] P001 — Define the optional layout contract for issue #275.
+- [x] P002 — Persist the selected network menu-bar layout.
+- [x] P003 — Render vertical upload/download rates and expose a compact settings control.
+- [x] P004 — Run focused checks and a separate review.
+- [ ] P005 — Commit and open the PR.
+
+## TODO
+
+- [x] F001 — Add persisted layout preference — files: `Plugins/SystemStatus/Sources/SystemStatusConfiguration.swift` — status: done
+- [x] F002 — Add vertical network metric rendering — files: `Plugins/SystemStatus/Sources/SystemStatusMenuBarMetricsController.swift` — status: done
+- [x] F003 — Add the layout picker — files: `Plugins/SystemStatus/Sources/SystemStatusSettingsView.swift` — status: done
+- [x] F004 — Add focused regression coverage — files: `Plugins/SystemStatus/Tests/SystemStatusPluginTests.swift` — status: done
+- [x] F005 — Verify and review the isolated change — files: `Plugins/SystemStatus/`, feature record — status: done
+
+## Acceptance / DoD
+
+- [x] Existing users retain horizontal network rates by default.
+- [x] Vertical layout is available as an explicit setting.
+- [x] Vertical layout renders upload above download with directional arrows.
+- [x] The selected layout persists across a settings-controller reload.
+- [x] Targeted XCTest and plugin build pass.
+- [x] Separate review completed.
+
+## Implementation journal
+
+- 2026-08-20 — Started issue #275 from an isolated GitButler change. Added a persisted `horizontal`/`vertical` display preference, a compact segmented setting, and a dedicated two-line renderer for the network metric. Existing metrics and default network rendering remain unchanged.
+- 2026-08-20 — Checks passed: JSON validation for the string catalog, `MacToolsTests/SystemStatusPluginTests` (10 tests), and `make build-plugin PLUGIN=SystemStatus`. The focused XCTest build emitted pre-existing warnings in DiskClean test support and SystemAutomationProviders tests, outside this feature’s files.
+- 2026-08-20 — Separate review completed. Checked preference migration fallback, rendering width and line order, menu-bar sampling behavior, settings update propagation, and localized copy. No actionable finding.
+
+## Files
+
+- `Plugins/SystemStatus/Sources/SystemStatusConfiguration.swift`
+- `Plugins/SystemStatus/Sources/SystemStatusMenuBarMetricsController.swift`
+- `Plugins/SystemStatus/Sources/SystemStatusSettingsView.swift`
+- `Plugins/SystemStatus/Tests/SystemStatusPluginTests.swift`
+- `changes/unreleased/network-menu-bar-vertical-rates.md`
+
+## Test / QA commands
+
+- `xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug -derivedDataPath build/DerivedData test -quiet -only-testing:MacToolsTests/SystemStatusPluginTests`
+- `make build-plugin PLUGIN=SystemStatus`
+- Manual: enable the Network metric, switch between Horizontal and Vertical, then relaunch MacTools and confirm the selection persists.


### PR DESCRIPTION
Closes #275

## Summary
- Add an optional vertical upload/download layout for the System Status menu-bar network metric.
- Keep the existing horizontal layout as the default.
- Persist the selection and provide localized settings.

## Verification
- xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug -derivedDataPath build/DerivedData test -quiet -only-testing:MacToolsTests/SystemStatusPluginTests
- make build-plugin PLUGIN=SystemStatus