### PR TITLE
Add System Status global shortcut

### DIFF
--- a/Plugins/SystemStatus/Resources/Localizable.xcstrings
+++ b/Plugins/SystemStatus/Resources/Localizable.xcstrings
@@ -1,6 +1,219 @@
 {
   "sourceLanguage": "zh-Hans",
   "strings": {
+    "action.showSystemStatus.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض حالة النظام"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemstatus anzeigen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show System Status"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar estado del sistema"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l’état du système"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムステータスを表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 상태 보기"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar status do sistema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать состояние системы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示系统状态"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示系統狀態"
+          }
+        }
+      }
+    },
+    "action.showSystemStatus.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض أو إخفاء نظرة عامة من شريط القوائم. إذا كانت مقاييس شريط القوائم مخفية، تُفتح لوحة المعلومات بدلاً من ذلك."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeigt oder verbirgt die Übersicht in der Menüleiste. Sind Menüleistenmetriken ausgeblendet, wird stattdessen das Dashboard geöffnet."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows or hides the menu bar overview. If menu bar metrics are hidden, opens the dashboard instead."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra u oculta el resumen de la barra de menús. Si las métricas están ocultas, abre el panel."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affiche ou masque l’aperçu de la barre des menus. Si les métriques sont masquées, ouvre le tableau de bord."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーの概要を表示または非表示にします。指標が非表示の場合は、代わりにダッシュボードを開きます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대 개요를 표시하거나 가립니다. 메뉴 막대 측정항목이 가려져 있으면 대시보드를 엽니다."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra ou oculta a visão geral da barra de menus. Se as métricas estiverem ocultas, abre o painel."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывает или скрывает обзор в строке меню. Если показатели скрыты, открывает панель."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示或隐藏菜单栏概览。如果菜单栏指标已隐藏，则改为打开仪表盘。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示或隱藏選單列概覽。如果選單列指標已隱藏，則改為打開儀表板。"
+          }
+        }
+      }
+    },
+    "settings.shortcuts.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختصار لوحة المفاتيح"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturkurzbefehl"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard Shortcut"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atajo de teclado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raccourci clavier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードショートカット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 단축키"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atalho de teclado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сочетание клавиш"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵盤快捷鍵"
+          }
+        }
+      }
+    },
     "metadata.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Plugins/SystemStatus/Sources/SystemStatusMenuBarMetricsController.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusMenuBarMetricsController.swift
@@ -1161,6 +1161,19 @@ final class SystemStatusMenuBarMetricsController: NSObject {
         removeStatusItem()
     }
 
