### PR TITLE
Fix Swift 6.3.3 compiler crash in modifier drag startup

### DIFF
--- a/Plugins/WindowLayouts/Sources/WindowModifierDragEventMonitor.swift
+++ b/Plugins/WindowLayouts/Sources/WindowModifierDragEventMonitor.swift
@@ -69,6 +69,34 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
             stop()
         }
 
+        let readySignal = DispatchSemaphore(value: 0)
+        let finishedSignal = DispatchSemaphore(value: 0)
+        switch prepareEventTap(handler: handler, readySignal: readySignal, finishedSignal: finishedSignal) {
+        case .success:
+            break
+        case let .failure(error):
+            return .failure(error)
+        }
+
+        eventQueue.async { [self] in
+            runEventLoop()
+        }
+        readySignal.wait()
+
+        guard isRunning else {
+            stop()
+            return .failure(.eventLoopUnavailable)
+        }
+        return .success(())
+    }
+
+    // Keep Core Foundation resource setup separate from queue startup to avoid a Swift 6.3.3
+    // SendNonSendable compiler crash. Publish all startup state under the same lock.
+    private func prepareEventTap(
+        handler: WindowModifierDragEventHandler,
+        readySignal: DispatchSemaphore,
+        finishedSignal: DispatchSemaphore
+    ) -> Result<Void, WindowModifierDragMonitorStartError> {
         let eventMask = CGEventMask(1 << CGEventType.flagsChanged.rawValue)
             | CGEventMask(1 << CGEventType.mouseMoved.rawValue)
             | CGEventMask(1 << CGEventType.leftMouseDown.rawValue)
@@ -95,8 +123,6 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
             return .failure(.runLoopSourceUnavailable)
         }
 
-        let readySignal = DispatchSemaphore(value: 0)
-        let finishedSignal = DispatchSemaphore(value: 0)
         lock.withLock {
             self.tap = tap
             self.source = source
@@ -105,15 +131,6 @@ nonisolated final class SystemWindowModifierDragEventMonitor: @unchecked Sendabl
             self.finishedSignal = finishedSignal
             self.eventHandler = handler
             shouldRun = true
-        }
-        eventQueue.async { [self] in
-            runEventLoop()
-        }
-        readySignal.wait()
-
-        guard isRunning else {
-            stop()
-            return .failure(.eventLoopUnavailable)
         }
         return .success(())
     }


### PR DESCRIPTION
Extract event-tap setup from queue startup to avoid a reproducible Swift 6.3.3 SendNonSendable compiler crash inherited by main. Preserve atomic startup-state publication, cleanup, and readiness behavior. No compiler checks are disabled.

Extracted unchanged from 5a9e5080 in #352 so main can be fixed independently of CLI Phase 1. The identical patch passed local make ci (145 script tests, 3,044 XCTest tests, PluginKit v5 binary compatibility).

This branch GitHub Build and test passed on 88adb19b: https://github.com/ggbond268/MacTools/actions/runs/33038220240. A fresh read-only review of the cumulative Phase 1 delta inspected this extraction and found no actionable issue in it; that larger review found two CLI boundary issues instead. Those CLI fixes are not part of this PR.

Kept as draft pending a completed final review gate. No merge or release has been performed.