### PR TITLE
[Phase 1] Implement read-only CLI action discovery

### DIFF
--- a/Plugins/AppleShortcuts/Sources/AppleShortcutsIconCache.swift
+++ b/Plugins/AppleShortcuts/Sources/AppleShortcutsIconCache.swift
@@ -14,9 +14,14 @@ final class AppleShortcutsIconCache {
     /// removed explicitly when the settings workspace closes.
     static let defaultTotalCostLimit = 16 * 1_024 * 1_024
 
-    private let cache = NSCache<NSUUID, NSData>()
+    private let cache: NSCache<NSUUID, NSData>
 
-    init(totalCostLimit: Int = AppleShortcutsIconCache.defaultTotalCostLimit) {
+    // Inject storage for deterministic tests; production keeps NSCache's automatic eviction.
+    init(
+        totalCostLimit: Int = AppleShortcutsIconCache.defaultTotalCostLimit,
+        cache: NSCache<NSUUID, NSData> = NSCache()
+    ) {
+        self.cache = cache
         cache.totalCostLimit = totalCostLimit
     }
 

--- a/Plugins/AppleShortcuts/Tests/AppleShortcutsControllerTests.swift
+++ b/Plugins/AppleShortcuts/Tests/AppleShortcutsControllerTests.swift
@@ -613,6 +613,7 @@ final class AppleShortcutsControllerTests: XCTestCase {
         AppleShortcutsController(
             runner: runner,
             visualMetadataLoader: visualMetadataLoader,
+            iconCache: AppleShortcutsIconCache(cache: ControlledIconCache()),
             localization: PluginLocalization(bundle: .main),
             now: now
         )

--- a/Plugins/AppleShortcuts/Tests/AppleShortcutsIconCacheTests.swift
+++ b/Plugins/AppleShortcuts/Tests/AppleShortcutsIconCacheTests.swift
@@ -5,7 +5,8 @@ import XCTest
 @MainActor
 final class AppleShortcutsIconCacheTests: XCTestCase {
     func testStoresAndReturnsIconData() {
-        let cache = AppleShortcutsIconCache()
+        let storage = ControlledIconCache()
+        let cache = AppleShortcutsIconCache(cache: storage)
         let shortcutID = UUID()
         let iconData = Data([0x01, 0x02, 0x03])
 
@@ -13,18 +14,83 @@ final class AppleShortcutsIconCacheTests: XCTestCase {
         cache.store(iconData, for: shortcutID)
 
         XCTAssertEqual(cache.data(for: shortcutID), iconData)
+        XCTAssertEqual(storage.cost(for: shortcutID), iconData.count)
     }
 
     func testRemoveAllDiscardsEveryCachedIcon() {
-        let cache = AppleShortcutsIconCache()
+        let cache = AppleShortcutsIconCache(cache: ControlledIconCache())
         let firstID = UUID()
         let secondID = UUID()
         cache.store(Data([0x01]), for: firstID)
         cache.store(Data([0x02]), for: secondID)
+        XCTAssertEqual(cache.data(for: firstID), Data([0x01]))
+        XCTAssertEqual(cache.data(for: secondID), Data([0x02]))
 
         cache.removeAll()
 
         XCTAssertNil(cache.data(for: firstID))
         XCTAssertNil(cache.data(for: secondID))
+    }
+
+    func testEvictedIconsAreMissingAndCanBeStoredAgain() {
+        let storage = ControlledIconCache()
+        let cache = AppleShortcutsIconCache(cache: storage)
+        let shortcutID = UUID()
+        cache.store(Data([0x01]), for: shortcutID)
+        XCTAssertEqual(cache.data(for: shortcutID), Data([0x01]))
+
+        storage.removeObject(forKey: shortcutID as NSUUID)
+
+        XCTAssertNil(cache.data(for: shortcutID))
+        cache.store(Data([0x02, 0x03]), for: shortcutID)
+        XCTAssertEqual(cache.data(for: shortcutID), Data([0x02, 0x03]))
+        XCTAssertEqual(storage.cost(for: shortcutID), 2)
+    }
+
+    func testReplacingAnIconUpdatesBytesAndCost() {
+        let storage = ControlledIconCache()
+        let cache = AppleShortcutsIconCache(cache: storage)
+        let shortcutID = UUID()
+        cache.store(Data([0x01]), for: shortcutID)
+        cache.store(Data([0x02, 0x03]), for: shortcutID)
+
+        XCTAssertEqual(cache.data(for: shortcutID), Data([0x02, 0x03]))
+        XCTAssertEqual(storage.cost(for: shortcutID), 2)
+    }
+
+    func testConfiguresDefaultAndCustomCostLimits() {
+        let defaultStorage = ControlledIconCache()
+        _ = AppleShortcutsIconCache(cache: defaultStorage)
+        XCTAssertEqual(defaultStorage.totalCostLimit, AppleShortcutsIconCache.defaultTotalCostLimit)
+        let customStorage = ControlledIconCache()
+        _ = AppleShortcutsIconCache(totalCostLimit: 123, cache: customStorage)
+        XCTAssertEqual(customStorage.totalCostLimit, 123)
+    }
+}
+
+/// Only this test double retains entries until explicit eviction. Tests must not assume that
+/// real NSCache retains a value between setObject and object(forKey:) under memory pressure.
+nonisolated final class ControlledIconCache: NSCache<NSUUID, NSData>, @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [NSUUID: (data: NSData, cost: Int)] = [:]
+
+    override func object(forKey key: NSUUID) -> NSData? {
+        lock.withLock { entries[key]?.data }
+    }
+
+    override func setObject(_ obj: NSData, forKey key: NSUUID, cost: Int) {
+        lock.withLock { entries[key] = (obj, cost) }
+    }
+
+    override func removeObject(forKey key: NSUUID) {
+        lock.withLock { _ = entries.removeValue(forKey: key) }
+    }
+
+    override func removeAllObjects() {
+        lock.withLock { entries.removeAll() }
+    }
+
+    func cost(for id: UUID) -> Int? {
+        lock.withLock { entries[id as NSUUID]?.cost }
     }
 }

--- a/Plugins/WindowLayouts/Sources/WindowModifierDragEventMonitor.swift
+++ b/Plugins/WindowLayouts/Sources/WindowModifierDragEventMonitor.swift
@@ -69,6 +69,34 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
             stop()
         }
 
+        let readySignal = DispatchSemaphore(value: 0)
+        let finishedSignal = DispatchSemaphore(value: 0)
+        switch prepareEventTap(handler: handler, readySignal: readySignal, finishedSignal: finishedSignal) {
+        case .success:
+            break
+        case let .failure(error):
+            return .failure(error)
+        }
+
+        eventQueue.async { [self] in
+            runEventLoop()
+        }
+        readySignal.wait()
+
+        guard isRunning else {
+            stop()
+            return .failure(.eventLoopUnavailable)
+        }
+        return .success(())
+    }
+
+    // Keep Core Foundation resource setup separate from queue startup to avoid a Swift 6.3.3
+    // SendNonSendable compiler crash. Publish all startup state under the same lock.
+    private func prepareEventTap(
+        handler: WindowModifierDragEventHandler,
+        readySignal: DispatchSemaphore,
+        finishedSignal: DispatchSemaphore
+    ) -> Result<Void, WindowModifierDragMonitorStartError> {
         let eventMask = CGEventMask(1 << CGEventType.flagsChanged.rawValue)
             | CGEventMask(1 << CGEventType.mouseMoved.rawValue)
             | CGEventMask(1 << CGEventType.leftMouseDown.rawValue)
@@ -95,8 +123,6 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
             return .failure(.runLoopSourceUnavailable)
         }
 
-        let readySignal = DispatchSemaphore(value: 0)
-        let finishedSignal = DispatchSemaphore(value: 0)
         lock.withLock {
             self.tap = tap
             self.source = source
@@ -105,15 +131,6 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
             self.finishedSignal = finishedSignal
             self.eventHandler = handler
             shouldRun = true
-        }
-        eventQueue.async { [self] in
-            runEventLoop()
-        }
-        readySignal.wait()
-
-        guard isRunning else {
-            stop()
-            return .failure(.eventLoopUnavailable)
         }
         return .success(())
     }

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ brew install --cask mactools
 
 ### Experimental command-line prototype
 
-The source tree includes a separately built `mactools` prototype for local testing. Phase 0 intentionally supports only `help`, `version`, and `doctor`; it does not ship in the app bundle or expose app actions yet. Build and test it with the signed local app by following [the Phase 0 test guide](docs/testing/cli-phase-0.md).
+The source tree includes a separately built `mactools` prototype for local testing. In addition to `help`, `version`, and `doctor`, Phase 1 provides read-only `actions list`, `actions describe`, and `actions availability`, with human-readable or `--json` output. Discovery uses the host's canonical action registry and independent CLI exposure policy; it never executes actions or accepts parameter values. The CLI is not embedded in the app or publicly packaged yet. Follow [the Phase 1 test guide](docs/testing/cli-phase-1.md) for signed local setup and sample commands.
 
 ## Upgrade
 

--- a/Sources/App/MacToolsAppRuntime.swift
+++ b/Sources/App/MacToolsAppRuntime.swift
@@ -24,7 +24,11 @@ final class MacToolsAppRuntime {
     private var actionGridOverlayController: ActionGridOverlayController?
     private var appIntentCatalogCancellable: AnyCancellable?
     private var cliBrokerActivationCancellable: AnyCancellable?
-    private lazy var cliHostBridge = CLIHostBridge()
+    private lazy var cliDiscovery = CLIActionDiscovery(
+        registry: pluginHost.actionRegistry,
+        workflows: { [weak self] in self?.pluginHost.automationController.workflows ?? [] }
+    )
+    private lazy var cliHostBridge = CLIHostBridge(discovery: cliDiscovery)
     private lazy var settingsRecoveryScheduler = SettingsRecoveryScheduler { [weak self] in
         self?.windowRouter?.showSettings()
     }
@@ -188,6 +192,7 @@ final class MacToolsAppRuntime {
                 }
             }
             appIntentCoordinator.actionRegistryDidBecomeReady()
+            cliDiscovery.markReady()
             activateAppURLRouter()
         }
     }