+    func presentSystemStatus() {
+        let button = statusItem?.button
+        switch SystemStatusShortcutPresentationPolicy.destination(
+            hasMenuBarButton: button != nil
+        ) {
+        case .menuBarOverview:
+            guard let button else { return }
+            localPopoverController.toggle(relativeTo: button)
+        case .dashboard:
+            requestDashboardPresentation?()
+        }
+    }
+
     private func observeState() {
         settingsController.$configuration
             .removeDuplicates()
@@ -1318,6 +1331,17 @@ final class SystemStatusMenuBarMetricsController: NSObject {
     @objc
     private func openActivityMonitor() {
         SystemStatusProcessActions.openActivityMonitor()
+    }
+}
+
+enum SystemStatusShortcutPresentationPolicy {
+    enum Destination: Equatable {
+        case menuBarOverview
+        case dashboard
+    }
+
+    static func destination(hasMenuBarButton: Bool) -> Destination {
+        hasMenuBarButton ? .menuBarOverview : .dashboard
     }
 }
 

--- a/Plugins/SystemStatus/Sources/SystemStatusPlugin.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusPlugin.swift
@@ -24,6 +24,8 @@ private struct SystemStatusPluginProvider: PluginProvider {
 @MainActor
 final class SystemStatusPlugin:
     MacToolsPlugin,
+    PluginActionProviding,
+    PluginActionShortcutSettingsProviding,
     PluginComponentPanel,
     PluginPanelSurfaceLifecycleHandling,
     PluginSettingsPresenting,
@@ -33,6 +35,10 @@ final class SystemStatusPlugin:
     PluginPortablePreferencesRestorationReporting,
     PluginPersistentPreferencesChangeSignaling
 {
+    private enum ActionID {
+        static let showSystemStatus = "show-system-status"
+    }
+
     let metadata: PluginMetadata
 
     var descriptor: PluginComponentDescriptor {
@@ -128,6 +134,35 @@ final class SystemStatusPlugin:
 
     var permissionRequirements: [PluginPermissionRequirement] { [] }
     var shortcutDefinitions: [PluginShortcutDefinition] { [] }
+
+    var actionShortcutSettingsConfiguration: PluginActionShortcutSettingsConfiguration {
+        PluginActionShortcutSettingsConfiguration(
+            title: localization.string(
+                "settings.shortcuts.title",
+                defaultValue: "快捷键"
+            ),
+            systemImage: "command",
+            actionIDs: [ActionID.showSystemStatus],
+            placementAfterSectionID: "menu-bar-metrics"
+        )
+    }
+
+    var actionDefinitions: [ActionDefinition] {
+        [
+            ActionDefinition(
+                key: ActionKey(
+                    providerID: metadata.id,
+                    actionID: ActionID.showSystemStatus
+                ),
+                title: actionTitle,
+                description: actionDescription,
+                keywords: [metadata.title, actionTitle],
+                systemImage: metadata.iconName,
+                externalInvocationPolicy: .unavailable,
+                capabilities: [.foregroundInteractive]
+            ),
+        ]
+    }
 
     var settingsPage: PluginSettingsPage? {
         .form(description: metadata.defaultDescription, sections: [
@@ -260,6 +295,31 @@ final class SystemStatusPlugin:
     func handlePermissionAction(id: String) {}
     func handleSettingsAction(_ action: PluginSettingsAction) {}
     func handleShortcutAction(id: String) {}
+
+    func beginAction(_ invocation: ActionInvocation) throws -> ActionExecutionHandle {
+        guard invocation.reference.key.providerID == metadata.id,
+              invocation.reference.key.actionID == ActionID.showSystemStatus else {
+            return ActionExecutionHandle {
+                .failed(message: PluginKitLocalization.actionUnavailable)
+            }
+        }
+        menuBarMetricsController.presentSystemStatus()
+        return ActionExecutionHandle { .succeeded() }
+    }
+
+    private var actionTitle: String {
+        localization.string(
+            "action.showSystemStatus.title",
+            defaultValue: "显示系统状态"
+        )
+    }
+
+    private var actionDescription: String {
+        localization.string(
+            "action.showSystemStatus.description",
+            defaultValue: "显示或隐藏菜单栏概览。如果菜单栏指标已隐藏，则改为打开仪表盘。"
+        )
+    }
 }
 
 @MainActor

--- a/Plugins/SystemStatus/Tests/SystemStatusPluginTests.swift
+++ b/Plugins/SystemStatus/Tests/SystemStatusPluginTests.swift
@@ -173,6 +173,45 @@ final class SystemStatusPluginTests: XCTestCase {
         )
     }
 
+    func testSystemStatusActionUsesMenuBarOverviewWhenAvailableAndDashboardOtherwise() {
+        XCTAssertEqual(
+            SystemStatusShortcutPresentationPolicy.destination(hasMenuBarButton: true),
+            .menuBarOverview
+        )
+        XCTAssertEqual(
+            SystemStatusShortcutPresentationPolicy.destination(hasMenuBarButton: false),
+            .dashboard
+        )
+    }
+
+    func testSystemStatusActionAndShortcutSettingsDescribeOneOptionalGlobalAction() async throws {
+        let plugin = SystemStatusPlugin(storage: SystemStatusMemoryPluginStorage())
+        XCTAssertEqual(plugin.actionDefinitions.count, 1)
+        let definition = try XCTUnwrap(plugin.actionDefinitions.first)
+
+        XCTAssertEqual(definition.key.providerID, "system-status")
+        XCTAssertEqual(definition.key.actionID, "show-system-status")
+        XCTAssertEqual(definition.externalInvocationPolicy, .unavailable)
+        XCTAssertEqual(definition.capabilities, [.foregroundInteractive])
+        XCTAssertTrue(plugin.shortcutDefinitions.isEmpty)
+
+        let configuration = plugin.actionShortcutSettingsConfiguration
+        XCTAssertEqual(configuration.actionIDs, ["show-system-status"])
+        XCTAssertEqual(configuration.placementAfterSectionID, "menu-bar-metrics")
+        XCTAssertNil(configuration.description)
+
+        var dashboardPresentationCount = 0
+        plugin.requestDashboardPresentation = { dashboardPresentationCount += 1 }
+        let result = try await plugin.beginAction(ActionInvocation(
+            reference: ActionReference(key: definition.key),
+            source: .test,
+            mode: .foreground
+        )).result()
+
+        XCTAssertEqual(result, .succeeded())
+        XCTAssertEqual(dashboardPresentationCount, 1)
+    }
+
     func testConfigurationDefaultsShowPanelMetricsAndHideMenuBarMetrics() {
         let controller = SystemStatusSettingsController(
             store: SystemStatusPluginStorageConfigurationStore(storage: SystemStatusMemoryPluginStorage())
@@ -830,6 +869,8 @@ final class SystemStatusPluginTests: XCTestCase {
                 .map(\.rawValue)
         )
         let exactKeys: Set<String> = [
+            "action.showSystemStatus.description",
+            "action.showSystemStatus.title",
             "disk.availableUnitFormat",
             "chart.range30Minutes",
             "chart.range2Hours",
@@ -867,6 +908,7 @@ final class SystemStatusPluginTests: XCTestCase {
             "settings.menuBarValue.first",
             "settings.menuBarValue.secondOptional",
             "settings.metric.reorderAccessibility",
+            "settings.shortcuts.title",
             "topProcesses.openActivityMonitor",
             "topProcesses.sortHelpFormat",
         ]

--- a/Plugins/SystemStatus/plugin.json
+++ b/Plugins/SystemStatus/plugin.json
@@ -51,6 +51,32 @@
   "productStrings": {
     "display-name": "@displayName",
     "summary": "@summary",
+    "action.show-system-status.title": {
+      "ar": "عرض حالة النظام",
+      "de": "Systemstatus anzeigen",
+      "en": "Show System Status",
+      "es": "Mostrar estado del sistema",
+      "fr": "Afficher l’état du système",
+      "ja": "システムステータスを表示",
+      "ko": "시스템 상태 보기",
+      "pt": "Mostrar status do sistema",
+      "ru": "Показать состояние системы",
+      "zh-Hans": "显示系统状态",
+      "zh-Hant": "顯示系統狀態"
+    },
+    "action.show-system-status.description": {
+      "ar": "عرض أو إخفاء نظرة عامة من شريط القوائم. إذا كانت مقاييس شريط القوائم مخفية، تُفتح لوحة المعلومات بدلاً من ذلك.",
+      "de": "Zeigt oder verbirgt die Übersicht in der Menüleiste. Sind Menüleistenmetriken ausgeblendet, wird stattdessen das Dashboard geöffnet.",
+      "en": "Shows or hides the menu bar overview. If menu bar metrics are hidden, opens the dashboard instead.",
+      "es": "Muestra u oculta el resumen de la barra de menús. Si las métricas están ocultas, abre el panel.",
+      "fr": "Affiche ou masque l’aperçu de la barre des menus. Si les métriques sont masquées, ouvre le tableau de bord.",
+      "ja": "メニューバーの概要を表示または非表示にします。指標が非表示の場合は、代わりにダッシュボードを開きます。",
+      "ko": "메뉴 막대 개요를 표시하거나 가립니다. 메뉴 막대 측정항목이 가려져 있으면 대시보드를 엽니다.",
+      "pt": "Mostra ou oculta a visão geral da barra de menus. Se as métricas estiverem ocultas, abre o painel.",
+      "ru": "Показывает или скрывает обзор в строке меню. Если показатели скрыты, открывает панель.",
+      "zh-Hans": "显示或隐藏菜单栏概览。如果菜单栏指标已隐藏，则改为打开仪表盘。",
+      "zh-Hant": "顯示或隱藏選單列概覽。如果選單列指標已隱藏，則改為打開儀表板。"
+    },
     "retention-description": {
       "ar": "تظل الإعدادات محفوظة حتى إزالة بيانات الإضافة. يقتصر سجل الأداء على 24 ساعة و8640 عينة.",
       "de": "Einstellungen bleiben bis zum Entfernen der Plug-in-Daten erhalten. Der Leistungsverlauf ist auf 24 Stunden und 8.640 Messwerte begrenzt.",
@@ -189,5 +215,39 @@
     "includedPackIDs": [],
     "suggestedRecipeIDs": [],
     "supersedesPluginIDs": []
+  },
+  "actions": {
+    "providers": [
+      {
+        "id": "system-status",
+        "kind": "static",
+        "staticActions": [
+          {
+            "id": "show-system-status",
+            "title": "@productStrings.action.show-system-status.title",
+            "description": "@productStrings.action.show-system-status.description",
+            "keywords": [
+              "系统状态",
+              "system status",
+              "monitoring",
+              "menu bar",
+              "dashboard"
+            ],
+            "systemImage": "gauge.with.dots.needle.67percent",
+            "parameters": [],
+            "permissionIDs": [],
+            "risk": "safe",
+            "surfaces": [
+              "unified-search",
+              "global-shortcut",
+              "manual"
+            ],
+            "automaticEligible": false,
+            "externalInvocation": "unavailable"
+          }
+        ],
+        "dynamicTemplates": []
+      }
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
 
 > **Shortcut settings:** Plugin and app shortcut rows keep the action icon/name beside the recorder field, wrapping groups between rows without splitting an individual shortcut control.
 
-> **System Status:** Both dashboard entry points keep readings current while open. Detail statistics use all retained readings in the selected range, independent of chart simplification, and pinned readings stay fixed until they leave that range. Expanded metric settings adapt to narrower windows. The updated plugin requires MacTools 1.2.1 or later.
+> **System Status:** Both dashboard entry points keep readings current while open. Detail statistics use all retained readings in the selected range, independent of chart simplification, and pinned readings stay fixed until they leave that range. Expanded metric settings adapt to narrower windows. An optional global shortcut shows the menu-bar overview when available and otherwise opens the dashboard. The updated plugin requires MacTools 1.2.1 or later.
 
 > **Pre-install plugin metadata:** The signed plugin catalog can disclose localized product details, requirements, privacy behavior, setup guidance, and static or dynamic action capabilities before a plugin is installed. The same validated metadata is available to Marketplace, search, onboarding, and website clients without loading plugin code or publishing machine-local action entries.
 

--- a/changes/unreleased/system-status-shortcut.md
+++ b/changes/unreleased/system-status-shortcut.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: added
+area: System Status
+---
+
+- Added an optional global shortcut for showing System Status from anywhere.


### PR DESCRIPTION
## Summary

- add an optional global shortcut for showing System Status
- toggle the existing menu-bar overview when menu-bar metrics are visible
- open the dashboard as a fallback when menu-bar metrics are hidden
- publish localized action metadata for search and shortcut surfaces

## UX

- place the shortcut directly after Menu Bar Metrics
- leave it unassigned by default
- reuse the canonical System Status action instead of adding a separate shortcut path

## Screenshot

<img width="1152" height="832" alt="System Status keyboard shortcut settings" src="https://github.com/user-attachments/assets/7e6da5d7-aeba-4dbc-accc-af5e2b46ca4c" />

## Validation

- `SystemStatusPluginTests`
- focused shortcut and localization tests after rebasing onto latest `main`
- 196 repository script tests
- 46 focused action-manifest and catalog tests
- rebuilt, installed, and interactively reviewed `MacTools Dev.app`
