### PR TITLE
Window Layouts: harden Modifier Drag monitoring

### DIFF
--- a/Plugins/WindowLayouts/Resources/Localizable.xcstrings
+++ b/Plugins/WindowLayouts/Resources/Localizable.xcstrings
@@ -244,6 +244,14 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "視窗佈局需要輔助使用權限。" } }
       }
     },
+    "error.modifierDragMonitorUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Unable to start global pointer monitoring. Turn Modifier Drag off and on to try again." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法启动全局指针监控。请关闭后重新开启修饰键拖移。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法啟動全域指標監控。請關閉後重新開啟修飾鍵拖移。" } }
+      }
+    },
     "error.noFocusedWindow": {
       "extractionState": "manual",
       "localizations": {

--- a/Plugins/WindowLayouts/Sources/WindowLayoutsPlugin.swift
+++ b/Plugins/WindowLayouts/Sources/WindowLayoutsPlugin.swift
@@ -90,6 +90,7 @@ final class WindowLayoutsPlugin: MacToolsPlugin, AccessibilityPermissionRefreshi
     private var isAccessibilityGranted: Bool
     private var modifierDragSession: (any WindowModifierDragSessionManaging)?
     private var modifierDragError: String?
+    private var modifierDragMonitorStartFailed = false
     private var externalGestureConflicts: [PluginInputGestureConflict] = []
 
     var actionExecutionRevision: UInt64 { store.revision }
@@ -154,7 +155,10 @@ final class WindowLayoutsPlugin: MacToolsPlugin, AccessibilityPermissionRefreshi
     }
 
     var activeInputGestureClaims: [PluginInputGestureClaim] {
-        guard store.modifierDragEnabled, isAccessibilityGranted else { return [] }
+        guard store.modifierDragEnabled,
+              isAccessibilityGranted,
+              !modifierDragMonitorStartFailed
+        else { return [] }
         return [modifierDragClaim]
     }
 
@@ -321,6 +325,7 @@ final class WindowLayoutsPlugin: MacToolsPlugin, AccessibilityPermissionRefreshi
         if previous != isAccessibilityGranted {
             if isAccessibilityGranted {
                 modifierDragError = nil
+                modifierDragMonitorStartFailed = false
             } else if store.modifierDragEnabled {
                 modifierDragError = localizedMessage(for: .accessibilityRequired)
             }
@@ -464,6 +469,7 @@ final class WindowLayoutsPlugin: MacToolsPlugin, AccessibilityPermissionRefreshi
 
     func setModifierDragModifiers(_ modifiers: ShortcutModifiers) {
         modifierDragError = nil
+        modifierDragMonitorStartFailed = false
         store.setModifierDragModifiers(modifiers)
         applyModifierDragConfiguration()
     }
@@ -477,6 +483,7 @@ final class WindowLayoutsPlugin: MacToolsPlugin, AccessibilityPermissionRefreshi
 
     func setModifierDragEnabled(_ enabled: Bool) {
         modifierDragError = nil
+        modifierDragMonitorStartFailed = false
         guard enabled else {
             store.setModifierDragEnabled(false)
             applyModifierDragConfiguration()
@@ -525,7 +532,16 @@ final class WindowLayoutsPlugin: MacToolsPlugin, AccessibilityPermissionRefreshi
             session = newSession
         }
         session.configure(modifiers: store.modifierDragModifiers)
-        session.start()
+        switch session.start() {
+        case .success:
+            modifierDragMonitorStartFailed = false
+        case let .failure(error):
+            session.stop()
+            modifierDragSession = nil
+            modifierDragMonitorStartFailed = true
+            modifierDragError = localizedMessage(for: error)
+            onStateChange?()
+        }
     }
 
     private func stopModifierDragSession() {
@@ -863,6 +879,7 @@ final class WindowLayoutsPlugin: MacToolsPlugin, AccessibilityPermissionRefreshi
         switch controlID {
         case SettingsID.reset:
             modifierDragError = nil
+            modifierDragMonitorStartFailed = false
             store.reset()
             applyModifierDragConfiguration()
         case SettingsID.addCustom:
@@ -1121,6 +1138,16 @@ final class WindowLayoutsPlugin: MacToolsPlugin, AccessibilityPermissionRefreshi
         case .noPreviousFrame: localizedKey("error.noPreviousFrame", "此窗口没有可恢复的上一个位置。")
         case .frameReadFailed: localizedKey("error.frameReadFailed", "无法读取当前窗口的位置和大小。")
         case .frameWriteFailed: localizedKey("error.frameWriteFailed", "无法调整当前窗口。")
+        }
+    }
+
+    private func localizedMessage(for error: WindowModifierDragMonitorStartError) -> String {
+        switch error {
+        case .eventTapUnavailable, .runLoopSourceUnavailable, .eventLoopUnavailable:
+            localizedKey(
+                "error.modifierDragMonitorUnavailable",
+                "无法启动全局指针监控。请关闭后重新开启修饰键拖移。"
+            )
         }
     }
 

--- a/Plugins/WindowLayouts/Sources/WindowModifierDragEventMonitor.swift
+++ b/Plugins/WindowLayouts/Sources/WindowModifierDragEventMonitor.swift
@@ -1,0 +1,215 @@
+import ApplicationServices
+import Foundation
+import MacToolsPluginKit
+
+enum WindowModifierDragMonitorStartError: Error, Equatable, Sendable {
+    case eventTapUnavailable
+    case runLoopSourceUnavailable
+    case eventLoopUnavailable
+}
+
+struct WindowModifierDragMonitorEvent: Sendable {
+    let type: CGEventType
+    let location: CGPoint
+    let flags: CGEventFlags
+}
+
+protocol WindowModifierDragEventMonitoring: AnyObject, Sendable {
+    var isRunning: Bool { get }
+
+    func start(
+        handler: @escaping @Sendable (WindowModifierDragMonitorEvent) -> Void
+    ) -> Result<Void, WindowModifierDragMonitorStartError>
+    func stop()
+}
+
+nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendable,
+    WindowModifierDragEventMonitoring
+{
+    private typealias CallbackContext = PluginCallbackContext<SystemWindowModifierDragEventMonitor>
+    private typealias EventHandler = @Sendable (WindowModifierDragMonitorEvent) -> Void
+
+    private let lock = NSLock()
+    private let eventQueue = DispatchQueue(
+        label: "com.mactools.window-layouts.modifier-drag-events",
+        qos: .userInteractive
+    )
+    private var tap: CFMachPort?
+    private var source: CFRunLoopSource?
+    private var callbackPointer: UnsafeMutableRawPointer?
+    private var eventRunLoop: CFRunLoop?
+    private var readySignal: DispatchSemaphore?
+    private var finishedSignal: DispatchSemaphore?
+    private var eventHandler: EventHandler?
+    private var shouldRun = false
+
+    var isRunning: Bool {
+        lock.withLock {
+            shouldRun && tap != nil && source != nil && eventRunLoop != nil
+        }
+    }
+
+    func start(
+        handler: @escaping @Sendable (WindowModifierDragMonitorEvent) -> Void
+    ) -> Result<Void, WindowModifierDragMonitorStartError> {
+        if isRunning { return .success(()) }
+        if lock.withLock({ tap != nil || callbackPointer != nil }) {
+            stop()
+        }
+
+        let eventMask = CGEventMask(1 << CGEventType.flagsChanged.rawValue)
+            | CGEventMask(1 << CGEventType.mouseMoved.rawValue)
+            | CGEventMask(1 << CGEventType.leftMouseDown.rawValue)
+            | CGEventMask(1 << CGEventType.rightMouseDown.rawValue)
+            | CGEventMask(1 << CGEventType.otherMouseDown.rawValue)
+        let callbackContext = CallbackContext(owner: self)
+        let callbackPointer = Unmanaged.passRetained(callbackContext).toOpaque()
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: eventMask,
+            callback: Self.eventCallback,
+            userInfo: callbackPointer
+        ) else {
+            callbackContext.invalidate()
+            Unmanaged<CallbackContext>.fromOpaque(callbackPointer).release()
+            return .failure(.eventTapUnavailable)
+        }
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            CFMachPortInvalidate(tap)
+            callbackContext.invalidate()
+            Unmanaged<CallbackContext>.fromOpaque(callbackPointer).release()
+            return .failure(.runLoopSourceUnavailable)
+        }
+
+        let readySignal = DispatchSemaphore(value: 0)
+        let finishedSignal = DispatchSemaphore(value: 0)
+        lock.withLock {
+            self.tap = tap
+            self.source = source
+            self.callbackPointer = callbackPointer
+            self.readySignal = readySignal
+            self.finishedSignal = finishedSignal
+            self.eventHandler = handler
+            shouldRun = true
+        }
+        eventQueue.async { [self] in
+            runEventLoop()
+        }
+        readySignal.wait()
+
+        guard isRunning else {
+            stop()
+            return .failure(.eventLoopUnavailable)
+        }
+        return .success(())
+    }
+
+    func stop() {
+        let state = lock.withLock { () -> (
+            CFMachPort?,
+            UnsafeMutableRawPointer?,
+            CFRunLoop?,
+            DispatchSemaphore?
+        ) in
+            shouldRun = false
+            eventHandler = nil
+            return (tap, callbackPointer, eventRunLoop, finishedSignal)
+        }
+        guard state.0 != nil || state.1 != nil else { return }
+
+        if let callbackPointer = state.1 {
+            Unmanaged<CallbackContext>
+                .fromOpaque(callbackPointer)
+                .takeUnretainedValue()
+                .invalidate()
+        }
+        if let tap = state.0 {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
+        }
+        if let runLoop = state.2 {
+            CFRunLoopStop(runLoop)
+            CFRunLoopWakeUp(runLoop)
+        }
+        state.3?.wait()
+
+        if let callbackPointer = state.1 {
+            Unmanaged<CallbackContext>.fromOpaque(callbackPointer).release()
+        }
+        lock.withLock {
+            tap = nil
+            source = nil
+            callbackPointer = nil
+            eventRunLoop = nil
+            readySignal = nil
+            finishedSignal = nil
+        }
+    }
+
+    private func runEventLoop() {
+        let signals = lock.withLock { (readySignal, finishedSignal) }
+        guard let state = lock.withLock({ () -> (
+            CFMachPort,
+            CFRunLoopSource,
+            DispatchSemaphore,
+            DispatchSemaphore
+        )? in
+            guard let tap, let source, let readySignal, let finishedSignal else {
+                return nil
+            }
+            eventRunLoop = CFRunLoopGetCurrent()
+            return (tap, source, readySignal, finishedSignal)
+        }) else {
+            signals.0?.signal()
+            signals.1?.signal()
+            return
+        }
+
+        let runLoop = CFRunLoopGetCurrent()
+        CFRunLoopAddSource(runLoop, state.1, .defaultMode)
+        CGEvent.tapEnable(tap: state.0, enable: true)
+        state.2.signal()
+
+        while lock.withLock({ shouldRun }) {
+            _ = CFRunLoopRunInMode(.defaultMode, 60, true)
+        }
+
+        CFRunLoopRemoveSource(runLoop, state.1, .defaultMode)
+        lock.withLock {
+            eventRunLoop = nil
+        }
+        state.3.signal()
+    }
+
+    private func handle(type: CGEventType, event: CGEvent) {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput,
+           let tap = lock.withLock({ tap }) {
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+        let handler = lock.withLock { eventHandler }
+        handler?(WindowModifierDragMonitorEvent(
+            type: type,
+            location: event.location,
+            flags: event.flags
+        ))
+    }
+
+    private static let eventCallback: CGEventTapCallBack = { _, type, event, userInfo in
+        guard let userInfo else { return Unmanaged.passUnretained(event) }
+        let context = Unmanaged<CallbackContext>.fromOpaque(userInfo).takeUnretainedValue()
+        context.withOwner { monitor in
+            monitor.handle(type: type, event: event)
+        }
+        return Unmanaged.passUnretained(event)
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return body()
+    }
+}

--- a/Plugins/WindowLayouts/Sources/WindowModifierDragEventMonitor.swift
+++ b/Plugins/WindowLayouts/Sources/WindowModifierDragEventMonitor.swift
@@ -14,11 +14,25 @@ struct WindowModifierDragMonitorEvent: Sendable {
     let flags: CGEventFlags
 }
 
+/// Carries the callback across the Core Graphics event-thread boundary. The session receiving
+/// events protects its gesture and action state with a lock before dispatching UI work.
+nonisolated final class WindowModifierDragEventHandler: @unchecked Sendable {
+    private let body: (WindowModifierDragMonitorEvent) -> Void
+
+    init(_ body: @escaping (WindowModifierDragMonitorEvent) -> Void) {
+        self.body = body
+    }
+
+    func handle(_ event: WindowModifierDragMonitorEvent) {
+        body(event)
+    }
+}
+
 protocol WindowModifierDragEventMonitoring: AnyObject, Sendable {
     var isRunning: Bool { get }
 
     func start(
-        handler: @escaping @Sendable (WindowModifierDragMonitorEvent) -> Void
+        handler: WindowModifierDragEventHandler
     ) -> Result<Void, WindowModifierDragMonitorStartError>
     func stop()
 }
@@ -27,8 +41,6 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
     WindowModifierDragEventMonitoring
 {
     private typealias CallbackContext = PluginCallbackContext<SystemWindowModifierDragEventMonitor>
-    private typealias EventHandler = @Sendable (WindowModifierDragMonitorEvent) -> Void
-
     private let lock = NSLock()
     private let eventQueue = DispatchQueue(
         label: "com.mactools.window-layouts.modifier-drag-events",
@@ -40,7 +52,7 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
     private var eventRunLoop: CFRunLoop?
     private var readySignal: DispatchSemaphore?
     private var finishedSignal: DispatchSemaphore?
-    private var eventHandler: EventHandler?
+    private var eventHandler: WindowModifierDragEventHandler?
     private var shouldRun = false
 
     var isRunning: Bool {
@@ -50,7 +62,7 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
     }
 
     func start(
-        handler: @escaping @Sendable (WindowModifierDragMonitorEvent) -> Void
+        handler: WindowModifierDragEventHandler
     ) -> Result<Void, WindowModifierDragMonitorStartError> {
         if isRunning { return .success(()) }
         if lock.withLock({ tap != nil || callbackPointer != nil }) {
@@ -189,7 +201,7 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
             CGEvent.tapEnable(tap: tap, enable: true)
         }
         let handler = lock.withLock { eventHandler }
-        handler?(WindowModifierDragMonitorEvent(
+        handler?.handle(WindowModifierDragMonitorEvent(
             type: type,
             location: event.location,
             flags: event.flags

--- a/Plugins/WindowLayouts/Sources/WindowModifierDragGesture.swift
+++ b/Plugins/WindowLayouts/Sources/WindowModifierDragGesture.swift
@@ -29,6 +29,16 @@ struct WindowModifierDragGesture {
         self.activationDistance = activationDistance
     }
 
+    func shouldProcessPointerMovement(modifiers: ShortcutModifiers) -> Bool {
+        if modifiers == requiredModifiers { return true }
+        switch state {
+        case .armed, .active:
+            return true
+        case .idle, .blocked:
+            return false
+        }
+    }
+
     mutating func modifiersChanged(
         _ modifiers: ShortcutModifiers,
         pointer: CGPoint

--- a/Plugins/WindowLayouts/Sources/WindowModifierDragSession.swift
+++ b/Plugins/WindowLayouts/Sources/WindowModifierDragSession.swift
@@ -329,9 +329,10 @@ nonisolated final class WindowModifierDragSession: @unchecked Sendable,
         lock.withLock {
             _ = actionQueue.activate()
         }
-        let result = eventMonitor.start { [weak self] event in
+        let eventHandler = WindowModifierDragEventHandler { [weak self] event in
             self?.handle(event)
         }
+        let result = eventMonitor.start(handler: eventHandler)
         if case .failure = result {
             eventMonitor.stop()
             lock.withLock {

--- a/Plugins/WindowLayouts/Sources/WindowModifierDragSession.swift
+++ b/Plugins/WindowLayouts/Sources/WindowModifierDragSession.swift
@@ -7,8 +7,9 @@ import MacToolsPluginKit
 protocol WindowModifierDragSessionManaging: AnyObject {
     var onFailure: (WindowLayoutError) -> Void { get set }
     var onSuccess: () -> Void { get set }
+    var isRunning: Bool { get }
     func configure(modifiers: ShortcutModifiers)
-    func start()
+    func start() -> Result<Void, WindowModifierDragMonitorStartError>
     func stop()
 }
 
@@ -278,7 +279,6 @@ struct WindowModifierDragActionQueue {
 nonisolated final class WindowModifierDragSession: @unchecked Sendable,
     WindowModifierDragSessionManaging
 {
-    private typealias CallbackContext = PluginCallbackContext<WindowModifierDragSession>
     @MainActor var onFailure: (WindowLayoutError) -> Void {
         get { controller.onFailure }
         set { controller.onFailure = newValue }
@@ -290,17 +290,18 @@ nonisolated final class WindowModifierDragSession: @unchecked Sendable,
 
     private let lock = NSLock()
     private let controller: WindowModifierDragController
+    private let eventMonitor: any WindowModifierDragEventMonitoring
     private var gesture: WindowModifierDragGesture
     private var actionQueue = WindowModifierDragActionQueue()
-    private var tap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
-    private var callbackPointer: UnsafeMutableRawPointer?
+
+    @MainActor var isRunning: Bool { eventMonitor.isRunning }
 
     @MainActor
     init(
         modifiers: ShortcutModifiers = WindowLayoutsStore.defaultModifierDragModifiers,
         resolver: (any WindowUnderPointerResolving)? = nil,
-        frameAdapter: AccessibilityWindowFrameAdapter? = nil
+        frameAdapter: AccessibilityWindowFrameAdapter? = nil,
+        eventMonitor: (any WindowModifierDragEventMonitoring)? = nil
     ) {
         let adapter = frameAdapter ?? AccessibilityWindowFrameAdapter()
         self.controller = WindowModifierDragController(
@@ -308,6 +309,7 @@ nonisolated final class WindowModifierDragSession: @unchecked Sendable,
             frameReader: adapter,
             frameWriter: adapter
         )
+        self.eventMonitor = eventMonitor ?? SystemWindowModifierDragEventMonitor()
         self.gesture = WindowModifierDragGesture(requiredModifiers: modifiers)
     }
 
@@ -322,93 +324,51 @@ nonisolated final class WindowModifierDragSession: @unchecked Sendable,
     }
 
     @MainActor
-    func start() {
-        guard lock.withLock({ tap == nil }) else { return }
-        let eventMask = CGEventMask(1 << CGEventType.flagsChanged.rawValue)
-            | CGEventMask(1 << CGEventType.mouseMoved.rawValue)
-            | CGEventMask(1 << CGEventType.leftMouseDown.rawValue)
-            | CGEventMask(1 << CGEventType.rightMouseDown.rawValue)
-            | CGEventMask(1 << CGEventType.otherMouseDown.rawValue)
-        let callbackContext = CallbackContext(owner: self)
-        let callbackPointer = Unmanaged.passRetained(callbackContext).toOpaque()
-        guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .listenOnly,
-            eventsOfInterest: eventMask,
-            callback: Self.eventCallback,
-            userInfo: callbackPointer
-        ) else {
-            callbackContext.invalidate()
-            Unmanaged<CallbackContext>.fromOpaque(callbackPointer).release()
-            onFailure(.accessibilityRequired)
-            return
-        }
-        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-            CFMachPortInvalidate(tap)
-            callbackContext.invalidate()
-            Unmanaged<CallbackContext>.fromOpaque(callbackPointer).release()
-            onFailure(.accessibilityRequired)
-            return
-        }
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+    func start() -> Result<Void, WindowModifierDragMonitorStartError> {
+        if eventMonitor.isRunning { return .success(()) }
         lock.withLock {
-            self.tap = tap
-            self.runLoopSource = source
-            self.callbackPointer = callbackPointer
-            _ = self.actionQueue.activate()
+            _ = actionQueue.activate()
         }
-        CGEvent.tapEnable(tap: tap, enable: true)
+        let result = eventMonitor.start { [weak self] event in
+            self?.handle(event)
+        }
+        if case .failure = result {
+            eventMonitor.stop()
+            lock.withLock {
+                _ = gesture.reset()
+                actionQueue.deactivate()
+            }
+            controller.stop()
+        }
+        return result
     }
 
     @MainActor
     func stop() {
-        let state = lock.withLock { () -> (CFMachPort?, CFRunLoopSource?, UnsafeMutableRawPointer?) in
+        eventMonitor.stop()
+        lock.withLock {
             _ = gesture.reset()
             actionQueue.deactivate()
-            let state = (tap, runLoopSource, callbackPointer)
-            tap = nil
-            runLoopSource = nil
-            callbackPointer = nil
-            return state
         }
         controller.stop()
-        if let callbackPointer = state.2 {
-            Unmanaged<CallbackContext>
-                .fromOpaque(callbackPointer)
-                .takeUnretainedValue()
-                .invalidate()
-        }
-        if let tap = state.0 {
-            CGEvent.tapEnable(tap: tap, enable: false)
-        }
-        if let runLoopSource = state.1 {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
-        }
-        if let tap = state.0 {
-            CFMachPortInvalidate(tap)
-        }
-        if let callbackPointer = state.2 {
-            Unmanaged<CallbackContext>.fromOpaque(callbackPointer).release()
-        }
     }
 
-    private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap = lock.withLock({ tap }) {
-                CGEvent.tapEnable(tap: tap, enable: true)
-            }
+    private func handle(_ event: WindowModifierDragMonitorEvent) {
+        if event.type == .tapDisabledByTimeout || event.type == .tapDisabledByUserInput {
             let cancellation = lock.withLock { gesture.reset() }
             dispatch(cancellation)
-            return Unmanaged.passUnretained(event)
+            return
         }
 
         let modifiers = ShortcutModifiers.from(event.flags)
         let action = lock.withLock { () -> WindowModifierDragGestureAction? in
-            switch type {
+            switch event.type {
             case .flagsChanged:
                 return gesture.modifiersChanged(modifiers, pointer: event.location)
             case .mouseMoved:
+                guard gesture.shouldProcessPointerMovement(modifiers: modifiers) else {
+                    return nil
+                }
                 return gesture.pointerMoved(to: event.location, modifiers: modifiers)
             case .leftMouseDown, .rightMouseDown, .otherMouseDown:
                 return gesture.mouseButtonPressed()
@@ -417,7 +377,6 @@ nonisolated final class WindowModifierDragSession: @unchecked Sendable,
             }
         }
         dispatch(action)
-        return Unmanaged.passUnretained(event)
     }
 
     private func dispatch(_ action: WindowModifierDragGestureAction?) {
@@ -443,13 +402,6 @@ nonisolated final class WindowModifierDragSession: @unchecked Sendable,
         }
     }
 
-    private static let eventCallback: CGEventTapCallBack = { _, type, event, userInfo in
-        guard let userInfo else { return Unmanaged.passUnretained(event) }
-        let context = Unmanaged<CallbackContext>.fromOpaque(userInfo).takeUnretainedValue()
-        return context.withOwner { session in
-            session.handle(type: type, event: event)
-        } ?? Unmanaged.passUnretained(event)
-    }
 }
 
 private extension NSLock {

--- a/Plugins/WindowLayouts/Tests/WindowLayoutsPluginTests.swift
+++ b/Plugins/WindowLayouts/Tests/WindowLayoutsPluginTests.swift
@@ -251,6 +251,11 @@ final class WindowLayoutsPluginTests: XCTestCase {
         plugin.inputGestureConflictsDidChange([conflict])
 
         XCTAssertEqual(session.stopCount, 1)
+        XCTAssertEqual(
+            plugin.activeInputGestureClaims.map(\.id),
+            ["pointer.move.modifiers.9"],
+            "A paused owner must retain its claim so conflict resolution stays stable"
+        )
         XCTAssertEqual(stateChangeCount, 0)
 
         let configureCountAfterConflict = session.configureCount
@@ -263,6 +268,38 @@ final class WindowLayoutsPluginTests: XCTestCase {
         plugin.inputGestureConflictsDidChange([])
         XCTAssertEqual(session.startCount, startCountBeforeResume + 1)
         XCTAssertEqual(stateChangeCount, 0)
+    }
+
+    func testModifierDragMonitorStartupFailureSuppressesClaimAndSupportsRetry() throws {
+        let session = MockWindowModifierDragSession()
+        session.startResult = .failure(.eventTapUnavailable)
+        let plugin = makePlugin(modifierDragSession: session)
+
+        plugin.activate(context: PluginRuntimeContext(pluginID: "window-layouts"))
+        plugin.setModifierDragEnabled(true)
+
+        XCTAssertTrue(plugin.activeInputGestureClaims.isEmpty)
+        XCTAssertFalse(session.isRunning)
+        XCTAssertEqual(session.startCount, 1)
+        XCTAssertEqual(session.stopCount, 1)
+        XCTAssertEqual(
+            try modifierDragFooter(in: plugin),
+            plugin.localizedKey(
+                "error.modifierDragMonitorUnavailable",
+                "无法启动全局指针监控。请关闭后重新开启修饰键拖移。"
+            )
+        )
+
+        session.startResult = .success(())
+        plugin.setModifierDragEnabled(false)
+        plugin.setModifierDragEnabled(true)
+
+        XCTAssertTrue(session.isRunning)
+        XCTAssertEqual(session.startCount, 2)
+        XCTAssertEqual(
+            plugin.activeInputGestureClaims.map(\.id),
+            ["pointer.move.modifiers.6"]
+        )
     }
 
     func testModifierDragFooterHidesInactiveConflictsAndClearsRuntimeErrors() throws {
@@ -867,18 +904,25 @@ private final class MockWindowModifierDragSession: WindowModifierDragSessionMana
     private(set) var configureCount = 0
     private(set) var startCount = 0
     private(set) var stopCount = 0
+    private(set) var isRunning = false
+    var startResult: Result<Void, WindowModifierDragMonitorStartError> = .success(())
 
     func configure(modifiers: ShortcutModifiers) {
         configureCount += 1
         configuredModifiers = modifiers
     }
 
-    func start() {
+    func start() -> Result<Void, WindowModifierDragMonitorStartError> {
         startCount += 1
+        if case .success = startResult {
+            isRunning = true
+        }
+        return startResult
     }
 
     func stop() {
         stopCount += 1
+        isRunning = false
     }
 }
 

--- a/Plugins/WindowLayouts/Tests/WindowModifierDragTests.swift
+++ b/Plugins/WindowLayouts/Tests/WindowModifierDragTests.swift
@@ -4,6 +4,23 @@ import MacToolsPluginKit
 @testable import WindowLayoutsPlugin
 
 final class WindowModifierDragGestureTests: XCTestCase {
+    func testSkipsIdlePointerMovementWithoutExactModifiers() {
+        var gesture = WindowModifierDragGesture(requiredModifiers: [.control, .option])
+
+        XCTAssertFalse(gesture.shouldProcessPointerMovement(modifiers: []))
+        XCTAssertFalse(gesture.shouldProcessPointerMovement(modifiers: [.shift]))
+        XCTAssertTrue(gesture.shouldProcessPointerMovement(modifiers: [.control, .option]))
+
+        _ = gesture.modifiersChanged([.control, .option], pointer: .zero)
+        XCTAssertTrue(
+            gesture.shouldProcessPointerMovement(modifiers: []),
+            "An armed gesture must still observe release when a flags event is missed"
+        )
+
+        _ = gesture.modifiersChanged([.control, .option, .shift], pointer: .zero)
+        XCTAssertFalse(gesture.shouldProcessPointerMovement(modifiers: []))
+    }
+
     func testActivatesAfterDeadZoneAndKeepsOneGeneration() {
         var gesture = WindowModifierDragGesture(
             requiredModifiers: [.control, .option],
@@ -142,6 +159,20 @@ final class WindowModifierDragActionQueueTests: XCTestCase {
             queue.enqueue(.begin(generation: 2, origin: .zero, pointer: CGPoint(x: 6, y: 0))),
             currentEpoch
         )
+    }
+}
+
+@MainActor
+final class WindowModifierDragSessionTests: XCTestCase {
+    func testPropagatesMonitorStartupFailureAndLeavesSessionStopped() {
+        let monitor = StubWindowModifierDragEventMonitor(
+            startResult: .failure(.eventTapUnavailable)
+        )
+        let session = WindowModifierDragSession(eventMonitor: monitor)
+
+        XCTAssertEqual(session.start(), .failure(.eventTapUnavailable))
+        XCTAssertFalse(session.isRunning)
+        XCTAssertEqual(monitor.stopCount, 1)
     }
 }
 
@@ -356,5 +387,31 @@ private final class RecordingWindowFrameIO: WindowFrameReading, WindowFrameWriti
     ) async throws {
         writes.append(Write(frame: frame, window: window, resize: resize))
         onWrite()
+    }
+}
+
+nonisolated private final class StubWindowModifierDragEventMonitor: @unchecked Sendable,
+    WindowModifierDragEventMonitoring
+{
+    let startResult: Result<Void, WindowModifierDragMonitorStartError>
+    private(set) var isRunning = false
+    private(set) var stopCount = 0
+
+    init(startResult: Result<Void, WindowModifierDragMonitorStartError>) {
+        self.startResult = startResult
+    }
+
+    func start(
+        handler: @escaping @Sendable (WindowModifierDragMonitorEvent) -> Void
+    ) -> Result<Void, WindowModifierDragMonitorStartError> {
+        if case .success = startResult {
+            isRunning = true
+        }
+        return startResult
+    }
+
+    func stop() {
+        isRunning = false
+        stopCount += 1
     }
 }

--- a/Plugins/WindowLayouts/Tests/WindowModifierDragTests.swift
+++ b/Plugins/WindowLayouts/Tests/WindowModifierDragTests.swift
@@ -170,7 +170,12 @@ final class WindowModifierDragSessionTests: XCTestCase {
         )
         let session = WindowModifierDragSession(eventMonitor: monitor)
 
-        XCTAssertEqual(session.start(), .failure(.eventTapUnavailable))
+        switch session.start() {
+        case .success:
+            XCTFail("Expected monitor startup to fail")
+        case let .failure(error):
+            XCTAssertEqual(error, .eventTapUnavailable)
+        }
         XCTAssertFalse(session.isRunning)
         XCTAssertEqual(monitor.stopCount, 1)
     }
@@ -402,7 +407,7 @@ nonisolated private final class StubWindowModifierDragEventMonitor: @unchecked S
     }
 
     func start(
-        handler: @escaping @Sendable (WindowModifierDragMonitorEvent) -> Void
+        handler: WindowModifierDragEventHandler
     ) -> Result<Void, WindowModifierDragMonitorStartError> {
         if case .success = startResult {
             isRunning = true

--- a/changes/unreleased/window-layouts-modifier-drag-monitor.md
+++ b/changes/unreleased/window-layouts-modifier-drag-monitor.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: fixed
+area: Window Layouts
+---
+
+Modifier Drag now reports global pointer monitor failures accurately and handles pointer events away from the main UI thread.


### PR DESCRIPTION
## Summary

- move Modifier Drag's global event tap onto a dedicated run loop so pointer traffic no longer executes on the main UI thread
- skip unrelated pointer movement while the gesture is idle, while retaining the existing latest-pointer coalescing during active movement
- report monitor startup failures separately from Accessibility failures, suppress inactive gesture claims, and support an explicit off/on retry
- preserve gesture claims while another plugin conflict temporarily pauses the monitor, avoiding conflict ownership oscillation

Follow-up to #342. Addresses the findings in https://github.com/ggbond268/MacTools/pull/342#issuecomment-5426476941.

## Validation

- focused `WindowLayoutsPluginTests` and Modifier Drag XCTest classes passed
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer make build-plugin PLUGIN=WindowLayouts`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer make script-tests` (135 passed)
- changelog and localization JSON validation passed