@@ -195,6 +200,7 @@ final class MacToolsAppRuntime {
     private func completeBootstrap() {
         automationStartupCoordinator.actionRegistryDidBecomeReady()
         appIntentCoordinator.actionRegistryDidBecomeReady()
+        cliDiscovery.markReady()
         activateAppURLRouter()
     }
 

--- a/Sources/Core/CLI/CLIActionDiscovery.swift
+++ b/Sources/Core/CLI/CLIActionDiscovery.swift
@@ -1,0 +1,170 @@
+import CryptoKit
+import Foundation
+import MacToolsCLIProtocol
+import MacToolsPluginKit
+
+enum CLIActionDiscoveryError: Error {
+    case notReady
+    case catalogTooLarge
+    case staleCursor
+    case invalidCursor
+    case unknownTarget
+}
+
+/// The CLI never receives a registry reference, saved input, executor, or provider callback.
+@MainActor
+final class CLIActionDiscovery {
+    static let surface = ActionExposureSurface(rawValue: "cli")
+    private let registry: ActionRegistry
+    private let workflows: () -> [WorkflowDefinition]
+    private let instanceID = UUID().uuidString
+    private(set) var isReady = false
+
+    init(registry: ActionRegistry, workflows: @escaping () -> [WorkflowDefinition] = { [] }) {
+        self.registry = registry
+        self.workflows = workflows
+    }
+
+    func markReady() { isReady = true }
+
+    func list(_ request: CLIActionListRequest) throws -> CLIActionPage {
+        try CLIDiscoveryValidation.validate(request)
+        let catalog = try snapshot()
+        var offset = 0
+        if let cursor = request.cursor {
+            guard let parts = CLIDiscoveryValidation.cursorParts(cursor) else {
+                throw CLIActionDiscoveryError.invalidCursor
+            }
+            guard parts.generation == catalog.generation else { throw CLIActionDiscoveryError.staleCursor }
+            guard parts.offset < catalog.items.count else { throw CLIActionDiscoveryError.invalidCursor }
+            offset = parts.offset
+        }
+        let end = min(offset + request.pageSize, catalog.items.count)
+        let result = CLIActionPage(
+            actions: catalog.items[offset..<end].map { CLIActionSummary(id: $0.record.id, title: $0.record.title) },
+            generation: catalog.generation,
+            nextCursor: end < catalog.items.count ? "\(catalog.generation).\(end)" : nil
+        )
+        try CLIDiscoveryValidation.validate(result, request: request)
+        return result
+    }
+
+    func describe(_ request: CLIActionTargetRequest) throws -> CLIActionDescription {
+        try target(request).record
+    }
+
+    func availability(_ request: CLIActionTargetRequest) throws -> CLIActionAvailability {
+        let item = try target(request)
+        let available = registry.availability(for: item.reference).isAvailable
+        // Provider messages can interpolate saved inputs or paths. Export a stable reason code only.
+        return CLIActionAvailability(id: item.record.id, available: available,
+                                     reason: available ? nil : .providerUnavailable)
+    }
+
+    private struct Item {
+        let reference: ActionReference
+        let record: CLIActionDescription
+        let revision: String
+    }
+
+    private func target(_ request: CLIActionTargetRequest) throws -> Item {
+        try CLIDiscoveryValidation.validate(request)
+        guard let item = try snapshot().items.first(where: { $0.record.id == request.id }) else {
+            throw CLIActionDiscoveryError.unknownTarget
+        }
+        return item
+    }
+
+    private func snapshot() throws -> (items: [Item], generation: String) {
+        guard isReady else { throw CLIActionDiscoveryError.notReady }
+        guard registry.catalogEntries.count <= CLIDiscoveryLimits.maximumCatalogSize else {
+            throw CLIActionDiscoveryError.catalogTooLarge
+        }
+        let definitions = workflows()
+        guard definitions.count <= CLIDiscoveryLimits.maximumCatalogSize else {
+            throw CLIActionDiscoveryError.catalogTooLarge
+        }
+        let byID = Dictionary(definitions.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        var items: [Item] = []
+        // A shared traversal budget bounds work even when many workflows share a large graph.
+        var budget = CLIDiscoveryLimits.maximumCatalogSize * 8
+        for entry in registry.catalogEntries {
+            guard eligible(entry.reference, workflows: byID, visiting: [], depth: 0, budget: &budget),
+                  case let .success(action) = registry.registeredAction(for: entry.reference) else { continue }
+            let definition = action.definition
+            let parameters = definition.parameters.compactMap { parameter -> CLIActionParameter? in
+                guard let kind = CLIActionParameter.Kind(rawValue: parameter.kind.rawValue),
+                      let privacy = CLIActionParameter.Privacy(rawValue: parameter.privacy.rawValue),
+                      let portability = CLIActionParameter.Portability(rawValue: parameter.portability.rawValue)
+                else { return nil }
+                return CLIActionParameter(id: parameter.id, kind: kind, isRequired: parameter.isRequired,
+                                          privacy: privacy, portability: portability)
+            }
+            guard parameters.count == definition.parameters.count else { continue }
+            let id = try identifier(entry.reference)
+            // Definition-level copy, not preset titles/subtitles that may contain saved values.
+            let record = CLIActionDescription(id: id, title: sanitized(definition.title),
+                                              description: sanitized(definition.description),
+                                              parameterSchemaVersion: definition.parameterSchemaVersion,
+                                              parameters: parameters)
+            guard (try? CLIDiscoveryValidation.validate(record, id: id)) != nil else { continue }
+            items.append(Item(reference: entry.reference, record: record,
+                              revision: "\(action.providerGeneration):\(action.providerExecutionRevision)"))
+        }
+        guard budget >= 0 else { throw CLIActionDiscoveryError.catalogTooLarge }
+        items.sort { $0.record.id < $1.record.id }
+        guard Set(items.map { $0.record.id }).count == items.count else {
+            throw CLIActionDiscoveryError.catalogTooLarge
+        }
+        var digest = SHA256()
+        digest.update(data: Data(instanceID.utf8))
+        for item in items {
+            digest.update(data: try CLIProtocolCodec.encodeResponse(item.record))
+            digest.update(data: Data(item.revision.utf8))
+        }
+        return (items, digest.finalize().map { String(format: "%02x", $0) }.joined())
+    }
+
+    private func eligible(_ reference: ActionReference, workflows: [UUID: WorkflowDefinition],
+                          visiting: Set<UUID>, depth: Int, budget: inout Int) -> Bool {
+        budget -= 1
+        guard budget >= 0,
+              case let .success(action) = registry.registeredAction(for: reference),
+              action.catalogEntry != nil,
+              action.definition.risk == .safe,
+              action.definition.capabilities.contains([.background, .automatic]),
+              registry.portability(of: reference) == .portable,
+              registry.exposurePolicy(for: reference, on: Self.surface) == .automatic else { return false }
+        guard reference.key.providerID == AutomationController.providerID else { return true }
+        guard depth < WorkflowExecutionLimits.maximumDepth,
+              let id = WorkflowExecutionAnalysis.nestedWorkflowID(for: reference.key),
+              !visiting.contains(id), let workflow = workflows[id], workflow.isEnabled,
+              !workflow.steps.isEmpty, workflow.steps.count <= CLIDiscoveryLimits.maximumCatalogSize else { return false }
+        var next = visiting
+        next.insert(id)
+        return workflow.steps.allSatisfy {
+            eligible($0.reference, workflows: workflows, visiting: next, depth: depth + 1, budget: &budget)
+        }
+    }
+
+    private func identifier(_ reference: ActionReference) throws -> String {
+        guard !reference.parameters.entries.isEmpty else { return reference.key.id }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let digest = SHA256.hash(data: try encoder.encode(reference)).map { String(format: "%02x", $0) }.joined()
+        return "\(reference.key.id)@\(digest)"
+    }
+
+    private func sanitized(_ value: String) -> String {
+        var result = ""
+        var bytes = 0
+        for scalar in value.unicodeScalars.prefix(CLIDiscoveryLimits.maximumTextBytes * 2) {
+            guard !CharacterSet.controlCharacters.contains(scalar) else { continue }
+            let count = scalar.utf8.count
+            guard bytes + count <= CLIDiscoveryLimits.maximumTextBytes else { break }
+            result.unicodeScalars.append(scalar)
+            bytes += count
+        }
+        return result
+    }
+}

--- a/Sources/Core/CLI/CLIHostBridge.swift
+++ b/Sources/Core/CLI/CLIHostBridge.swift
@@ -5,6 +5,8 @@ import MacToolsCLIProtocol
 @MainActor
 final class CLIHostBridge: NSObject, CLIHostXPCProtocol {
     private let serviceController: CLIBrokerServiceController
+    private let discovery: CLIActionDiscovery?
+    private let readinessTimeout: Duration
     private let identityValidator = CLIPeerIdentityValidator()
     nonisolated private let callerIsBroker: @Sendable () -> Bool
     nonisolated private let requestState = CLIHostRequestState()
@@ -28,12 +30,16 @@ final class CLIHostBridge: NSObject, CLIHostXPCProtocol {
 
     init(
         serviceController: CLIBrokerServiceController = .shared,
+        discovery: CLIActionDiscovery? = nil,
+        readinessTimeout: Duration = .seconds(8),
         callerIsBroker: @escaping @Sendable () -> Bool = {
             guard let connection = NSXPCConnection.current() else { return false }
             return CLIPeerIdentityValidator().accepts(connection, as: .broker)
         }
     ) {
         self.serviceController = serviceController
+        self.discovery = discovery
+        self.readinessTimeout = readinessTimeout
         self.callerIsBroker = callerIsBroker
         super.init()
         serviceStatusObservation = serviceController.$status
@@ -101,7 +107,7 @@ final class CLIHostBridge: NSObject, CLIHostXPCProtocol {
                     startedAt: .now
                 )
             } else {
-                response = Self.response(to: request)
+                response = await self.response(to: request)
             }
             reply.call(response)
         }
@@ -115,13 +121,12 @@ final class CLIHostBridge: NSObject, CLIHostXPCProtocol {
         reply(requestState.cancel(requestID))
     }
 
-    private static func response(to request: CLIRequestEnvelope) -> Data {
+    private func response(to request: CLIRequestEnvelope) async -> Data {
         let startedAt = Date()
-        guard request.operation == .doctor,
-              request.payload == nil,
+        guard request.protocolVersion >= request.operation.minimumProtocolVersion,
               (CLIProtocolVersion.minimum...CLIProtocolVersion.current)
                 .contains(request.protocolVersion) else {
-            return encodedFailure(
+            return Self.encodedFailure(
                 request: request,
                 outcome: .protocolIncompatible,
                 category: "protocolIncompatible",
@@ -129,14 +134,45 @@ final class CLIHostBridge: NSObject, CLIHostXPCProtocol {
                 startedAt: startedAt
             )
         }
-        let record = CLIDoctorRecord(
-            hostVersion: AppMetadata.shortVersion ?? "unknown",
-            hostBuild: AppMetadata.buildNumber ?? "unknown",
-            protocolVersion: request.protocolVersion,
-            brokerServiceStatus: CLIBrokerServiceController.shared.status.rawValue
-        )
         do {
-            let payload = try CLIProtocolCodec.encodeResponse(record)
+            let payload: Data
+            if request.operation == .doctor {
+                guard request.payload == nil else { throw CLIProtocolCodecError.invalidObject }
+                payload = try CLIProtocolCodec.encodeResponse(CLIDoctorRecord(
+                    hostVersion: AppMetadata.shortVersion ?? "unknown",
+                    hostBuild: AppMetadata.buildNumber ?? "unknown",
+                    protocolVersion: request.protocolVersion,
+                    brokerServiceStatus: serviceController.status.rawValue
+                ))
+            } else {
+                guard let data = request.payload else { throw CLIProtocolCodecError.invalidObject }
+                // Validate before waiting; malformed requests must not consume the readiness budget.
+                if request.operation == .actionsList {
+                    try CLIDiscoveryValidation.validate(CLIDiscoveryValidation.decode(CLIActionListRequest.self, from: data))
+                } else {
+                    try CLIDiscoveryValidation.validate(CLIDiscoveryValidation.decode(CLIActionTargetRequest.self, from: data))
+                }
+                guard let discovery else { throw CLIActionDiscoveryError.notReady }
+                let deadline = ContinuousClock.now.advanced(by: readinessTimeout)
+                while !discovery.isReady && ContinuousClock.now < deadline {
+                    guard !requestState.isCancelled(request.requestID) else { throw CancellationError() }
+                    try await Task.sleep(for: .milliseconds(50))
+                }
+                guard !requestState.isCancelled(request.requestID) else { throw CancellationError() }
+                switch request.operation {
+                case .actionsList:
+                    payload = try CLIProtocolCodec.encodeResponse(discovery.list(
+                        CLIDiscoveryValidation.decode(CLIActionListRequest.self, from: data)))
+                case .actionsDescribe:
+                    payload = try CLIProtocolCodec.encodeResponse(discovery.describe(
+                        CLIDiscoveryValidation.decode(CLIActionTargetRequest.self, from: data)))
+                case .actionsAvailability:
+                    payload = try CLIProtocolCodec.encodeResponse(discovery.availability(
+                        CLIDiscoveryValidation.decode(CLIActionTargetRequest.self, from: data)))
+                case .doctor:
+                    throw CLIProtocolCodecError.invalidObject
+                }
+            }
             return try CLIProtocolCodec.encodeResponse(CLIResponseEnvelope(
                 protocolVersion: request.protocolVersion,
                 requestID: request.requestID,
@@ -149,13 +185,23 @@ final class CLIHostBridge: NSObject, CLIHostXPCProtocol {
                 payload: payload
             ))
         } catch {
-            return encodedFailure(
-                request: request,
-                outcome: .hostUnavailable,
-                category: "responseEncodingFailed",
-                message: "MacTools could not encode the doctor response.",
-                startedAt: startedAt
-            )
+            let failure: (CLIOutcome, String, String)
+            switch error {
+            case is CancellationError:
+                failure = (.cancelled, "cancelled", "The request was cancelled.")
+            case CLIActionDiscoveryError.notReady:
+                failure = (.hostUnavailable, "registryNotReady", "The action registry is not ready. Try again after MacTools finishes starting.")
+            case CLIActionDiscoveryError.unknownTarget:
+                failure = (.unknownTarget, "unknownAction", "The requested action is not discoverable.")
+            case CLIActionDiscoveryError.staleCursor:
+                failure = (.invalidInput, "staleCursor", "The catalog changed. Restart actions list without a cursor.")
+            case CLIActionDiscoveryError.catalogTooLarge, CLIProtocolCodecError.responseTooLarge:
+                failure = (.hostUnavailable, "catalogLimitExceeded", "The action catalog exceeds the discovery limits.")
+            default:
+                failure = (.invalidInput, "invalidRequest", "The discovery request is invalid.")
+            }
+            return Self.encodedFailure(request: request, outcome: failure.0, category: failure.1,
+                                       message: failure.2, startedAt: startedAt)
         }
     }
 

--- a/Sources/MacToolsCLI/CLIApplication.swift
+++ b/Sources/MacToolsCLI/CLIApplication.swift
@@ -42,21 +42,23 @@ struct CLIApplication {
                 return CLIExitCode.transportFailure.rawValue
             }
         case let .doctor(json):
-            return await interruptibleDoctor(json: json)
+            return await interruptibleRequest(operation: .doctor, payload: nil, json: json)
+        case let .discovery(operation, payload, json):
+            return await interruptibleRequest(operation: operation, payload: payload, json: json)
         }
     }
 
-    private func interruptibleDoctor(json: Bool) async -> Int32 {
+    private func interruptibleRequest(operation: CLIOperation, payload: Data?, json: Bool) async -> Int32 {
         let taskState = CLICommandTaskState()
         let signalCoordinator = CLISignalCoordinator { taskState.cancel() }
         defer { signalCoordinator.finish() }
-        let task = Task { try await doctor(json: json) }
+        let task = Task { try await request(operation: operation, payload: payload, json: json) }
         taskState.install(task)
         do {
             return try await task.value
         } catch is CancellationError {
             writeFailure(output.localFailure(
-                command: "doctor",
+                command: operation.rawValue,
                 outcome: .cancelled,
                 category: "cancelled",
                 message: "The request was cancelled.",
@@ -65,7 +67,7 @@ struct CLIApplication {
             return CLIExitCode.cancellation.rawValue
         } catch CLIBrokerClientError.protocolIncompatible {
             writeFailure(output.localFailure(
-                command: "doctor",
+                command: operation.rawValue,
                 outcome: .protocolIncompatible,
                 category: "protocolIncompatible",
                 message: "The CLI protocol is incompatible with the installed MacTools components.",
@@ -74,7 +76,7 @@ struct CLIApplication {
             return CLIExitCode.protocolIncompatible.rawValue
         } catch CLIBrokerClientError.invalidPeerResponse {
             writeFailure(output.localFailure(
-                command: "doctor",
+                command: operation.rawValue,
                 outcome: .protocolIncompatible,
                 category: "invalidPeerResponse",
                 message: "The authenticated broker or host returned an invalid response.",
@@ -83,7 +85,7 @@ struct CLIApplication {
             return CLIExitCode.protocolIncompatible.rawValue
         } catch let CLIBrokerClientError.unavailable(message) {
             writeFailure(output.localFailure(
-                command: "doctor",
+                command: operation.rawValue,
                 outcome: .hostUnavailable,
                 category: "hostUnavailable",
                 message: message,
@@ -92,7 +94,7 @@ struct CLIApplication {
             return CLIExitCode.transportFailure.rawValue
         } catch {
             writeFailure(output.localFailure(
-                command: "doctor",
+                command: operation.rawValue,
                 outcome: .hostUnavailable,
                 category: "hostUnavailable",
                 message: "MacTools command-line integration is unavailable.",
@@ -102,14 +104,19 @@ struct CLIApplication {
         }
     }
 
-    private func doctor(json: Bool) async throws -> Int32 {
+    private func request(operation: CLIOperation, payload: Data?, json: Bool) async throws -> Int32 {
         let deadline = CLIStartupDeadline(timeout: .seconds(10))
         let handshake = try await client.prepareHost(deadline: deadline)
-        let response = try await client.sendDoctor(deadline: deadline)
+        let response = try await client.send(operation: operation, payload: payload, deadline: deadline)
         let rendered: String
         if response.outcome == .completed {
             do {
-                rendered = try output.renderDoctor(response, handshake: handshake, json: json)
+                if operation == .doctor {
+                    rendered = try output.renderDoctor(response, handshake: handshake, json: json)
+                } else {
+                    guard let payload else { throw CLIBrokerClientError.invalidPeerResponse }
+                    rendered = try output.renderDiscovery(response, requestPayload: payload, json: json)
+                }
             } catch {
                 throw CLIBrokerClientError.invalidPeerResponse
             }
@@ -130,6 +137,7 @@ struct CLIApplication {
         case .completed: .success
         case .cancelled: .cancellation
         case .invalidInput: .invalidInput
+        case .unknownTarget: .unknownTarget
         case .hostUnavailable: .transportFailure
         case .protocolIncompatible: .protocolIncompatible
         }
@@ -151,6 +159,11 @@ struct CLIApplication {
           help
           version [--json]
           doctor [--json]
+          actions list [--page-size 1...100] [--cursor <cursor>] [--json]
+          actions describe <id-from-list> [--json]
+          actions availability <id-from-list> [--json]
+
+        Discovery is read-only. Action execution and parameter input are not supported.
         """
     }
 }

--- a/Sources/MacToolsCLI/CLIArgumentParser.swift
+++ b/Sources/MacToolsCLI/CLIArgumentParser.swift
@@ -1,9 +1,11 @@
 import Foundation
+import MacToolsCLIProtocol
 
 enum CLICommand: Equatable {
     case help
     case version(json: Bool)
     case doctor(json: Bool)
+    case discovery(operation: CLIOperation, payload: Data, json: Bool)
 }
 
 enum CLIArgumentError: Error, Equatable {
@@ -17,12 +19,48 @@ struct CLIArgumentParser {
             guard arguments.count == 1 else { throw CLIArgumentError.invalidCommand }
             return .help
         }
+        if command == "actions" { return try discovery(Array(arguments.dropFirst())) }
         let json = try jsonFlag(Array(arguments.dropFirst()))
         switch command {
         case "version": return .version(json: json)
         case "doctor": return .doctor(json: json)
         default: throw CLIArgumentError.invalidCommand
         }
+    }
+
+    private func discovery(_ arguments: [String]) throws -> CLICommand {
+        guard let verb = arguments.first else { throw CLIArgumentError.invalidCommand }
+        var remaining = Array(arguments.dropFirst())
+        let json = remaining.contains("--json")
+        guard remaining.filter({ $0 == "--json" }).count <= 1 else { throw CLIArgumentError.invalidCommand }
+        remaining.removeAll { $0 == "--json" }
+        if verb == "list" {
+            var pageSize = CLIDiscoveryLimits.defaultPageSize
+            var cursor: String?
+            var seen = Set<String>()
+            while !remaining.isEmpty {
+                let flag = remaining.removeFirst()
+                guard seen.insert(flag).inserted, !remaining.isEmpty else { throw CLIArgumentError.invalidCommand }
+                let value = remaining.removeFirst()
+                switch flag {
+                case "--page-size":
+                    guard let size = Int(value), String(size) == value else { throw CLIArgumentError.invalidCommand }
+                    pageSize = size
+                case "--cursor": cursor = value
+                default: throw CLIArgumentError.invalidCommand
+                }
+            }
+            let request = CLIActionListRequest(pageSize: pageSize, cursor: cursor)
+            try CLIDiscoveryValidation.validate(request)
+            return .discovery(operation: .actionsList, payload: try CLIProtocolCodec.encodeRequest(request), json: json)
+        }
+        guard remaining.count == 1, verb == "describe" || verb == "availability" else {
+            throw CLIArgumentError.invalidCommand
+        }
+        let request = CLIActionTargetRequest(id: remaining[0])
+        try CLIDiscoveryValidation.validate(request)
+        return .discovery(operation: verb == "describe" ? .actionsDescribe : .actionsAvailability,
+                          payload: try CLIProtocolCodec.encodeRequest(request), json: json)
     }
 
     private func jsonFlag(_ arguments: [String]) throws -> Bool {

--- a/Sources/MacToolsCLI/CLIBrokerClient.swift
+++ b/Sources/MacToolsCLI/CLIBrokerClient.swift
@@ -78,15 +78,28 @@ final class CLIBrokerClient: @unchecked Sendable {
         requestID: UUID = UUID(),
         deadline: CLIStartupDeadline
     ) async throws -> CLIResponseEnvelope {
+        try await send(operation: .doctor, payload: nil, requestID: requestID, deadline: deadline)
+    }
+
+    func send(
+        operation: CLIOperation,
+        payload: Data?,
+        requestID: UUID = UUID(),
+        deadline: CLIStartupDeadline
+    ) async throws -> CLIResponseEnvelope {
         guard let version = negotiatedProtocolVersion else {
             throw CLIBrokerClientError.unavailable("The host handshake has not completed.")
+        }
+        guard version >= operation.minimumProtocolVersion else {
+            invalidateConnection()
+            throw CLIBrokerClientError.protocolIncompatible
         }
         let request = CLIRequestEnvelope(
             protocolVersion: version,
             requestID: requestID,
-            operation: .doctor,
+            operation: operation,
             sentAt: .now,
-            payload: nil
+            payload: payload
         )
         let data = try CLIProtocolCodec.encodeRequest(request)
         let responseData: Data

--- a/Sources/MacToolsCLI/CLIOutput.swift
+++ b/Sources/MacToolsCLI/CLIOutput.swift
@@ -2,6 +2,40 @@ import Foundation
 import MacToolsCLIProtocol
 
 struct CLIOutput {
+    func renderDiscovery(_ response: CLIResponseEnvelope, requestPayload: Data, json: Bool) throws -> String {
+        guard response.outcome == .completed, let payload = response.payload,
+              response.protocolVersion.map({ $0 >= 2 }) == true else {
+            throw CLIProtocolSemanticError.invalidResponse
+        }
+        let human: String
+        switch response.operation {
+        case .actionsList:
+            let request = try CLIDiscoveryValidation.decode(CLIActionListRequest.self, from: requestPayload)
+            let page = try CLIDiscoveryValidation.decode(CLIActionPage.self, from: payload)
+            try CLIDiscoveryValidation.validate(page, request: request)
+            var lines = page.actions.map { "\($0.id)  \($0.title)" }
+            if lines.isEmpty { lines.append("No discoverable actions.") }
+            if let cursor = page.nextCursor { lines.append("Next page: mactools actions list --cursor \(cursor)") }
+            human = lines.joined(separator: "\n")
+        case .actionsDescribe:
+            let request = try CLIDiscoveryValidation.decode(CLIActionTargetRequest.self, from: requestPayload)
+            let action = try CLIDiscoveryValidation.decode(CLIActionDescription.self, from: payload)
+            try CLIDiscoveryValidation.validate(action, id: request.id)
+            var lines = ["\(action.id)  \(action.title)", action.description,
+                         "Parameter schema: \(action.parameterSchemaVersion)", "Execution: not supported"]
+            lines += action.parameters.map { "  \($0.id): \($0.kind.rawValue) (\($0.isRequired ? "required" : "optional"), \($0.privacy.rawValue), \($0.portability.rawValue))" }
+            human = lines.joined(separator: "\n")
+        case .actionsAvailability:
+            let request = try CLIDiscoveryValidation.decode(CLIActionTargetRequest.self, from: requestPayload)
+            let availability = try CLIDiscoveryValidation.decode(CLIActionAvailability.self, from: payload)
+            try CLIDiscoveryValidation.validate(availability, id: request.id)
+            human = "\(availability.id)\nCLI eligibility: eligible\nAvailability: \(availability.available ? "available" : "currently unavailable in MacTools")"
+        case .doctor:
+            throw CLIProtocolSemanticError.invalidResponse
+        }
+        return json ? try envelopeJSON(response, data: JSONSerialization.jsonObject(with: payload)) : human
+    }
+
     func renderVersion(
         cli: (version: String, build: String),
         handshake: CLIHandshakeResponse?,

--- a/Sources/MacToolsCLIProtocol/CLIDiscoveryModels.swift
+++ b/Sources/MacToolsCLIProtocol/CLIDiscoveryModels.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+public enum CLIDiscoveryLimits {
+    public static let defaultPageSize = 50
+    public static let maximumPageSize = 100
+    public static let maximumCatalogSize = 4_096
+    public static let maximumTextBytes = 1_024
+}
+
+public struct CLIActionListRequest: Codable, Equatable, Sendable {
+    public let pageSize: Int
+    public let cursor: String?
+
+    public init(pageSize: Int = CLIDiscoveryLimits.defaultPageSize, cursor: String? = nil) {
+        self.pageSize = pageSize
+        self.cursor = cursor
+    }
+}
+
+public struct CLIActionTargetRequest: Codable, Equatable, Sendable {
+    public let id: String
+    public init(id: String) { self.id = id }
+}
+
+public struct CLIActionSummary: Codable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public init(id: String, title: String) {
+        self.id = id
+        self.title = title
+    }
+}
+
+public struct CLIActionPage: Codable, Equatable, Sendable {
+    public let actions: [CLIActionSummary]
+    public let generation: String
+    public let nextCursor: String?
+
+    public init(actions: [CLIActionSummary], generation: String, nextCursor: String?) {
+        self.actions = actions
+        self.generation = generation
+        self.nextCursor = nextCursor
+    }
+}
+
+public struct CLIActionParameter: Codable, Equatable, Sendable {
+    public enum Kind: String, Codable, Sendable { case string, integer, double, boolean }
+    public enum Privacy: String, Codable, Sendable { case publicValue, sensitive }
+    public enum Portability: String, Codable, Sendable { case portable, localOnly }
+    public let id: String
+    public let kind: Kind
+    public let isRequired: Bool
+    public let privacy: Privacy
+    public let portability: Portability
+
+    public init(id: String, kind: Kind, isRequired: Bool, privacy: Privacy, portability: Portability) {
+        self.id = id
+        self.kind = kind
+        self.isRequired = isRequired
+        self.privacy = privacy
+        self.portability = portability
+    }
+}
+
+public struct CLIActionDescription: Codable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let description: String
+    public let parameterSchemaVersion: Int
+    public let parameters: [CLIActionParameter]
+    public let executionSupported: Bool
+
+    public init(id: String, title: String, description: String, parameterSchemaVersion: Int,
+                parameters: [CLIActionParameter], executionSupported: Bool = false) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.parameterSchemaVersion = parameterSchemaVersion
+        self.parameters = parameters
+        self.executionSupported = executionSupported
+    }
+}
+
+public struct CLIActionAvailability: Codable, Equatable, Sendable {
+    public enum Reason: String, Codable, Sendable { case providerUnavailable }
+    public let id: String
+    public let eligible: Bool
+    public let available: Bool
+    public let reason: Reason?
+
+    public init(id: String, eligible: Bool = true, available: Bool, reason: Reason?) {
+        self.id = id
+        self.eligible = eligible
+        self.available = available
+        self.reason = reason
+    }
+}
+
+public enum CLIDiscoveryValidation {
+    public static func validComponent(_ value: String) -> Bool {
+        !value.isEmpty && value != "." && value != ".." && value.utf8.count <= 128 && value.unicodeScalars.allSatisfy {
+            CharacterSet.alphanumerics.contains($0) || $0 == "." || $0 == "_" || $0 == "-"
+        }
+    }
+
+    public static func validID(_ value: String) -> Bool {
+        let parts = value.split(separator: "@", omittingEmptySubsequences: false)
+        guard parts.count == 1 || (parts.count == 2 && validDigest(String(parts[1]))) else { return false }
+        let key = parts[0].split(separator: "/", omittingEmptySubsequences: false)
+        return key.count == 2 && key.allSatisfy { validComponent(String($0)) }
+    }
+
+    public static func validDigest(_ value: String) -> Bool {
+        value.utf8.count == 64 && value.utf8.allSatisfy { (48...57).contains($0) || (97...102).contains($0) }
+    }
+
+    public static func cursorParts(_ value: String) -> (generation: String, offset: Int)? {
+        guard value.utf8.count <= 80 else { return nil }
+        let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 2, validDigest(String(parts[0])),
+              let offset = Int(parts[1]), offset > 0,
+              offset < CLIDiscoveryLimits.maximumCatalogSize,
+              String(offset) == parts[1] else { return nil }
+        return (String(parts[0]), offset)
+    }
+
+    public static func validate(_ request: CLIActionListRequest) throws {
+        guard (1...CLIDiscoveryLimits.maximumPageSize).contains(request.pageSize),
+              request.cursor == nil || cursorParts(request.cursor!) != nil else {
+            throw CLIProtocolCodecError.invalidObject
+        }
+    }
+
+    public static func validate(_ request: CLIActionTargetRequest) throws {
+        guard validID(request.id) else { throw CLIProtocolCodecError.invalidObject }
+    }
+
+    public static func validate(_ page: CLIActionPage, request: CLIActionListRequest) throws {
+        try validate(request)
+        guard validDigest(page.generation), page.actions.count <= request.pageSize,
+              page.actions.map(\.id) == page.actions.map(\.id).sorted(),
+              Set(page.actions.map(\.id)).count == page.actions.count,
+              page.actions.allSatisfy({ validID($0.id) && validText($0.title, allowEmpty: false) })
+        else { throw CLIProtocolSemanticError.invalidResponse }
+        let previous = request.cursor.flatMap(cursorParts)
+        guard (previous == nil || previous?.generation == page.generation),
+              (previous?.offset ?? 0) + page.actions.count <= CLIDiscoveryLimits.maximumCatalogSize else {
+            throw CLIProtocolSemanticError.invalidResponse
+        }
+        if let next = page.nextCursor {
+            guard let parts = cursorParts(next), parts.generation == page.generation,
+                  !page.actions.isEmpty,
+                  parts.offset == (previous?.offset ?? 0) + page.actions.count else {
+                throw CLIProtocolSemanticError.invalidResponse
+            }
+        }
+    }
+
+    public static func validate(_ action: CLIActionDescription, id: String) throws {
+        guard action.id == id, validID(id), validText(action.title, allowEmpty: false),
+              validText(action.description), action.parameterSchemaVersion > 0,
+              action.parameters.count <= 32, !action.executionSupported,
+              Set(action.parameters.map(\.id)).count == action.parameters.count,
+              action.parameters.allSatisfy({ validComponent($0.id) }) else {
+            throw CLIProtocolSemanticError.invalidResponse
+        }
+    }
+
+    public static func validate(_ availability: CLIActionAvailability, id: String) throws {
+        guard availability.id == id, validID(id), availability.eligible,
+              availability.available == (availability.reason == nil) else {
+            throw CLIProtocolSemanticError.invalidResponse
+        }
+    }
+
+    public static func validText(_ value: String, allowEmpty: Bool = true) -> Bool {
+        (allowEmpty || !value.isEmpty) && value.utf8.count <= CLIDiscoveryLimits.maximumTextBytes
+            && !value.unicodeScalars.contains { CharacterSet.controlCharacters.contains($0) }
+    }
+
+    /// Closed recursive shape validation: neither saved values nor unknown metadata can pass through.
+    public static func decode<T: Codable>(_ type: T.Type, from data: Data) throws -> T {
+        guard data.count <= CLIProtocolVersion.maximumResponseBytes else {
+            throw CLIProtocolCodecError.responseTooLarge
+        }
+        try CLIProtocolCodec.rejectDuplicateFieldsRecursively(in: data)
+        let decoded = try CLIProtocolCodec.decodeResponse(type, from: data)
+        let canonical = try CLIProtocolCodec.encodeResponse(decoded)
+        guard let original = try JSONSerialization.jsonObject(with: data) as? NSDictionary,
+              let reencoded = try JSONSerialization.jsonObject(with: canonical) as? NSDictionary,
+              original.isEqual(reencoded) else {
+            throw CLIProtocolCodecError.invalidObject
+        }
+        return decoded
+    }
+
+}

--- a/Sources/MacToolsCLIProtocol/CLIProtocolCodec.swift
+++ b/Sources/MacToolsCLIProtocol/CLIProtocolCodec.swift
@@ -193,6 +193,7 @@ public enum CLIProtocolCodec {
 private struct CLIJSONDuplicateFieldScanner {
     private let bytes: [UInt8]
     private var index = 0
+    private var depth = 0
 
     init(data: Data) {
         bytes = Array(data)
@@ -206,6 +207,9 @@ private struct CLIJSONDuplicateFieldScanner {
     }
 
     private mutating func scanValue() throws {
+        guard depth < 64 else { throw CLIProtocolCodecError.invalidObject }
+        depth += 1
+        defer { depth -= 1 }
         skipWhitespace()
         guard index < bytes.count else { throw CLIProtocolCodecError.invalidObject }
         switch bytes[index] {

--- a/Sources/MacToolsCLIProtocol/CLIProtocolModels.swift
+++ b/Sources/MacToolsCLIProtocol/CLIProtocolModels.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public enum CLIProtocolVersion {
     public static let minimum = 1
-    public static let current = 1
+    public static let current = 2
     public static let maximumRequestBytes = 64 * 1_024
     public static let maximumResponseBytes = 4 * 1_024 * 1_024
     public static let maximumInFlightRequestsPerClient = 8
@@ -35,12 +35,18 @@ public enum CLIProtocolNegotiator {
 
 public enum CLIOperation: String, Codable, CaseIterable, Sendable {
     case doctor
+    case actionsList = "actions.list"
+    case actionsDescribe = "actions.describe"
+    case actionsAvailability = "actions.availability"
+
+    public var minimumProtocolVersion: Int { self == .doctor ? 1 : 2 }
 }
 
 public enum CLIOutcome: String, Codable, Sendable {
     case completed
     case cancelled
     case invalidInput
+    case unknownTarget
     case hostUnavailable
     case protocolIncompatible
 }
@@ -48,6 +54,7 @@ public enum CLIOutcome: String, Codable, Sendable {
 public enum CLIExitCode: Int32, Codable, Sendable {
     case success = 0
     case invalidInput = 2
+    case unknownTarget = 3
     case cancellation = 8
     case transportFailure = 9
     case protocolIncompatible = 10
@@ -272,6 +279,7 @@ public enum CLIProtocolSemanticValidator {
               response.protocolVersion == request.protocolVersion,
               response.requestID == request.requestID,
               response.operation == request.operation,
+              response.outcome != .unknownTarget || request.operation != .doctor,
               response.finishedAt >= response.startedAt
         else { throw CLIProtocolSemanticError.invalidResponse }
         switch response.outcome {
@@ -280,7 +288,7 @@ public enum CLIProtocolSemanticValidator {
                   response.rejection == nil,
                   response.message == nil
             else { throw CLIProtocolSemanticError.invalidResponse }
-        case .cancelled, .invalidInput, .hostUnavailable, .protocolIncompatible:
+        case .cancelled, .invalidInput, .unknownTarget, .hostUnavailable, .protocolIncompatible:
             guard response.payload == nil,
                   let rejection = response.rejection,
                   !rejection.category.isEmpty,

--- a/Tests/Core/CLI/CLIActionDiscoveryTests.swift
+++ b/Tests/Core/CLI/CLIActionDiscoveryTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import MacToolsCLIProtocol
+import MacToolsPluginKit
+import XCTest
+@testable import MacTools
+
+@MainActor
+final class CLIActionDiscoveryTests: XCTestCase {
+    private let owner = NSObject()
+
+    func testReadinessEmptyAndMissingTargetsAreDistinct() throws {
+        let discovery = CLIActionDiscovery(registry: ActionRegistry())
+        XCTAssertThrowsError(try discovery.list(.init()))
+        discovery.markReady()
+        XCTAssertTrue(try discovery.list(.init()).actions.isEmpty)
+        XCTAssertThrowsError(try discovery.describe(.init(id: "test/missing")))
+    }
+
+    func testUnavailableIsDiscoverableAndRunLinkPolicyIsIndependent() throws {
+        let registry = ActionRegistry()
+        var available = false
+        var excluded = false
+        let action = definition("a")
+        registry.synchronize([registration([action], availability: { _ in
+            available ? .available : .unavailable("private path or parameter")
+        }, exposure: { _, surface in surface == CLIActionDiscovery.surface && excluded ? .excluded : .automatic })])
+        let discovery = ready(registry)
+        XCTAssertEqual(try discovery.list(.init()).actions.map(\.id), ["test/a"])
+        XCTAssertEqual(try discovery.availability(.init(id: "test/a")).reason, .providerUnavailable)
+        available = true
+        XCTAssertTrue(try discovery.availability(.init(id: "test/a")).available)
+        excluded = true
+        XCTAssertTrue(try discovery.list(.init()).actions.isEmpty)
+        XCTAssertThrowsError(try discovery.describe(.init(id: "test/a")))
+        XCTAssertThrowsError(try discovery.availability(.init(id: "test/a")))
+    }
+
+    func testOnlyPublishedSafeBackgroundAutomaticActionsAreDiscoverable() throws {
+        let registry = ActionRegistry()
+        let definitions = [definition("safe"), definition("unpublished"),
+                           definition("interactive", capabilities: [.foregroundInteractive, .automatic]),
+                           definition("manual", capabilities: [.background])]
+        registry.synchronize([registration(definitions, entries: [definitions[0], definitions[2], definitions[3]].map {
+            ActionCatalogEntry(reference: ActionReference(key: $0.key), title: $0.title)
+        })])
+        XCTAssertEqual(try ready(registry).list(.init()).actions.map(\.id), ["test/safe"])
+    }
+
+    func testParameterizedReferencesHaveDistinctOpaqueIDsAndNoSavedValues() throws {
+        let registry = ActionRegistry()
+        let action = definition("parameter", parameters: [.init(id: "value", title: "Value", kind: .string)])
+        let entries = try ["saved-first-value", "saved-second-value"].map { value in
+            ActionCatalogEntry(reference: ActionReference(key: action.key,
+                parameters: try ActionParameterSet(["value": .string(value)])), title: value, subtitle: value)
+        }
+        registry.synchronize([registration([action], entries: entries)])
+        let discovery = ready(registry)
+        let page = try discovery.list(.init())
+        XCTAssertEqual(page.actions.count, 2)
+        XCTAssertNotEqual(page.actions[0].id, page.actions[1].id)
+        XCTAssertTrue(page.actions.allSatisfy { $0.id.hasPrefix("test/parameter@") })
+        XCTAssertThrowsError(try discovery.describe(.init(id: "test/parameter")))
+        for summary in page.actions {
+            let record = try discovery.describe(.init(id: summary.id))
+            let text = String(decoding: try CLIProtocolCodec.encodeResponse(record), as: UTF8.self)
+            XCTAssertFalse(text.contains("saved-"))
+            XCTAssertEqual(record.parameters.count, 1)
+            XCTAssertFalse(record.executionSupported)
+        }
+    }
+
+    func testSensitiveAndLocalOnlyReferencesAreExcluded() throws {
+        let registry = ActionRegistry()
+        let sensitive = definition("sensitive", parameters: [.init(id: "value", title: "Value", kind: .string, privacy: .sensitive)])
+        let local = definition("local", parameters: [.init(id: "value", title: "Value", kind: .string, portability: .localOnly)])
+        let entries = try [sensitive, local].map {
+            ActionCatalogEntry(reference: ActionReference(key: $0.key,
+                parameters: try ActionParameterSet(["value": .string("secret")])), title: "secret")
+        }
+        registry.synchronize([registration([sensitive, local], entries: entries)])
+        XCTAssertTrue(try ready(registry).list(.init()).actions.isEmpty)
+    }
+
+    func testPagingIsOrderedAndRejectsChangedCatalogAndHostRestart() throws {
+        let registry = ActionRegistry()
+        let definitions = [definition("c"), definition("b"), definition("a")]
+        registry.synchronize([registration(definitions)])
+        let discovery = ready(registry)
+        let first = try discovery.list(.init(pageSize: 1))
+        XCTAssertEqual(first.actions.map(\.id), ["test/a"])
+        let cursor = try XCTUnwrap(first.nextCursor)
+        let second = try discovery.list(.init(pageSize: 2, cursor: cursor))
+        XCTAssertEqual(second.actions.map(\.id), ["test/b", "test/c"])
+        XCTAssertNil(second.nextCursor)
+        XCTAssertThrowsError(try ready(registry).list(.init(cursor: cursor)))
+        registry.synchronize([registration([definition("b")])])
+        XCTAssertThrowsError(try discovery.list(.init(cursor: cursor)))
+    }
+
+    func testMetadataIsBoundedAndTerminalControlCharactersAreRemoved() throws {
+        let registry = ActionRegistry()
+        let action = ActionDefinition(key: .init(providerID: "test", actionID: "a"),
+            title: "Title\u{1b}\n", description: String(repeating: "x", count: 5_000),
+            systemImage: "bolt", capabilities: [.background, .automatic])
+        registry.synchronize([registration([action])])
+        let record = try ready(registry).describe(.init(id: "test/a"))
+        XCTAssertEqual(record.title, "Title")
+        XCTAssertEqual(record.description.utf8.count, CLIDiscoveryLimits.maximumTextBytes)
+    }
+
+    func testOversizedCatalogFailsWithoutPartialResults() {
+        let registry = ActionRegistry()
+        registry.synchronize([registration((0...CLIDiscoveryLimits.maximumCatalogSize).map { definition("a\($0)") })])
+        XCTAssertThrowsError(try ready(registry).list(.init()))
+    }
+
+    func testWorkflowChecksEveryDependencyIncludingNestedReferencesAndCycles() throws {
+        let registry = ActionRegistry()
+        let leaf = definition("leaf")
+        var excluded = false
+        var child = WorkflowDefinition(name: "Child", steps: [.init(reference: .init(key: leaf.key))])
+        var parent = WorkflowDefinition(name: "Parent", steps: [.init(reference: child.actionReference)])
+        let workflowDefinitions = [child, parent].map {
+            ActionDefinition(key: $0.actionKey, title: $0.name, description: "", systemImage: "bolt",
+                             capabilities: [.background, .automatic])
+        }
+        registry.synchronize([
+            registration([leaf], exposure: { _, _ in excluded ? .excluded : .automatic }),
+            registration(workflowDefinitions, provider: AutomationController.providerID),
+        ])
+        let discovery = CLIActionDiscovery(registry: registry, workflows: { [child, parent] })
+        discovery.markReady()
+        XCTAssertEqual(try discovery.list(.init()).actions.count, 3)
+        excluded = true
+        XCTAssertTrue(try discovery.list(.init()).actions.isEmpty)
+        excluded = false
+        parent.steps[0].reference = ActionReference(key: child.actionKey, schemaVersion: 999)
+        XCTAssertThrowsError(try discovery.describe(.init(id: parent.actionKey.id)))
+        parent.steps[0].reference = child.actionReference
+        child.steps[0].reference = parent.actionReference
+        XCTAssertEqual(try discovery.list(.init()).actions.map(\.id), ["test/leaf"])
+    }
+
+    func testWorkflowDepthLimitCountsWorkflowsNotLeafActions() throws {
+        let registry = ActionRegistry()
+        let leaf = definition("leaf")
+        var workflows: [WorkflowDefinition] = []
+        var reference = ActionReference(key: leaf.key)
+        for depth in 1...(WorkflowExecutionLimits.maximumDepth + 1) {
+            let workflow = WorkflowDefinition(name: "Level \(depth)", steps: [.init(reference: reference)])
+            workflows.append(workflow)
+            reference = workflow.actionReference
+        }
+        let definitions = workflows.map {
+            ActionDefinition(key: $0.actionKey, title: $0.name, description: "", systemImage: "bolt",
+                             capabilities: [.background, .automatic])
+        }
+        registry.synchronize([registration([leaf]), registration(definitions, provider: AutomationController.providerID)])
+        let discovery = CLIActionDiscovery(registry: registry, workflows: { workflows })
+        discovery.markReady()
+        let supportedID = workflows[WorkflowExecutionLimits.maximumDepth - 1].actionKey.id
+        let unsupportedID = workflows[WorkflowExecutionLimits.maximumDepth].actionKey.id
+        let ids = try discovery.list(.init()).actions.map(\.id)
+        XCTAssertTrue(ids.contains(supportedID))
+        XCTAssertFalse(ids.contains(unsupportedID))
+        XCTAssertEqual(try discovery.describe(.init(id: supportedID)).id, supportedID)
+        XCTAssertThrowsError(try discovery.describe(.init(id: unsupportedID)))
+    }
+
+    private func ready(_ registry: ActionRegistry) -> CLIActionDiscovery {
+        let value = CLIActionDiscovery(registry: registry)
+        value.markReady()
+        return value
+    }
+
+    private func definition(_ id: String, parameters: [ActionParameterDefinition] = [],
+                            capabilities: ActionExecutionCapabilities = [.background, .automatic]) -> ActionDefinition {
+        ActionDefinition(key: .init(providerID: "test", actionID: id), title: id, description: "Description",
+                         systemImage: "bolt", parameters: parameters, externalInvocationPolicy: .unavailable,
+                         capabilities: capabilities)
+    }
+
+    private func registration(_ definitions: [ActionDefinition], entries: [ActionCatalogEntry]? = nil,
+                              provider: String = "test",
+                              availability: @escaping (ActionReference) -> ActionAvailability = { _ in .available },
+                              exposure: @escaping (ActionReference, ActionExposureSurface) -> ActionExposurePolicy = { _, _ in .automatic }) -> ActionProviderRegistration {
+        ActionProviderRegistration(providerID: provider, identity: ObjectIdentifier(owner), definitions: definitions,
+            catalogEntries: entries ?? definitions.map { ActionCatalogEntry(reference: .init(key: $0.key), title: $0.title) },
+            availability: availability, exposurePolicy: exposure,
+            migrate: { _, _ in XCTFail("Discovery must not migrate or persist references"); return nil },
+            begin: { _ in XCTFail("Discovery must not execute actions"); return .failure(.providerChanged) })
+    }
+}

--- a/Tests/Core/CLI/CLIArgumentParserTests.swift
+++ b/Tests/Core/CLI/CLIArgumentParserTests.swift
@@ -1,8 +1,9 @@
 import XCTest
+import MacToolsCLIProtocol
 @testable import MacTools
 
 final class CLIArgumentParserTests: XCTestCase {
-    func testParsesOnlyPhaseZeroCommands() throws {
+    func testPreservesPhaseZeroCommands() throws {
         XCTAssertEqual(try CLIArgumentParser().parse([]), .help)
         XCTAssertEqual(try CLIArgumentParser().parse(["help"]), .help)
         XCTAssertEqual(try CLIArgumentParser().parse(["version"]), .version(json: false))
@@ -11,9 +12,16 @@ final class CLIArgumentParserTests: XCTestCase {
         XCTAssertEqual(try CLIArgumentParser().parse(["doctor", "--json"]), .doctor(json: true))
     }
 
-    func testRejectsPostPhaseZeroAndMalformedCommands() {
+    func testRejectsExecutionAndMalformedCommands() {
         for arguments in [
-            ["actions", "list"],
+            ["actions", "run", "test/run"],
+            ["actions", "list", "--parameter", "enabled=true"],
+            ["actions", "list", "--page-size", "0"],
+            ["actions", "list", "--page-size", "101"],
+            ["actions", "list", "--page-size", "1", "--page-size", "2"],
+            ["actions", "list", "--cursor", "invalid"],
+            ["actions", "describe", "test/run", "--json", "--json"],
+            ["actions", "describe", "test/run", "extra"],
             ["plugins", "list"],
             ["workflows", "run", "name"],
             ["doctor", "--unknown"],
@@ -21,6 +29,23 @@ final class CLIArgumentParserTests: XCTestCase {
             ["help", "--json"],
         ] {
             XCTAssertThrowsError(try CLIArgumentParser().parse(arguments), arguments.joined(separator: " "))
+        }
+    }
+
+    func testDiscoveryArgumentsProduceTypedPayloads() throws {
+        guard case let .discovery(operation, payload, json) = try CLIArgumentParser().parse(
+            ["actions", "list", "--json", "--page-size", "2"]
+        ) else { return XCTFail("Expected discovery") }
+        XCTAssertEqual(operation, .actionsList)
+        XCTAssertTrue(json)
+        XCTAssertEqual(try CLIDiscoveryValidation.decode(CLIActionListRequest.self, from: payload),
+                       CLIActionListRequest(pageSize: 2))
+        for verb in ["describe", "availability"] {
+            guard case let .discovery(operation, payload, _) = try CLIArgumentParser().parse(
+                ["actions", verb, "test/run"]
+            ) else { return XCTFail("Expected discovery") }
+            XCTAssertEqual(operation.rawValue, "actions.\(verb)")
+            XCTAssertEqual(try CLIDiscoveryValidation.decode(CLIActionTargetRequest.self, from: payload).id, "test/run")
         }
     }
 }

--- a/Tests/Core/CLI/CLIDiscoveryProtocolTests.swift
+++ b/Tests/Core/CLI/CLIDiscoveryProtocolTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import MacToolsCLIProtocol
+import XCTest
+@testable import MacTools
+
+final class CLIDiscoveryProtocolTests: XCTestCase {
+    func testVersionNegotiationKeepsV1DiagnosticsAndRequiresV2Discovery() {
+        XCTAssertEqual(CLIProtocolNegotiator.selectedVersion(clientMinimum: 1, clientMaximum: 2,
+                                                             hostMinimum: 1, hostMaximum: 1), 1)
+        XCTAssertEqual(CLIProtocolNegotiator.selectedVersion(clientMinimum: 1, clientMaximum: 1), 1)
+        XCTAssertEqual(CLIOperation.doctor.minimumProtocolVersion, 1)
+        XCTAssertEqual(CLIOperation.actionsList.minimumProtocolVersion, 2)
+    }
+
+    func testStrictShapesRejectUnknownDuplicateAndMalformedNestedFields() throws {
+        let examples = [
+            #"{"pageSize":1,"cursor":null,"unknown":null}"#,
+            #"{"pageSize":1,"pageSize":2}"#,
+            #"{"pageSize":1,"parameters":{"secret":"hidden"}}"#,
+        ]
+        for json in examples {
+            XCTAssertThrowsError(try CLIDiscoveryValidation.decode(CLIActionListRequest.self, from: Data(json.utf8)))
+        }
+        let action = description()
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: CLIProtocolCodec.encodeResponse(action)) as? [String: Any])
+        var parameters = try XCTUnwrap(object["parameters"] as? [[String: Any]])
+        parameters[0]["default"] = "private"
+        object["parameters"] = parameters
+        XCTAssertThrowsError(try CLIDiscoveryValidation.decode(CLIActionDescription.self,
+                                                              from: JSONSerialization.data(withJSONObject: object)))
+        parameters[0].removeValue(forKey: "default")
+        parameters[0]["kind"] = "unexpected"
+        object["parameters"] = parameters
+        XCTAssertThrowsError(try CLIDiscoveryValidation.decode(CLIActionDescription.self,
+                                                              from: JSONSerialization.data(withJSONObject: object)))
+        let deep = "{\"a\":" + String(repeating: "[", count: 100) + "0" + String(repeating: "]", count: 100) + "}"
+        XCTAssertThrowsError(try CLIProtocolCodec.rejectDuplicateFieldsRecursively(in: Data(deep.utf8)))
+    }
+
+    func testPageAndReferenceSemanticValidation() throws {
+        let generation = String(repeating: "a", count: 64)
+        let items = [CLIActionSummary(id: "test/a", title: "A")]
+        try CLIDiscoveryValidation.validate(CLIActionPage(actions: items, generation: generation,
+                                                        nextCursor: "\(generation).1"), request: .init(pageSize: 1))
+        for size in [0, 101, -1] { XCTAssertThrowsError(try CLIDiscoveryValidation.validate(CLIActionListRequest(pageSize: size))) }
+        for id in ["../x", "a/b/c", "a/", "a/b@bad", "a/b\n"] {
+            XCTAssertFalse(CLIDiscoveryValidation.validID(id))
+        }
+        for page in [
+            CLIActionPage(actions: items + items, generation: generation, nextCursor: nil),
+            CLIActionPage(actions: items, generation: generation, nextCursor: "\(generation).2"),
+            CLIActionPage(actions: [], generation: generation, nextCursor: "\(generation).1"),
+            CLIActionPage(actions: items, generation: "invalid", nextCursor: nil),
+        ] { XCTAssertThrowsError(try CLIDiscoveryValidation.validate(page, request: .init(pageSize: 1))) }
+        XCTAssertThrowsError(try CLIDiscoveryValidation.validate(description(), id: "test/other"))
+        let duplicate = CLIActionDescription(id: "test/a", title: "A", description: "", parameterSchemaVersion: 1,
+                                            parameters: description().parameters + description().parameters)
+        XCTAssertThrowsError(try CLIDiscoveryValidation.validate(duplicate, id: duplicate.id))
+        XCTAssertThrowsError(try CLIDiscoveryValidation.validate(
+            CLIActionAvailability(id: "test/a", available: true, reason: .providerUnavailable), id: "test/a"))
+    }
+
+    func testTerminalPageCannotExceedCatalogLimit() throws {
+        let generation = String(repeating: "a", count: 64)
+        let request = CLIActionListRequest(pageSize: 2,
+            cursor: "\(generation).\(CLIDiscoveryLimits.maximumCatalogSize - 1)")
+        let items = [CLIActionSummary(id: "test/a", title: "A"), CLIActionSummary(id: "test/b", title: "B")]
+        try CLIDiscoveryValidation.validate(CLIActionPage(actions: [items[0]], generation: generation,
+                                                        nextCursor: nil), request: request)
+        let overflow = CLIActionPage(actions: items, generation: generation, nextCursor: nil)
+        XCTAssertThrowsError(try CLIDiscoveryValidation.validate(overflow, request: request))
+        let response = envelope(operation: .actionsList, payload: try CLIProtocolCodec.encodeResponse(overflow))
+        let payload = try CLIProtocolCodec.encodeRequest(request)
+        for json in [false, true] {
+            XCTAssertThrowsError(try CLIOutput().renderDiscovery(response, requestPayload: payload, json: json))
+        }
+    }
+
+    func testHumanAndJSONRenderersValidateBeforeOutput() throws {
+        let request = try CLIProtocolCodec.encodeRequest(CLIActionTargetRequest(id: "test/a"))
+        let payload = try CLIProtocolCodec.encodeResponse(description())
+        let response = envelope(operation: .actionsDescribe, payload: payload)
+        let human = try CLIOutput().renderDiscovery(response, requestPayload: request, json: false)
+        XCTAssertTrue(human.contains("Execution: not supported"))
+        let json = try CLIOutput().renderDiscovery(response, requestPayload: request, json: true)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        XCTAssertEqual(object["command"] as? String, "actions.describe")
+        XCTAssertEqual((object["data"] as? [String: Any])?["executionSupported"] as? Bool, false)
+        XCTAssertThrowsError(try CLIOutput().renderDiscovery(response,
+            requestPayload: CLIProtocolCodec.encodeRequest(CLIActionTargetRequest(id: "test/wrong")), json: true))
+        let availability = CLIActionAvailability(id: "test/a", available: false, reason: .providerUnavailable)
+        let rendered = try CLIOutput().renderDiscovery(envelope(operation: .actionsAvailability,
+            payload: CLIProtocolCodec.encodeResponse(availability)), requestPayload: request, json: false)
+        XCTAssertTrue(rendered.contains("currently unavailable"))
+    }
+
+    func testResponseOutcomeAndTimestampSemantics() throws {
+        let request = CLIRequestEnvelope(protocolVersion: 2, requestID: UUID(), operation: .actionsDescribe,
+                                         sentAt: .now, payload: nil)
+        for response in [
+            CLIResponseEnvelope(protocolVersion: 2, requestID: request.requestID, operation: .actionsDescribe,
+                                startedAt: .now, finishedAt: .distantPast, outcome: .completed,
+                                message: nil, rejection: nil, payload: Data()),
+            CLIResponseEnvelope(protocolVersion: 2, requestID: request.requestID, operation: .actionsDescribe,
+                                startedAt: .distantPast, finishedAt: .now, outcome: .unknownTarget,
+                                message: nil, rejection: nil, payload: Data()),
+        ] { XCTAssertThrowsError(try CLIProtocolSemanticValidator.validate(response: response, matching: request)) }
+    }
+
+    private func description() -> CLIActionDescription {
+        CLIActionDescription(id: "test/a", title: "A", description: "Description", parameterSchemaVersion: 1,
+            parameters: [CLIActionParameter(id: "enabled", kind: .boolean, isRequired: true,
+                                             privacy: .publicValue, portability: .portable)])
+    }
+
+    private func envelope(operation: CLIOperation, payload: Data) -> CLIResponseEnvelope {
+        CLIResponseEnvelope(protocolVersion: 2, requestID: UUID(), operation: operation,
+                            startedAt: .distantPast, finishedAt: .now, outcome: .completed,
+                            message: nil, rejection: nil, payload: payload)
+    }
+}

--- a/Tests/Core/CLI/CLIExecutableTests.swift
+++ b/Tests/Core/CLI/CLIExecutableTests.swift
@@ -7,7 +7,7 @@ final class CLIExecutableTests: XCTestCase {
         XCTAssertEqual(help.status, CLIExitCode.success.rawValue)
         XCTAssertTrue(help.output.contains("version [--json]"))
         XCTAssertTrue(help.output.contains("doctor [--json]"))
-        XCTAssertFalse(help.output.contains("actions"))
+        XCTAssertTrue(help.output.contains("actions list"))
 
         let version = try runCLI(["version", "--json"])
         XCTAssertEqual(version.status, CLIExitCode.success.rawValue)
@@ -23,8 +23,8 @@ final class CLIExecutableTests: XCTestCase {
         XCTAssertNotEqual(data["cliBuild"] as? String, "unknown")
     }
 
-    func testCommandsBeyondPhaseZeroAreRejectedWithStableJSON() throws {
-        let result = try runCLI(["actions", "list", "--json"])
+    func testExecutionIsRejectedWithStableJSON() throws {
+        let result = try runCLI(["actions", "run", "test/run", "--json"])
         XCTAssertEqual(result.status, CLIExitCode.invalidInput.rawValue)
         XCTAssertTrue(result.error.isEmpty)
         let object = try XCTUnwrap(

--- a/Tests/Core/CLI/CLIHostDiscoveryTests.swift
+++ b/Tests/Core/CLI/CLIHostDiscoveryTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import MacToolsCLIProtocol
+import XCTest
+@testable import MacTools
+
+@MainActor
+final class CLIHostDiscoveryTests: XCTestCase {
+    func testDiscoveryWaitsForRegistryAndV1DoctorStillWorks() async throws {
+        let discovery = CLIActionDiscovery(registry: ActionRegistry())
+        let bridge = CLIHostBridge(discovery: discovery, readinessTimeout: .milliseconds(200), callerIsBroker: { true })
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(20))
+            discovery.markReady()
+        }
+        let page = try await response(bridge, operation: .actionsList,
+                                     payload: CLIProtocolCodec.encodeRequest(CLIActionListRequest()))
+        XCTAssertEqual(page.outcome, .completed)
+        let doctor = try await response(bridge, operation: .doctor, version: 1, payload: nil)
+        XCTAssertEqual(doctor.outcome, .completed)
+        let old = try await response(bridge, operation: .actionsList, version: 1,
+                                    payload: CLIProtocolCodec.encodeRequest(CLIActionListRequest()))
+        XCTAssertEqual(old.outcome, .protocolIncompatible)
+    }
+
+    func testNotReadyInvalidInputAndUnknownTargetRemainDistinct() async throws {
+        let discovery = CLIActionDiscovery(registry: ActionRegistry())
+        let bridge = CLIHostBridge(discovery: discovery, readinessTimeout: .zero, callerIsBroker: { true })
+        let pending = try await response(bridge, operation: .actionsList,
+                                        payload: CLIProtocolCodec.encodeRequest(CLIActionListRequest()))
+        XCTAssertEqual(pending.rejection?.category, "registryNotReady")
+        let malformed = try await response(bridge, operation: .actionsList, payload: Data("{}".utf8))
+        XCTAssertEqual(malformed.outcome, .invalidInput)
+        discovery.markReady()
+        let missing = try await response(bridge, operation: .actionsDescribe,
+                                        payload: CLIProtocolCodec.encodeRequest(CLIActionTargetRequest(id: "test/missing")))
+        XCTAssertEqual(missing.outcome, .unknownTarget)
+    }
+
+    func testReadinessWaitHonorsCancellation() async throws {
+        let discovery = CLIActionDiscovery(registry: ActionRegistry())
+        let bridge = CLIHostBridge(discovery: discovery, callerIsBroker: { true })
+        let id = UUID()
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(20))
+            bridge.cancel(id) { _ in }
+        }
+        let result = try await response(bridge, operation: .actionsList, id: id,
+                                       payload: CLIProtocolCodec.encodeRequest(CLIActionListRequest()))
+        XCTAssertEqual(result.outcome, .cancelled)
+    }
+
+    private func response(_ bridge: CLIHostBridge, operation: CLIOperation, version: Int = 2,
+                          id: UUID = UUID(), payload: Data?) async throws -> CLIResponseEnvelope {
+        let request = CLIRequestEnvelope(protocolVersion: version, requestID: id, operation: operation,
+                                         sentAt: .now, payload: payload)
+        let encoded = try CLIProtocolCodec.encodeRequest(request)
+        let data = await withCheckedContinuation { continuation in
+            bridge.handle(encoded) { continuation.resume(returning: $0) }
+        }
+        let response = try CLIProtocolCodec.decodeResponse(CLIResponseEnvelope.self, from: data)
+        try CLIProtocolSemanticValidator.validate(response: response, matching: request)
+        return response
+    }
+}

--- a/changes/unreleased/cli-phase-1-discovery.md
+++ b/changes/unreleased/cli-phase-1-discovery.md
@@ -1,0 +1,6 @@
+---
+release: app
+type: added
+---
+
+The optional development CLI can list discoverable actions, inspect their parameter schemas, and check current availability without executing actions.

--- a/docs/superpowers/specs/2026-08-26-cli-phase-1-discovery.md
+++ b/docs/superpowers/specs/2026-08-26-cli-phase-1-discovery.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planning draft; discovery commands are not implemented by this change. The current executable still supports only `help`, `version`, and `doctor`.
+Implemented development prototype; signed smoke testing and independent review are required before leaving draft. This is not a public protocol or distribution commitment.
 
 This is a narrow follow-up to merged [Phase 0 PR #340](https://github.com/ggbond268/MacTools/pull/340), following the [maintainer's RFC guidance](https://github.com/ggbond268/MacTools/issues/309#issuecomment-5386412095). The closed [broad prototype #338](https://github.com/ggbond268/MacTools/pull/338) remains reference material, not a branch to merge wholesale.
 
@@ -10,15 +10,15 @@ This is a narrow follow-up to merged [Phase 0 PR #340](https://github.com/ggbond
 
 Let users inspect the host's canonical actions from a separately installed CLI without executing actions or duplicating plugin behavior. Keep the Phase 0 authentication, opt-in service lifecycle, cold launch, bounded waits, cancellation, and recovery guarantees.
 
-## Proposed command surface
+## Command surface
 
 ```text
-mactools actions list [--json]
-mactools actions describe <provider/action> [--json]
-mactools actions availability <provider/action> [--json]
+mactools actions list [--page-size 1...100] [--cursor <opaque-cursor>] [--json]
+mactools actions describe <id-from-list> [--json]
+mactools actions availability <id-from-list> [--json]
 ```
 
-Both human-readable and versioned JSON output are required. Pagination syntax and exact wire fields must be specified alongside protocol fixtures before implementation is considered complete.
+Both human-readable and versioned JSON output are supported. The default page size is 50, maximum 100, with a 4,096-entry catalog limit. Oversized catalogs fail explicitly rather than returning partial results.
 
 - `list` returns a deterministically ordered, bounded page of discoverable actions with stable identifiers and concise titles.
 - `describe` returns identity, description, relevant capabilities, and sanitized parameter-schema metadata. It must not export parameter values, saved inputs, or sensitive defaults/examples.
@@ -35,11 +35,13 @@ Discovery must not invoke an action, request confirmation, prompt for action per
 
 Use a dedicated `.cli` exposure surface, independent of Run Link `externalInvocationPolicy`. Preserve the maintainer's default polarity: `.automatic` means not excluded at the exposure layer, not unconditional execution permission.
 
-The proposed conservative discovery set is catalog-published, currently registered, portable references whose actions are safe, support background operation, include the automatic capability, and are not excluded from CLI exposure. Retain otherwise eligible but currently unavailable actions so users can inspect the reason. Excluded or non-discoverable actions must not become accessible by guessing an identifier through `describe` or `availability`.
+The conservative discovery set is catalog-published, currently registered, portable references whose actions are safe, support background operation, include the automatic capability, and are not excluded from CLI exposure. Retain otherwise eligible but currently unavailable actions so users can inspect the reason. Excluded or non-discoverable actions cannot become accessible by guessing an identifier through `describe` or `availability`. The existing string-backed PluginKit surface uses raw value `cli`; no PluginKit ABI or execution-source change is needed.
 
-Current availability and parameter requirements remain separate facts. Parameterized actions may expose sanitized schema metadata, but Phase 1 accepts no parameter values and must not imply that such actions can be run without them. Do not flatten distinct canonical references or presets into an ambiguous `provider/action` result; settle identifier resolution before freezing fixtures.
+Current availability and parameter requirements remain separate facts. Parameterized actions expose schema metadata only; Phase 1 accepts no values. Parameterless references use `provider/action`. Parameterized references append `@` and a lowercase SHA-256 digest of sorted-key JSON encoding of the complete canonical reference. This opaque suffix distinguishes presets without exposing their values. A bare key never selects a parameterized preset. Schema changes may change opaque IDs; use current list results.
 
-Workflows receive no separate command group or IPC interface. A workflow that appears as a canonical action must satisfy the same discovery policy across its complete dependency graph, including missing dependencies, cycles, and excluded children; omit it if that cannot be established safely.
+Descriptions use definition-level title/description, never preset titles/subtitles. Text is capped at 1,024 UTF-8 bytes and stripped of control characters. Up to 32 parameters expose only ID, kind (`string`, `integer`, `double`, `boolean`), requiredness, privacy, and portability; no values/defaults/examples are returned. Every description reports `executionSupported: false`. Availability reports `eligible: true` separately from `available`; the fixed reason `providerUnavailable` replaces arbitrary provider messages that may interpolate private inputs or paths.
+
+Workflows receive no separate command group or IPC interface. Every concrete reference in the dependency graph must satisfy the same discovery policy. Missing, unpublished, disabled, empty, cyclic, invalid, or too-deep dependencies fail closed. Traversal uses the existing eight-level depth limit and a shared 32,768-reference budget; budget exhaustion fails the request rather than yielding partial results.
 
 Keep any PluginKit changes minimal and preserve binary compatibility. A new execution source and executor integration belong to Phase 2, where requests will actually execute actions.
 
@@ -54,6 +56,36 @@ Keep any PluginKit changes minimal and preserve binary compatibility. A new exec
 - Preserve timeout cleanup, cancellation, reconnect backoff, and stale-connection callback isolation from Phase 0.
 - Do not export sensitive action-reference values through identifiers, metadata, messages, diagnostics, or JSON.
 
+### Wire contract and compatibility
+
+The unchanged handshake negotiates versions 1–2. Doctor remains valid at v1/v2; discovery requires v2. A new CLI rejects discovery before sending it if an old broker/host negotiates v1. Old diagnostics still work with new components. Product versions remain informational. The broker does not interpret discovery catalogs.
+
+Operations are `actions.list`, `actions.describe`, and `actions.availability`. Payloads remain encoded JSON data inside the existing envelope. Unknown fields (including nested/null extras), duplicate fields, malformed identifiers/cursors, invalid page bounds, unknown parameter enums, duplicate parameter IDs, and inconsistent response identity/outcome/timestamp/availability combinations are rejected. Optional inner fields are omitted, not null. Nesting is limited to 64; existing request/response byte and in-flight limits remain unchanged.
+
+Example decoded payloads (the generation below is illustrative):
+
+```json
+{"pageSize":50}
+```
+
+```json
+{"actions":[{"id":"example/status","title":"Status"}],"generation":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+```
+
+```json
+{"id":"example/status","title":"Status","description":"Inspect status","parameterSchemaVersion":1,"parameters":[],"executionSupported":false}
+```
+
+```json
+{"id":"example/status","eligible":true,"available":false,"reason":"providerUnavailable"}
+```
+
+Pages sort by full ID. The generation includes host incarnation, eligible sanitized descriptions, provider generations, and execution revisions. A generation mismatch yields `invalidInput/staleCursor`; restart without the cursor. Invalid offsets/syntax yield `invalidInput/invalidRequest`. Availability is read fresh and does not by itself change ordering. Cursors are opaque and cannot survive host restarts.
+
+Both bootstrap completion paths mark registry readiness. Discovery waits at most eight seconds for readiness, checks cancellation, and remains inside the CLI's total ten-second deadline. A ready empty registry succeeds; an unready one returns `hostUnavailable/registryNotReady`. No action permission prompt is requested by discovery.
+
+JSON keeps schema version 1 and the existing envelope fields, with decoded `data`. Exit codes remain 0 success, 2 invalid input, 8 cancellation, 9 host/transport failure, and 10 incompatibility; 3 is added for unknown/non-discoverable targets. Inspecting an unavailable eligible action succeeds with exit 0. JSON failures go to stdout; human failures go to stderr.
+
 ## Explicit non-goals
 
 - Action execution, confirmation UI, or foreground-interactive actions.
@@ -65,13 +97,13 @@ Keep any PluginKit changes minimal and preserve binary compatibility. A new exec
 
 ## Implementation sequence
 
-- [ ] Finalize identifiers, pagination, eligibility reasons, compatibility behavior, and JSON fixtures.
-- [ ] Add independent discovery wire models and codec/semantic tests.
-- [ ] Implement a host-owned read-only catalog adapter using the existing registry and the dedicated CLI exposure policy.
-- [ ] Connect the three commands to the authenticated transport and add human/JSON renderers.
-- [ ] Add client/host lifecycle and regression tests, then run the [Phase 1 test checklist](../../testing/cli-phase-1.md).
-- [ ] Update `README.md` and an app changelog fragment when the commands are actually implemented.
-- [ ] Keep the PR draft until implementation, required checks, and a fresh code review are complete.
+- Finalize identifiers, pagination, eligibility reasons, compatibility behavior, and JSON fixtures.
+- Add independent discovery wire models and codec/semantic tests.
+- Implement a host-owned read-only catalog adapter using the existing registry and the dedicated CLI exposure policy.
+- Connect the three commands to the authenticated transport and add human/JSON renderers.
+- Add client/host lifecycle and regression tests, then run the [Phase 1 test checklist](../../testing/cli-phase-1.md).
+- Update `README.md` and an app changelog fragment.
+- Keep the PR draft until implementation, required checks, and a fresh code review are complete.
 
 ## Compatibility evidence
 

--- a/docs/superpowers/specs/2026-08-26-cli-phase-1-discovery.md
+++ b/docs/superpowers/specs/2026-08-26-cli-phase-1-discovery.md
@@ -1,0 +1,78 @@
+# CLI Phase 1: read-only action discovery
+
+## Status
+
+Planning draft; discovery commands are not implemented by this change. The current executable still supports only `help`, `version`, and `doctor`.
+
+This is a narrow follow-up to merged [Phase 0 PR #340](https://github.com/ggbond268/MacTools/pull/340), following the [maintainer's RFC guidance](https://github.com/ggbond268/MacTools/issues/309#issuecomment-5386412095). The closed [broad prototype #338](https://github.com/ggbond268/MacTools/pull/338) remains reference material, not a branch to merge wholesale.
+
+## Goal
+
+Let users inspect the host's canonical actions from a separately installed CLI without executing actions or duplicating plugin behavior. Keep the Phase 0 authentication, opt-in service lifecycle, cold launch, bounded waits, cancellation, and recovery guarantees.
+
+## Proposed command surface
+
+```text
+mactools actions list [--json]
+mactools actions describe <provider/action> [--json]
+mactools actions availability <provider/action> [--json]
+```
+
+Both human-readable and versioned JSON output are required. Pagination syntax and exact wire fields must be specified alongside protocol fixtures before implementation is considered complete.
+
+- `list` returns a deterministically ordered, bounded page of discoverable actions with stable identifiers and concise titles.
+- `describe` returns identity, description, relevant capabilities, and sanitized parameter-schema metadata. It must not export parameter values, saved inputs, or sensitive defaults/examples.
+- `availability` reports current host-derived availability separately from CLI eligibility. Eligibility describes policy, not permission to execute; Phase 1 has no execution command.
+- `help`, `version`, and `doctor` retain their existing behavior. The executable must continue to reject `actions run` and parameter-input flags.
+
+## Ownership and safety
+
+The host owns catalog lookup, readiness, availability, exposure, and eligibility. The broker forwards bounded envelopes and handles authentication/lifecycle only; it must not acquire an action catalog or load plugins. The CLI depends only on the shared protocol package and does not link PluginKit, inspect plugin directories, or read host preferences.
+
+Discovery must not invoke an action, request confirmation, prompt for action permissions, or modify feature configuration. Normal opt-in broker startup may launch the host in the background, as in Phase 0.
+
+## Discovery and eligibility policy
+
+Use a dedicated `.cli` exposure surface, independent of Run Link `externalInvocationPolicy`. Preserve the maintainer's default polarity: `.automatic` means not excluded at the exposure layer, not unconditional execution permission.
+
+The proposed conservative discovery set is catalog-published, currently registered, portable references whose actions are safe, support background operation, include the automatic capability, and are not excluded from CLI exposure. Retain otherwise eligible but currently unavailable actions so users can inspect the reason. Excluded or non-discoverable actions must not become accessible by guessing an identifier through `describe` or `availability`.
+
+Current availability and parameter requirements remain separate facts. Parameterized actions may expose sanitized schema metadata, but Phase 1 accepts no parameter values and must not imply that such actions can be run without them. Do not flatten distinct canonical references or presets into an ambiguous `provider/action` result; settle identifier resolution before freezing fixtures.
+
+Workflows receive no separate command group or IPC interface. A workflow that appears as a canonical action must satisfy the same discovery policy across its complete dependency graph, including missing dependencies, cycles, and excluded children; omit it if that cannot be established safely.
+
+Keep any PluginKit changes minimal and preserve binary compatibility. A new execution source and executor integration belong to Phase 2, where requests will actually execute actions.
+
+## Protocol and lifecycle requirements
+
+- Keep wire models independent of PluginKit and explicitly validate request/response shapes and semantic combinations.
+- Negotiate support before sending new operations. An old Phase 0 peer must yield a bounded, documented incompatibility response for discovery without breaking compatible `version`/`doctor` use.
+- Preserve existing JSON envelopes and exit-code meanings; document any additions rather than repurposing old values.
+- Specify page-size defaults and limits, opaque cursor validation, deterministic ordering, and behavior when a provider/catalog generation changes between pages. A stale cursor must not silently skip or duplicate results.
+- Respect existing message-size and in-flight limits. Test large catalogs and oversized metadata without unbounded host-main-actor work.
+- Wait for actual action-registry readiness, not merely an XPC connection or running app. Return a bounded startup error if readiness cannot be reached.
+- Preserve timeout cleanup, cancellation, reconnect backoff, and stale-connection callback isolation from Phase 0.
+- Do not export sensitive action-reference values through identifiers, metadata, messages, diagnostics, or JSON.
+
+## Explicit non-goals
+
+- Action execution, confirmation UI, or foreground-interactive actions.
+- Typed/sensitive input transport, saved-preset execution, or parameter-value flags.
+- Separate workflow commands, history, progress streaming, plugin management, or MCP.
+- Public release packaging, notarization, Homebrew integration, or embedding the CLI in the app.
+- A public third-party protocol or network control surface.
+- Refactoring unrelated action invocation surfaces or reopening #338.
+
+## Implementation sequence
+
+- [ ] Finalize identifiers, pagination, eligibility reasons, compatibility behavior, and JSON fixtures.
+- [ ] Add independent discovery wire models and codec/semantic tests.
+- [ ] Implement a host-owned read-only catalog adapter using the existing registry and the dedicated CLI exposure policy.
+- [ ] Connect the three commands to the authenticated transport and add human/JSON renderers.
+- [ ] Add client/host lifecycle and regression tests, then run the [Phase 1 test checklist](../../testing/cli-phase-1.md).
+- [ ] Update `README.md` and an app changelog fragment when the commands are actually implemented.
+- [ ] Keep the PR draft until implementation, required checks, and a fresh code review are complete.
+
+## Compatibility evidence
+
+Phase 0 recorded signed runtime testing on macOS 26 and 27. Its PR still listed macOS 14/15 evidence as outstanding; the merge itself is not proof of that compatibility. Track and obtain that evidence before declaring the optional CLI ready for public release, while testing Phase 1 development on the available macOS 26/27 machines.

--- a/docs/testing/cli-phase-1.md
+++ b/docs/testing/cli-phase-1.md
@@ -68,6 +68,8 @@ Focused XCTest classes are `CLIActionDiscoveryTests`, `CLIDiscoveryProtocolTests
 
 The initial local validation passed 51 focused tests, 145 script tests, all 3,062 XCTest tests, changelog validation, and the PluginKit v5 binary-compatibility client. One existing 0.1-second callback expectation and one existing timed preferences-backup test each failed once under load; unchanged-source retries passed. These are recorded as transient verification events, not waived failures. Review subsequently added boundary coverage for eight-level workflows and terminal-page catalog limits; final check counts and review evidence are tracked in the PR.
 
+A later full-suite run exposed an Apple Shortcuts test that assumed `NSCache` would retain an inserted entry. The cache wrapper and controller tests now use controllable storage for deterministic hit, eviction, replacement, removal, and byte-cost checks; production still defaults to memory-pressure-aware `NSCache`. This test-stability fix and the compiler workaround are included in the same Phase 1 PR.
+
 The same Xcode 26.6 / Swift 6.3.3 build was development-signed and tested on:
 
 | Machine | OS/build | Signed smoke checks | Longest successful command |

--- a/docs/testing/cli-phase-1.md
+++ b/docs/testing/cli-phase-1.md
@@ -1,0 +1,56 @@
+# CLI Phase 1 implementation and test checklist
+
+Status: planned, not executed. This documentation-only change does not add discovery commands. Follow the [Phase 1 contract](../superpowers/specs/2026-08-26-cli-phase-1-discovery.md) and retain the [Phase 0 tests](cli-phase-0.md) as regression coverage.
+
+## Protocol and parsing
+
+- [ ] Human and JSON output for all three discovery commands.
+- [ ] Invalid syntax, unknown identifiers, unsupported commands, and rejection of execution/parameter-input flags.
+- [ ] Old/new CLI, broker, and host combinations: discovery support is negotiated, compatible diagnostics continue working, unsupported discovery fails clearly and promptly.
+- [ ] JSON shape, semantic validation, stable exit codes, unknown/duplicate fields, malformed identifiers, invalid page sizes/cursors, and message-size limits.
+- [ ] Large catalogs, stable ordering, bounded pages, and provider-generation changes between pages.
+
+## Host authority and policy
+
+- [ ] Catalog results come only from the host registry, with no plugin loading or host-configuration reads in the CLI/broker.
+- [ ] Ready, empty, startup-delayed, and failed registry states are distinguishable without hanging.
+- [ ] Current availability is separate from eligibility; unavailable but discoverable actions retain useful sanitized reasons.
+- [ ] CLI exclusions apply consistently to list, describe, and availability, including guessed identifiers.
+- [ ] Safe/background/automatic/portable eligibility is independent of Run Link exposure.
+- [ ] Missing/reloaded providers and changing availability produce fresh, consistent results.
+- [ ] Distinct canonical references or presets cannot collide through identifier simplification.
+- [ ] Workflow dependency checks reject missing, cyclic, or ineligible graphs without introducing workflow-specific IPC.
+- [ ] Sensitive reference values, defaults, inputs, and examples never appear in output or diagnostics.
+- [ ] Discovery invokes no action handlers and triggers no action confirmation, permission prompt, or feature-configuration mutation.
+
+## Transport regressions
+
+- [ ] Same-user, exact-role, Apple-anchor, and signing-team authentication still fail closed.
+- [ ] Integration disabled, approval required, app closed, broker unavailable, and interrupted connections retain bounded behavior.
+- [ ] Terminal startup failure, request timeout, and SIGINT cancellation invalidate XPC state; cleanup stays inside the absolute command deadline.
+- [ ] Backoff resets only for a current authenticated registration; old callbacks cannot affect a newer connection.
+
+## Required implementation verification
+
+- [ ] Run the smallest affected XCTest methods/classes first; record exact commands and results.
+- [ ] Run `make ci` before pushing cross-module or PluginKit changes. This includes script tests and compatibility validation.
+- [ ] Run signed local smoke tests on macOS 26 (`mini`) and macOS 27 (`m5.local`), recording commit, OS version, signing identity, installation path, outputs, and exit codes.
+- [ ] Test hot and cold host startup using a stable separately installed CLI path; verify that the app embeds only its broker.
+- [ ] Obtain a fresh independent review after implementation and resolve accepted findings before marking ready.
+
+These are proposed smoke commands after implementation; use an identifier returned by `actions list`, not an assumed built-in action ID:
+
+```bash
+mactools version --json
+mactools doctor --json
+mactools actions list --json
+mactools actions describe 'provider/action' --json
+mactools actions availability 'provider/action' --json
+```
+
+## Public-release compatibility follow-up
+
+- [ ] Obtain signed runtime evidence on macOS 14 and macOS 15. Do not mark this complete based on the Phase 0 merge or macOS 26/27 results.
+- [ ] Resolve the documented installation-path behavior before promising a public installation workflow.
+
+Public release packaging is a later change; this checklist does not authorize signing, notarization, release publication, or changes to remote test machines by itself.

--- a/docs/testing/cli-phase-1.md
+++ b/docs/testing/cli-phase-1.md
@@ -1,56 +1,95 @@
 # CLI Phase 1 implementation and test checklist
 
-Status: planned, not executed. This documentation-only change does not add discovery commands. Follow the [Phase 1 contract](../superpowers/specs/2026-08-26-cli-phase-1-discovery.md) and retain the [Phase 0 tests](cli-phase-0.md) as regression coverage.
+Discovery is implemented. This guide defines acceptance coverage; the PR tracks current check/review status, not public-release readiness. Follow the [Phase 1 contract](../superpowers/specs/2026-08-26-cli-phase-1-discovery.md) and use the [Phase 0 setup guide](cli-phase-0.md) to build the signed app and separate CLI, enable Command Line, and approve its background item if required.
 
 ## Protocol and parsing
 
-- [ ] Human and JSON output for all three discovery commands.
-- [ ] Invalid syntax, unknown identifiers, unsupported commands, and rejection of execution/parameter-input flags.
-- [ ] Old/new CLI, broker, and host combinations: discovery support is negotiated, compatible diagnostics continue working, unsupported discovery fails clearly and promptly.
-- [ ] JSON shape, semantic validation, stable exit codes, unknown/duplicate fields, malformed identifiers, invalid page sizes/cursors, and message-size limits.
-- [ ] Large catalogs, stable ordering, bounded pages, and provider-generation changes between pages.
+- Human and JSON output for all three discovery commands.
+- Invalid syntax, unknown identifiers, unsupported commands, and rejection of execution/parameter-input flags.
+- Old/new CLI, broker, and host combinations: discovery support is negotiated, compatible diagnostics continue working, unsupported discovery fails clearly and promptly.
+- JSON shape, semantic validation, stable exit codes, unknown/duplicate fields, malformed identifiers, invalid page sizes/cursors, and message-size limits.
+- Large catalogs, stable ordering, bounded pages, and provider-generation changes between pages.
 
 ## Host authority and policy
 
-- [ ] Catalog results come only from the host registry, with no plugin loading or host-configuration reads in the CLI/broker.
-- [ ] Ready, empty, startup-delayed, and failed registry states are distinguishable without hanging.
-- [ ] Current availability is separate from eligibility; unavailable but discoverable actions retain useful sanitized reasons.
-- [ ] CLI exclusions apply consistently to list, describe, and availability, including guessed identifiers.
-- [ ] Safe/background/automatic/portable eligibility is independent of Run Link exposure.
-- [ ] Missing/reloaded providers and changing availability produce fresh, consistent results.
-- [ ] Distinct canonical references or presets cannot collide through identifier simplification.
-- [ ] Workflow dependency checks reject missing, cyclic, or ineligible graphs without introducing workflow-specific IPC.
-- [ ] Sensitive reference values, defaults, inputs, and examples never appear in output or diagnostics.
-- [ ] Discovery invokes no action handlers and triggers no action confirmation, permission prompt, or feature-configuration mutation.
+- Catalog results come only from the host registry, with no plugin loading or host-configuration reads in the CLI/broker.
+- Ready, empty, startup-delayed, and failed registry states are distinguishable without hanging.
+- Current availability is separate from eligibility; unavailable but discoverable actions retain useful sanitized reasons.
+- CLI exclusions apply consistently to list, describe, and availability, including guessed identifiers.
+- Safe/background/automatic/portable eligibility is independent of Run Link exposure.
+- Missing/reloaded providers and changing availability produce fresh, consistent results.
+- Distinct canonical references or presets cannot collide through identifier simplification.
+- Workflow dependency checks reject missing, cyclic, or ineligible graphs without introducing workflow-specific IPC.
+- Sensitive reference values, defaults, inputs, and examples never appear in output or diagnostics.
+- Discovery invokes no action handlers and triggers no action confirmation, permission prompt, or feature-configuration mutation.
 
 ## Transport regressions
 
-- [ ] Same-user, exact-role, Apple-anchor, and signing-team authentication still fail closed.
-- [ ] Integration disabled, approval required, app closed, broker unavailable, and interrupted connections retain bounded behavior.
-- [ ] Terminal startup failure, request timeout, and SIGINT cancellation invalidate XPC state; cleanup stays inside the absolute command deadline.
-- [ ] Backoff resets only for a current authenticated registration; old callbacks cannot affect a newer connection.
+- Same-user, exact-role, Apple-anchor, and signing-team authentication still fail closed.
+- Integration disabled, approval required, app closed, broker unavailable, and interrupted connections retain bounded behavior.
+- Terminal startup failure, request timeout, and SIGINT cancellation invalidate XPC state; cleanup stays inside the absolute command deadline.
+- Backoff resets only for a current authenticated registration; old callbacks cannot affect a newer connection.
 
 ## Required implementation verification
 
-- [ ] Run the smallest affected XCTest methods/classes first; record exact commands and results.
-- [ ] Run `make ci` before pushing cross-module or PluginKit changes. This includes script tests and compatibility validation.
-- [ ] Run signed local smoke tests on macOS 26 (`mini`) and macOS 27 (`m5.local`), recording commit, OS version, signing identity, installation path, outputs, and exit codes.
-- [ ] Test hot and cold host startup using a stable separately installed CLI path; verify that the app embeds only its broker.
-- [ ] Obtain a fresh independent review after implementation and resolve accepted findings before marking ready.
+- Run the smallest affected XCTest methods/classes first; record exact commands and results.
+- Run `make ci` before pushing cross-module or PluginKit changes. This includes script tests and compatibility validation.
+- Run signed local smoke tests on macOS 26 (`mini`) and macOS 27 (`m5.local`), recording commit, OS version, signing identity, installation path, outputs, and exit codes.
+- Test hot and cold host startup using a stable separately installed CLI path; verify that the app embeds only its broker.
+- Obtain a fresh independent review after implementation and resolve accepted findings before marking ready.
 
-These are proposed smoke commands after implementation; use an identifier returned by `actions list`, not an assumed built-in action ID:
+Use an absolute executable path or a separately installed `mactools` on PATH. Copy the complete ID returned by `actions list`, including any opaque suffix; do not assume a built-in ID:
 
 ```bash
 mactools version --json
 mactools doctor --json
 mactools actions list --json
-mactools actions describe 'provider/action' --json
-mactools actions availability 'provider/action' --json
+mactools actions list --page-size 2 --json
+mactools actions describe 'ID-FROM-LIST' --json
+mactools actions availability 'ID-FROM-LIST' --json
+mactools actions list --cursor 'CURSOR-FROM-PREVIOUS-PAGE' --json
 ```
+
+Negative checks:
+
+```bash
+mactools actions list --page-size 0 --json
+mactools actions list --cursor invalid --json
+mactools actions describe missing/action --json
+mactools actions run missing/action --json
+mactools actions list --parameter enabled=true --json
+```
+
+Malformed/unsupported commands exit 2; unknown/non-discoverable IDs exit 3. Availability can be false while inspection exits 0. An old Phase 0 component yields discovery exit 10 while diagnostics remain compatible. Unready/disabled integration exits 9 within the deadline; interruption exits 8. Discovery never executes actions.
+
+Focused XCTest classes are `CLIActionDiscoveryTests`, `CLIDiscoveryProtocolTests`, `CLIHostDiscoveryTests`, `CLIArgumentParserTests`, and `CLIExecutableTests`, plus existing transport/security tests. Then run `make ci` for the full suite, script tests, changelog validation, and PluginKit binary compatibility.
+
+## Development evidence (2026-08-27)
+
+The initial local validation passed 51 focused tests, 145 script tests, all 3,062 XCTest tests, changelog validation, and the PluginKit v5 binary-compatibility client. One existing 0.1-second callback expectation and one existing timed preferences-backup test each failed once under load; unchanged-source retries passed. These are recorded as transient verification events, not waived failures. Review subsequently added boundary coverage for eight-level workflows and terminal-page catalog limits; final check counts and review evidence are tracked in the PR.
+
+The same Xcode 26.6 / Swift 6.3.3 build was development-signed and tested on:
+
+| Machine | OS/build | Signed smoke checks | Longest successful command |
+| --- | --- | --- | --- |
+| mini | macOS 26.6.2 / 25G83 | 17 passed | 0.54 seconds |
+| m5.local | macOS 27.0 / 26A5421a | 17 passed | 0.50 seconds |
+
+The checks covered help, version, doctor, human/JSON discovery, two-page traversal, descriptions and availability using complete opaque IDs, invalid sizes/cursors, unknown targets, rejected execution/parameter input, cold launch, and stale cursors after restart. Only the Night Shift plugin was installed in the QA data directory; no action was executed. The first macOS 27 doctor call immediately after service registration returned a transient host-transport error; the host stayed alive, a subsequent doctor succeeded, and the complete unchanged-artifact retry passed.
+
+QA artifacts use a separate app/broker/CLI identity and URL scheme, an isolated home through signed artifact `LSEnvironment`, and a separate Finder configuration path. Home/Application Support isolation was independently probed on both OS versions before app launch. Existing Dev app instances were not stopped or overwritten. App, broker, and standalone CLI signatures were verified with the existing development signing team.
+
+Paths on both machines:
+
+- App: `/Users/yihong/Applications/MacTools CLI Phase1 QA.app`
+- CLI: `/Users/yihong/Library/Application Support/MacTools CLI Phase1 QA/bin/mactools`
+- QA data: `/Users/yihong/Library/Application Support/MacTools CLI Phase1 QA/Home`
+
+These artifacts are for development testing only, not notarized public distribution. Final independent-review and GitHub CI evidence belongs in the PR.
 
 ## Public-release compatibility follow-up
 
-- [ ] Obtain signed runtime evidence on macOS 14 and macOS 15. Do not mark this complete based on the Phase 0 merge or macOS 26/27 results.
-- [ ] Resolve the documented installation-path behavior before promising a public installation workflow.
+- Obtain signed runtime evidence on macOS 14 and macOS 15. Do not mark this complete based on the Phase 0 merge or macOS 26/27 results.
+- Resolve the documented installation-path behavior before promising a public installation workflow.
 
 Public release packaging is a later change; this checklist does not authorize signing, notarization, release publication, or changes to remote test machines by itself.

--- a/project.yml
+++ b/project.yml
@@ -88,6 +88,7 @@ targets:
       - "../Plugins/**"
       - Plugins/**/CalendarPluginResources/**
     - path: Sources/MacToolsCLI/CLIArgumentParser.swift
+    - path: Sources/MacToolsCLI/CLIOutput.swift
     - path: Sources/MacToolsCLI/CLIStartupDeadline.swift
     - path: Sources/MacToolsCLI/CLISignalCoordinator.swift
     dependencies:


### PR DESCRIPTION
## Summary

Implements the narrow, read-only CLI discovery phase following merged #340 and RFC #309. All implementation, compiler-workaround, and test-stability changes are contained in this PR. Implementation, required validation, and independent review are complete: ready for code review and development testing, not a public CLI release. The broad prototype #338 remains closed/reference-only.

```text
mactools actions list [--page-size N] [--cursor CURSOR] [--json]
mactools actions describe ID [--json]
mactools actions availability ID [--json]
```

Discovery is host-owned. The standalone CLI does not link PluginKit, load plugins, or read host settings. The broker retains forwarding/lifecycle duties, and the app does not embed the CLI executable.

## Contract and safety

- Only exact published registry references satisfying safe/background/automatic/portable eligibility are discoverable. CLI exposure is independent of Run Links and enforced for all three commands.
- Unavailable eligible actions remain discoverable; availability is checked live and exports only a sanitized reason code.
- Parameterized entries have distinct opaque IDs. Saved parameter values, preset labels, defaults, and examples are not exported. Copy the complete ID from list.
- Metadata and catalogs are bounded; pagination rejects stale cursors across catalog changes or host restarts. Closed JSON shapes, duplicate-field rejection, and semantic validation apply before output.
- Workflow dependency traversal fails closed for missing/ineligible/cyclic graphs and preserves the existing eight-workflow depth limit.
- Discovery requires protocol v2; compatible v1 diagnostics remain supported. Readiness waits are bounded; existing authentication, cancellation, reconnect, and absolute-deadline behavior are retained.

No execution, parameter input, workflow/plugin command groups, history/progress streaming, public packaging, or notarization is included.

## Build and test fixes included here

- Retain the Swift 6.3.3 compiler workaround: separate event-tap resource preparation from queue startup without changing locked state publication, cleanup, or the readiness handshake. #353 contains the same patch as a separate draft reference; it is not a dependency of this PR.
- Resolve a repeated Apple Shortcuts test failure caused by assuming `NSCache` retains entries. An internal storage-injection seam enables deterministic wrapper/controller tests for hits, eviction, replacement, clearing, limits, and byte costs. Production still defaults to memory-pressure-aware `NSCache`; no compiler checks or test assertions are disabled.

## Validation at `3671d095`

Current head `c1c97051` is an empty CI-trigger commit with the identical source tree. It does not change the tested/reviewed code or installed QA artifacts.

| Check | Result |
| --- | --- |
| Apple Shortcuts cache/controller tests | 30 passed |
| CLI protocol/discovery/parser/output/lifecycle/security tests | 53 passed |
| Full `make ci` | 3,067 XCTest tests, 145 script tests, changelog validation, and PluginKit v5 binary compatibility passed |
| Signed development build | Passed |
| mini: macOS 26.6.2 / 25G83 | 17 signed smoke checks passed; longest successful command 0.52s |
| m5.local: macOS 27.0 / 26A5421a | 17 signed smoke checks passed; longest successful command 0.50s |
| Independent review | Two rounds; final fresh two-stage review CLEAN |
| GitHub CI | [Passed on the source-identical retry](https://github.com/ggbond268/MacTools/actions/runs/33092213606); fork-PR artifact/unsigned Release steps are conditionally skipped |

Round 1 found two boundary bugs: counting ordinary leaf actions toward workflow depth and accepting an oversized terminal page. Both were fixed, covered by boundary tests, and independently reconciled in round 2. Tests and review were bound to an unchanged whole-repository source fingerprint; the local branch is clean and matches the pushed commit.

The signed smoke suites cover help/version/doctor, human/JSON discovery, pagination, descriptions and availability using full IDs, malformed sizes/cursors, unknown targets, execution/parameter-input rejection, cold launch, and stale cursors. Only Night Shift was installed in the isolated QA catalog; no action was executed. The refreshed QA artifacts contain the final fixes. Existing Dev apps were not stopped or overwritten.

### Recorded verification events

Earlier runs exposed timing-sensitive callback, preferences-backup, and Homebrew cancellation failures; evidence-backed unchanged-source retries passed. The repeated cache-test failure was fixed rather than waived. The final focused/full-suite run passed without retries.

The first pushed-head GitHub run failed only `AutomationControllerTests.testActiveRunCanBeCancelledThroughControllerSurface`, an unchanged test using a fixed 100-yield wait. It passed in the local full suite and the single source-identical CI retry. Direct upstream rerun requires admin rights, so an empty commit on this fork branch requested the same CI through the normal pull-request workflow; no source or workflow checks were changed. That timing-sensitive test remains a potential future test-maintenance concern, not a waived failing check.

The first refreshed macOS 26 smoke attempt encountered the old QA broker still running after manual binary replacement. Security logs showed a code-signing hash mismatch. Restarting only the verified task-owned service allowed the single unchanged-artifact retry to pass. Manual development upgrades must restart the broker as well as the app; authentication was not weakened. An earlier macOS 27 call immediately after first service registration returned a bounded host-transport error; subsequent complete smoke runs passed.

## Test artifacts and release follow-ups

Updated signed development artifacts are installed on both test machines:

- App: `/Users/yihong/Applications/MacTools CLI Phase1 QA.app`
- CLI: `/Users/yihong/Library/Application Support/MacTools CLI Phase1 QA/bin/mactools`

They use unique app/broker/CLI identities, an isolated home, and a separate Finder configuration path. They are not notarized public-distribution packages.

Signed runtime evidence on macOS 14/15 and a public installation/distribution workflow remain release follow-ups. macOS 26/27 testing is not evidence for those older systems.

See the [implementation contract](https://github.com/xcv58/MacTools/blob/codex/issue-309-cli-phase-1/docs/superpowers/specs/2026-08-26-cli-phase-1-discovery.md) and [test guide](https://github.com/xcv58/MacTools/blob/codex/issue-309-cli-phase-1/docs/testing/cli-phase-1.md).

Related to #309; follows #340 and the maintainer's [RFC guidance](https://github.com/ggbond268/MacTools/issues/309#issuecomment-5386412095).
