### PR TITLE
fix(ci): register SystemSoftRestart as an action provider

### DIFF
--- a/changes/unreleased/system-soft-restart-plugin.md
+++ b/changes/unreleased/system-soft-restart-plugin.md
@@ -4,4 +4,4 @@ type: added
 area: System Soft Restart
 ---
 
-Added a guarded System Soft Restart plugin that restarts macOS user services, preserves the Dock layout, reopens regular apps and standalone third-party menu-bar apps without racing background helpers, and shows compact copyable diagnostics when recovery reports an issue.
+Added a System Soft Restart plugin that restarts macOS user services, can preserve Dock layout and reopen apps, and shows copyable diagnostics if recovery reports an issue.

--- a/changes/unreleased/system-soft-restart-plugin.md
+++ b/changes/unreleased/system-soft-restart-plugin.md
@@ -4,4 +4,4 @@ type: added
 area: System Soft Restart
 ---
 
-Added a System Soft Restart plugin that restarts macOS user services, can preserve Dock layout and reopen apps, and shows copyable diagnostics if recovery reports an issue.
+Added System Soft Restart to restart macOS user services, preserve Dock layout, reopen regular apps and standalone third-party menu-bar apps, and show copyable diagnostics on issues. Background helpers stay with launchd.

--- a/docs/plugins/action-provider-coverage.md
+++ b/docs/plugins/action-provider-coverage.md
@@ -14,7 +14,7 @@ The following plugin source directories publish canonical actions:
 - App and input control: `AppHotkey`, `AppVolume`, `AutoInput`, `MiddleClick`, `WindowSwitcher`.
 - Display and workspace control: `Appearance`, `DisplayBrightness`, `DisplayResolution`, `DisplaySleep`, `DisplayTrueColor`, `DockLock`, `HideNotch`, `NightShift`, `Sidecar`, `StageManager`.
 - Menu bar and Dock control: `AutoHideDock`, `AutoHideMenuBar`.
-- System and device control: `BatteryChargeLimit`, `FanControl`, `KeepAwake`, `LockScreen`, `MicrophoneMute`, `SystemMute`.
+- System and device control: `BatteryChargeLimit`, `FanControl`, `KeepAwake`, `LockScreen`, `MicrophoneMute`, `SystemMute`, `SystemSoftRestart`.
 - Productivity and maintenance: `ActivityBar`, `AppleShortcuts`, `ClipboardClear`, `CloudflareR2`, `DiskClean`, `EjectDisk`, `EmptyTrash`, `FixDamagedApp`, `Homebrew`, `IPOverview`, `LaunchControl`, `Launchpad`, `PhysicalCleanMode`, `QuitApps`, `Translator`, `XcodeClean`.
 
 Parameterized actions publish concrete catalog entries rather than asking each action surface to construct parameters. For example, Sidecar publishes per-device entries, Display Resolution publishes current display modes, App Volume publishes current audio apps, Battery Charge Limit publishes useful limit presets, and Fan Control publishes saved presets. Availability is resolved again at execution time so stale hardware, processes, or configuration fail safely.

--- a/scripts/e2e/mactools-e2e.sh
+++ b/scripts/e2e/mactools-e2e.sh
@@ -1790,6 +1790,7 @@ verify_code_session() {
         -only-testing:MacToolsTests/SidecarPluginTests \
         -only-testing:MacToolsTests/StageManagerPluginTests \
         -only-testing:MacToolsTests/SystemMutePluginTests \
+        -only-testing:MacToolsTests/SystemSoftRestartPluginTests \
         -only-testing:MacToolsTests/TranslatorPluginTests \
         -only-testing:MacToolsTests/WindowSwitcherPluginTests \
         -only-testing:MacToolsTests/XcodeCleanPluginTests \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cause

Remote `main` failed in **Build → Run script tests** on `d83a7714` (`feat: add system soft restart plugin`):

https://github.com/ggbond268/MacTools/actions/runs/32484672811

`test_every_plugin_directory_is_a_provider_or_an_explicit_exclusion` failed because `SystemSoftRestart` is a new plugin directory that was missing from `docs/plugins/action-provider-coverage.md`.

The plugin already implements `PluginActionProviding` and has `SystemSoftRestartPluginTests`, so it belongs in the migrated-provider inventory rather than the specialized-exclusion list. After adding it there, the e2e registry checkpoint would also require `-only-testing:MacToolsTests/SystemSoftRestartPluginTests`.

After that inventory gap was fixed, CI then failed changelog validation: `changes/unreleased/system-soft-restart-plugin.md` was 272 characters (max 220). That check never ran on `main` because script tests failed first.

## Fix

- Document `SystemSoftRestart` under migrated system/device action providers.
- Register `SystemSoftRestartPluginTests` in the e2e action-registry checkpoint.
- Shorten the System Soft Restart changelog fragment to 220 characters while keeping the reopen scope: regular apps and standalone third-party menu-bar apps, with background helpers left to launchd.

Verified locally:

```
python3 -m unittest scripts.tests.test_action_provider_coverage
python3 scripts/changelog.py validate
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02471-6b9f-7820-991d-cf56ff373119?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02471-6b9f-7820-991d-cf56ff373119&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

