### PR TITLE
fix(window-switcher): include windows from all Spaces

### DIFF
--- a/Plugins/DiskClean/Tests/DiskCleanPluginTests.swift
+++ b/Plugins/DiskClean/Tests/DiskCleanPluginTests.swift
@@ -159,7 +159,10 @@ final class DiskCleanPluginTests: XCTestCase {
         plugin.handleAction(.setDisclosureExpanded(true))
         let trashTitle = try XCTUnwrap(try cleanControl(of: plugin).actionTitle)
         XCTAssertTrue(trashTitle.hasPrefix("移到废纸篓 · 1 项 · 约"), "actual: \(trashTitle)")
-        XCTAssertTrue(trashTitle.contains("GB"), "actual: \(trashTitle)")
+        XCTAssertTrue(
+            trashTitle.hasSuffix("约 \(DiskCleanFormat.bytes(5_368_709_120))"),
+            "actual: \(trashTitle)"
+        )
 
         controller.snapshot = makeScannedSnapshot(
             candidates: candidates,
@@ -268,7 +271,10 @@ final class DiskCleanPluginTests: XCTestCase {
         let confirm = try XCTUnwrap(controls.first { $0.id == DiskCleanPlugin.ControlID.confirmClean })
         let confirmTitle = try XCTUnwrap(confirm.actionTitle)
         XCTAssertTrue(confirmTitle.hasPrefix("确认永久清理 3 项 · 约"), "actual: \(confirmTitle)")
-        XCTAssertTrue(confirmTitle.contains("GB"), "frozen byte count must appear in the confirmation copy")
+        XCTAssertTrue(
+            confirmTitle.hasSuffix("约 \(DiskCleanFormat.bytes(5_368_709_120))"),
+            "frozen byte count must appear in the confirmation copy: \(confirmTitle)"
+        )
     }
 
     func testConfirmAndCancelActionsForwardToController() {
@@ -308,7 +314,7 @@ final class DiskCleanPluginTests: XCTestCase {
         let subtitle = plugin.primaryPanelState.subtitle
         XCTAssertTrue(subtitle.hasPrefix("已移到废纸篓约"), "actual: \(subtitle)")
         XCTAssertFalse(subtitle.contains("已释放"), "objects in Trash have not truly freed space")
-        XCTAssertTrue(subtitle.contains("KB"), "actual: \(subtitle)")
+        XCTAssertTrue(subtitle.hasSuffix(DiskCleanFormat.bytes(1_024)), "actual: \(subtitle)")
     }
 
     /// Startup reconciliation must run on activate, or orphan staged objects have no second discovery path.

--- a/Plugins/LaunchControl/Tests/LaunchControlPluginTests.swift
+++ b/Plugins/LaunchControl/Tests/LaunchControlPluginTests.swift
@@ -39,7 +39,10 @@ final class LaunchControlCanonicalActionTests: XCTestCase {
 
         let result = await handle.result()
         XCTAssertEqual(result, .succeeded())
-        XCTAssertEqual(runner.calls, [["kickstart", "gui/501/\(item.label)"]])
+        XCTAssertEqual(
+            try XCTUnwrap(runner.calls.first),
+            ["kickstart", "gui/501/\(item.label)"]
+        )
     }
 
     func testOpenManagerRequestsConfigurationPresentation() {

--- a/Plugins/SystemStatus/Tests/SystemStatusPluginTests.swift
+++ b/Plugins/SystemStatus/Tests/SystemStatusPluginTests.swift
@@ -639,7 +639,7 @@ final class SystemStatusPluginTests: XCTestCase {
 
         XCTAssertEqual(
             SystemStatusMenuBarMetricsFormatter.text(snapshot: snapshot, kinds: [.memory, .cpu, .network]),
-            "RAM 60% 5.9K | CPU 13% 42° | NET ↓1K ↑2K"
+            "RAM 60% \(SystemStatusMenuBarMetricsFormatter.localizedDecimal(5.9))K | CPU 13% 42° | NET ↓1K ↑2K"
         )
     }
 
@@ -829,8 +829,10 @@ final class SystemStatusPluginTests: XCTestCase {
 
         let block = SystemStatusMenuBarMetricsFormatter.blocks(snapshot: snapshot, items: items).first
         XCTAssertEqual(block?.valueKinds, [.power, .load])
-        XCTAssertEqual(block?.values, ["8.5W", "L4.2"])
-        XCTAssertEqual(block?.horizontalValue, "8.5W L4.2")
+        let power = "\(SystemStatusMenuBarMetricsFormatter.localizedDecimal(8.5))W"
+        let load = "L\(SystemStatusMenuBarMetricsFormatter.localizedDecimal(4.2))"
+        XCTAssertEqual(block?.values, [power, load])
+        XCTAssertEqual(block?.horizontalValue, "\(power) \(load)")
     }
 
     func testCompactDecimalFormattingUsesRequestedLocale() {
@@ -1219,7 +1221,7 @@ final class SystemStatusPluginTests: XCTestCase {
                 snapshot: snapshot,
                 kinds: [.network]
             ).first?.values,
-            ["↓0.1G", "↑16E"]
+            ["↓\(SystemStatusMenuBarMetricsFormatter.localizedDecimal(0.1))G", "↑16E"]
         )
     }
 

--- a/Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift
+++ b/Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift
@@ -1285,40 +1285,62 @@ final class WindowSwitcherAppCatalog {
         isMinimized: Bool,
         deadline: Date
     ) {
+        focusWindow(
+            window,
+            isMinimized: isMinimized,
+            deadline: deadline,
+            setAttributeValue: setAXAttributeValue,
+            performRaise: { element, deadline in
+                guard !Task.isCancelled,
+                      setAXMessagingTimeout(on: element, deadline: deadline)
+                else {
+                    return false
+                }
+
+                return AXUIElementPerformAction(element, kAXRaiseAction as CFString) == .success
+            }
+        )
+    }
+
+    static func focusWindow(
+        _ window: AXUIElement,
+        isMinimized: Bool,
+        deadline: Date,
+        setAttributeValue: (AXUIElement, CFString, CFTypeRef, Date) -> Bool,
+        performRaise: (AXUIElement, Date) -> Bool
+    ) {
         if isMinimized {
             guard setAXAttributeValue(
                 window,
                 kAXMinimizedAttribute as CFString,
-                value: kCFBooleanFalse,
-                deadline: deadline
+                kCFBooleanFalse,
+                deadline
             ) else {
                 return
             }
         }
 
-        guard setAXAttributeValue(
+        _ = setAttributeValue(
             window,
             kAXMainAttribute as CFString,
-            value: kCFBooleanTrue,
-            deadline: deadline
-        ),
-        setAXAttributeValue(
-            window,
-            kAXFocusedAttribute as CFString,
-            value: kCFBooleanTrue,
-            deadline: deadline
-        ) else {
+            kCFBooleanTrue,
+            deadline
+        )
+        guard !Task.isCancelled, Date() < deadline else {
             return
         }
 
-        guard !Task.isCancelled,
-              setAXMessagingTimeout(on: window, deadline: deadline)
-        else {
+        _ = setAttributeValue(
+            window,
+            kAXFocusedAttribute as CFString,
+            kCFBooleanTrue,
+            deadline
+        )
+        guard !Task.isCancelled, Date() < deadline else {
             return
         }
-        guard AXUIElementPerformAction(window, kAXRaiseAction as CFString) == .success else {
-            return
-        }
+
+        _ = performRaise(window, deadline)
     }
 
     private static func setAXAttributeValue(

--- a/Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift
+++ b/Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift
@@ -1,36 +1,245 @@
 import AppKit
 import ApplicationServices
+import CoreGraphics
 import Foundation
+
+struct WindowSwitcherWindowRecord: Equatable, Sendable {
+    static let minimumWindowSize = CGSize(width: 80, height: 60)
+
+    let windowNumber: CGWindowID
+    let processIdentifier: pid_t
+    let title: String
+    let isOnScreen: Bool?
+    let bounds: CGRect
+
+    static func parse(_ windowInfo: [[String: Any]]) -> [Self] {
+        var seenWindowNumbers = Set<CGWindowID>()
+        var records: [WindowSwitcherWindowRecord] = []
+
+        for item in windowInfo {
+            guard let windowNumber = number(in: item, forKey: kCGWindowNumber),
+                  windowNumber > 0,
+                  let processIdentifier = processIdentifier(in: item),
+                  processIdentifier > 0,
+                  number(in: item, forKey: kCGWindowLayer) == 0,
+                  let alpha = numericValue(in: item, forKey: kCGWindowAlpha),
+                  alpha > 0,
+                  alpha <= 1,
+                  let bounds = rect(in: item[kCGWindowBounds as String]),
+                  bounds.width >= minimumWindowSize.width,
+                  bounds.height >= minimumWindowSize.height
+            else {
+                continue
+            }
+
+            guard seenWindowNumbers.insert(windowNumber).inserted else {
+                continue
+            }
+
+            records.append(
+                WindowSwitcherWindowRecord(
+                    windowNumber: windowNumber,
+                    processIdentifier: processIdentifier,
+                    title: item[kCGWindowName as String] as? String ?? "",
+                    isOnScreen: boolean(in: item, forKey: kCGWindowIsOnscreen),
+                    bounds: bounds
+                )
+            )
+        }
+
+        return records
+    }
+
+    private static func number(in item: [String: Any], forKey key: CFString) -> UInt32? {
+        guard let rawValue = numericValue(in: item, forKey: key),
+              rawValue.rounded() == rawValue,
+              rawValue >= 0,
+              rawValue <= Double(UInt32.max)
+        else {
+            return nil
+        }
+
+        return UInt32(rawValue)
+    }
+
+    private static func boolean(in item: [String: Any], forKey key: CFString) -> Bool? {
+        guard let value = item[key as String] as? NSNumber else {
+            return nil
+        }
+
+        let cfValue = value as CFTypeRef
+        guard CFGetTypeID(cfValue) == CFBooleanGetTypeID() else {
+            return nil
+        }
+
+        return value.boolValue
+    }
+
+    private static func numericValue(in item: [String: Any], forKey key: CFString) -> Double? {
+        guard let value = item[key as String] as? NSNumber else {
+            return nil
+        }
+
+        let cfValue = value as CFTypeRef
+        guard CFGetTypeID(cfValue) != CFBooleanGetTypeID() else {
+            return nil
+        }
+
+        let rawValue = value.doubleValue
+        guard rawValue.isFinite else {
+            return nil
+        }
+
+        return rawValue
+    }
+
+    private static func processIdentifier(in item: [String: Any]) -> pid_t? {
+        guard let rawValue = numericValue(in: item, forKey: kCGWindowOwnerPID),
+              rawValue.rounded() == rawValue,
+              rawValue > 0,
+              rawValue <= Double(pid_t.max)
+        else {
+            return nil
+        }
+
+        return pid_t(rawValue)
+    }
+
+    private static func rect(in value: Any?) -> CGRect? {
+        guard let dictionary = value as? NSDictionary,
+              let rect = CGRect(dictionaryRepresentation: dictionary),
+              rect.origin.x.isFinite,
+              rect.origin.y.isFinite,
+              rect.width.isFinite,
+              rect.height.isFinite
+        else {
+            return nil
+        }
+
+        return rect
+    }
+}
+
+struct WindowSwitcherWindowSnapshot {
+    let element: AXUIElement?
+    let windowNumber: CGWindowID?
+    let title: String
+    let isMinimized: Bool
+    let position: CGPoint
+    let size: CGSize
+}
+
+private struct WindowSwitcherWindowRecordSnapshot {
+    let records: [WindowSwitcherWindowRecord]
+    let isFresh: Bool
+}
+
+@MainActor
+protocol WindowSwitcherApplicationControlling: AnyObject {
+    var processIdentifier: pid_t { get }
+    var bundleIdentifier: String? { get }
+    var launchDate: Date? { get }
+    var isTerminated: Bool { get }
+
+    @discardableResult
+    func unhide() -> Bool
+    @discardableResult
+    func activate(options: NSApplication.ActivationOptions) -> Bool
+    @discardableResult
+    func terminate() -> Bool
+}
+
+extension NSRunningApplication: WindowSwitcherApplicationControlling {}
+
+private struct WindowSwitcherWindowMatchKey: Hashable {
+    let title: String
+    let positionX: Double
+    let positionY: Double
+    let sizeWidth: Double
+    let sizeHeight: Double
+
+    init(title: String, bounds: CGRect) {
+        self.title = title
+        positionX = Double(bounds.origin.x)
+        positionY = Double(bounds.origin.y)
+        sizeWidth = Double(bounds.size.width)
+        sizeHeight = Double(bounds.size.height)
+    }
+}
+
+private struct WindowSwitcherWindowBoundsKey: Hashable {
+    let positionX: Double
+    let positionY: Double
+    let sizeWidth: Double
+    let sizeHeight: Double
+
+    init(bounds: CGRect) {
+        positionX = Double(bounds.origin.x)
+        positionY = Double(bounds.origin.y)
+        sizeWidth = Double(bounds.size.width)
+        sizeHeight = Double(bounds.size.height)
+    }
+}
 
 @MainActor
 final class WindowSwitcherAppCatalog {
     var onChange: (() -> Void)?
 
-    private struct WindowSnapshot {
-        let element: AXUIElement
-        let title: String
-        let isMinimized: Bool
-        let position: CGPoint
-    }
-
     private static let axTimeout: Float = 0.2
-    private static let minimumWindowSize = CGSize(width: 80, height: 60)
+    private static let axScanBudget: TimeInterval = 0.75
+    private static let defaultWindowRecordRefreshTimeout: TimeInterval = 0.75
+    private static let maxWindowRecordRefreshesInFlight = 2
 
     private let notificationCenter: NotificationCenter
+    private let windowRecordProvider: @Sendable () -> [WindowSwitcherWindowRecord]
+    private let windowRecordRefreshTimeout: TimeInterval
+    private let applicationProvider: (pid_t) -> WindowSwitcherApplicationControlling?
+    private let activationWindowSnapshotProvider: ((pid_t, WindowSwitcherAppEntry) -> WindowSwitcherWindowSnapshot?)?
+    private let focusWindowHandler: ((AXUIElement, Bool) -> Void)?
     private var mruIDs: [String] = []
     private var observers: [NSObjectProtocol] = []
+    private var windowRecords: [WindowSwitcherWindowRecord] = []
+    private var windowRecordRefreshTask: Task<[WindowSwitcherWindowRecord], Never>?
+    private var windowRecordRefreshGeneration: UInt64 = 0
+    private var windowRecordRefreshLastCompletedGeneration: UInt64?
+    private var windowRecordRefreshInFlightCount = 0
 
-    init(notificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter) {
+    init(
+        notificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter,
+        windowRecordProvider: @escaping @Sendable () -> [WindowSwitcherWindowRecord] = {
+            WindowSwitcherWindowRecord.parse(
+                CGWindowListCopyWindowInfo(
+                    [.optionAll, .excludeDesktopElements],
+                    kCGNullWindowID
+                ) as? [[String: Any]] ?? []
+            )
+        },
+        windowRecordRefreshTimeout: TimeInterval = WindowSwitcherAppCatalog.defaultWindowRecordRefreshTimeout,
+        applicationProvider: @escaping (pid_t) -> WindowSwitcherApplicationControlling? = {
+            NSRunningApplication(processIdentifier: $0)
+        },
+        activationWindowSnapshotProvider: ((pid_t, WindowSwitcherAppEntry) -> WindowSwitcherWindowSnapshot?)? = nil,
+        focusWindowHandler: ((AXUIElement, Bool) -> Void)? = nil
+    ) {
         self.notificationCenter = notificationCenter
+        self.windowRecordProvider = windowRecordProvider
+        self.windowRecordRefreshTimeout = windowRecordRefreshTimeout.isFinite
+            ? max(0, windowRecordRefreshTimeout)
+            : Self.defaultWindowRecordRefreshTimeout
+        self.applicationProvider = applicationProvider
+        self.activationWindowSnapshotProvider = activationWindowSnapshotProvider
+        self.focusWindowHandler = focusWindowHandler
     }
 
     func start() {
         guard observers.isEmpty else {
             refreshFrontmostApplication()
+            refreshWindowRecords()
             return
         }
 
         refreshFrontmostApplication()
+        refreshWindowRecords()
         let activated = notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
@@ -86,14 +295,22 @@ final class WindowSwitcherAppCatalog {
             notificationCenter.removeObserver(observer)
         }
         observers.removeAll()
+        windowRecordRefreshGeneration &+= 1
+        windowRecordRefreshTask?.cancel()
+        windowRecordRefreshTask = nil
+        windowRecordRefreshLastCompletedGeneration = nil
+        windowRecords.removeAll()
     }
 
-    func entries(sortMode: WindowSwitcherSortMode) -> [WindowSwitcherAppEntry] {
+    func entries(sortMode: WindowSwitcherSortMode) async -> [WindowSwitcherAppEntry] {
         refreshFrontmostApplication()
-        let apps = NSWorkspace.shared.runningApplications.filter(Self.isUserFacingApplication)
         let ranks = Dictionary(uniqueKeysWithValues: mruIDs.enumerated().map { ($0.element, $0.offset) })
+        let windowRecords = await freshWindowRecords()
+        let recordsByProcessIdentifier = Dictionary(grouping: windowRecords, by: \.processIdentifier)
+        let axDeadline = Date().addingTimeInterval(Self.axScanBudget)
+        let apps = NSWorkspace.shared.runningApplications.filter(Self.isUserFacingApplication)
 
-        return apps
+        let sortedApps = apps
             .sorted { lhs, rhs in
                 switch sortMode {
                 case .recentUse:
@@ -130,7 +347,24 @@ final class WindowSwitcherAppCatalog {
 
                 return lhs.processIdentifier < rhs.processIdentifier
             }
-            .flatMap(Self.entries(for:))
+
+        var entries: [WindowSwitcherAppEntry] = []
+        for (appIndex, app) in sortedApps.enumerated() {
+            guard !Task.isCancelled else {
+                break
+            }
+
+            entries.append(contentsOf: self.entries(
+                for: app,
+                recordsForApplication: recordsByProcessIdentifier[app.processIdentifier] ?? [],
+                axDeadline: Self.axDeadline(
+                    sessionDeadline: axDeadline,
+                    appIndex: appIndex,
+                    appCount: sortedApps.count
+                )
+            ))
+        }
+        return entries
     }
 
     func frontmostApplicationID() -> String? {
@@ -143,42 +377,114 @@ final class WindowSwitcherAppCatalog {
         return Self.identifier(for: app)
     }
 
-    func activate(_ entry: WindowSwitcherAppEntry) {
-        guard let app = NSRunningApplication(processIdentifier: entry.processIdentifier) else {
+    func windowRecordsSnapshot() async -> [WindowSwitcherWindowRecord] {
+        await freshWindowRecords()
+    }
+
+    func activate(_ entry: WindowSwitcherAppEntry) async {
+        guard !Task.isCancelled else {
             return
         }
 
-        app.unhide()
-        app.activate(options: [])
-
-        if let windowElement = entry.windowElement {
-            if entry.isMinimized {
-                AXUIElementSetAttributeValue(
-                    windowElement,
-                    kAXMinimizedAttribute as CFString,
-                    kCFBooleanFalse
-                )
+        let currentRecords: [WindowSwitcherWindowRecord]
+        if entry.windowNumber != nil && entry.windowElement == nil {
+            let snapshot = await freshWindowRecordSnapshot()
+            guard snapshot.isFresh,
+                  !Task.isCancelled
+            else {
+                return
             }
-
-            AXUIElementSetAttributeValue(windowElement, kAXMainAttribute as CFString, kCFBooleanTrue)
-            AXUIElementSetAttributeValue(windowElement, kAXFocusedAttribute as CFString, kCFBooleanTrue)
-            AXUIElementPerformAction(windowElement, kAXRaiseAction as CFString)
+            currentRecords = snapshot.records
+        } else {
+            currentRecords = []
         }
 
+        guard !Task.isCancelled,
+              let app = applicationProvider(entry.processIdentifier),
+              Self.isCurrentApplication(app, for: entry),
+              entry.windowNumber == nil
+                  || entry.windowElement != nil
+                  || currentWindowRecord(for: entry, in: currentRecords) != nil
+        else {
+            return
+        }
+
+        guard !Task.isCancelled else {
+            return
+        }
+        app.unhide()
+
+        guard !Task.isCancelled else {
+            return
+        }
+        app.activate(options: entry.windowNumber != nil && entry.windowElement == nil
+            ? [.activateAllWindows]
+            : [])
+        let axDeadline = Date().addingTimeInterval(Self.axScanBudget)
+
+        if let windowElement = entry.windowElement {
+            focusWindow(
+                windowElement,
+                isMinimized: entry.isMinimized,
+                deadline: axDeadline
+            )
+        } else if entry.windowNumber != nil,
+                  let snapshot = windowSnapshot(
+                      for: app,
+                      matching: entry,
+                      deadline: axDeadline
+                  ),
+                  let windowElement = snapshot.element {
+            focusWindow(
+                windowElement,
+                isMinimized: snapshot.isMinimized,
+                deadline: axDeadline
+            )
+        }
+
+        guard !Task.isCancelled else {
+            return
+        }
         recordActivationID(Self.identifier(for: entry))
         onChange?()
     }
 
     func quitApplication(_ entry: WindowSwitcherAppEntry) {
-        guard let app = NSRunningApplication(processIdentifier: entry.processIdentifier),
-              !app.isTerminated
+        guard let app = applicationProvider(entry.processIdentifier),
+              Self.isCurrentApplication(app, for: entry),
+              !app.isTerminated,
+              app.terminate()
         else {
             return
         }
 
-        app.terminate()
         removeApplicationID(Self.identifier(for: entry))
         onChange?()
+    }
+
+    private func currentWindowRecord(
+        for entry: WindowSwitcherAppEntry,
+        in records: [WindowSwitcherWindowRecord]
+    ) -> WindowSwitcherWindowRecord? {
+        guard let windowNumber = entry.windowNumber,
+              let expectedBounds = entry.windowBounds,
+              let record = records.first(where: {
+                  $0.windowNumber == windowNumber
+                      && $0.processIdentifier == entry.processIdentifier
+              }),
+              record.bounds == expectedBounds
+        else {
+            return nil
+        }
+
+        if !record.title.isEmpty,
+           let expectedTitle = entry.windowTitle,
+           !expectedTitle.isEmpty,
+           record.title != expectedTitle {
+            return nil
+        }
+
+        return record
     }
 
     private func refreshFrontmostApplication() {
@@ -207,55 +513,229 @@ final class WindowSwitcherAppCatalog {
         mruIDs.removeAll { $0 == id }
     }
 
-    private static func entries(for app: NSRunningApplication) -> [WindowSwitcherAppEntry] {
-        let appID = identifier(for: app)
-        let windows = windows(for: app)
-        guard !windows.isEmpty else {
-            return [appEntry(for: app, id: appID)]
+    private func refreshWindowRecords() {
+        guard windowRecordRefreshTask == nil,
+              windowRecordRefreshInFlightCount < Self.maxWindowRecordRefreshesInFlight
+        else {
+            return
         }
 
-        return windows.enumerated().map { index, window in
+        windowRecordRefreshGeneration &+= 1
+        let generation = windowRecordRefreshGeneration
+        let provider = windowRecordProvider
+        windowRecordRefreshInFlightCount += 1
+        let task = Task.detached(priority: .userInitiated) {
+            provider()
+        }
+        windowRecordRefreshTask = task
+
+        Task { @MainActor [weak self] in
+            let records = await task.value
+            guard let self,
+                  self.windowRecordRefreshInFlightCount > 0
+            else {
+                return
+            }
+            self.windowRecordRefreshInFlightCount -= 1
+
+            guard self.windowRecordRefreshGeneration == generation else {
+                return
+            }
+
+            guard self.windowRecordRefreshTask != nil else {
+                return
+            }
+
+            self.windowRecordRefreshTask = nil
+            self.windowRecordRefreshLastCompletedGeneration = generation
+            let didChange = self.windowRecords != records
+            self.windowRecords = records
+            if didChange {
+                self.onChange?()
+            }
+        }
+    }
+
+    private func freshWindowRecords() async -> [WindowSwitcherWindowRecord] {
+        await freshWindowRecordSnapshot().records
+    }
+
+    private func freshWindowRecordSnapshot() async -> WindowSwitcherWindowRecordSnapshot {
+        refreshWindowRecords()
+        guard windowRecordRefreshTask != nil else {
+            return WindowSwitcherWindowRecordSnapshot(records: windowRecords, isFresh: false)
+        }
+        let generation = windowRecordRefreshGeneration
+        let refreshDeadline = Date().addingTimeInterval(windowRecordRefreshTimeout)
+
+        while windowRecordRefreshTask != nil,
+              windowRecordRefreshGeneration == generation {
+            guard !Task.isCancelled,
+                  Date() < refreshDeadline
+            else {
+                abandonWindowRecordRefresh(generation: generation)
+                return WindowSwitcherWindowRecordSnapshot(records: windowRecords, isFresh: false)
+            }
+
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        return WindowSwitcherWindowRecordSnapshot(
+            records: windowRecords,
+            isFresh: windowRecordRefreshLastCompletedGeneration == generation
+        )
+    }
+
+    private func abandonWindowRecordRefresh(generation: UInt64) {
+        guard windowRecordRefreshGeneration == generation else {
+            return
+        }
+
+        windowRecordRefreshTask?.cancel()
+        windowRecordRefreshTask = nil
+        windowRecordRefreshGeneration &+= 1
+    }
+
+    static func axDeadline(
+        sessionDeadline: Date,
+        appIndex: Int,
+        appCount: Int,
+        now: Date = Date()
+    ) -> Date {
+        guard appIndex < appCount else {
+            return now
+        }
+
+        let remaining = sessionDeadline.timeIntervalSince(now)
+        guard remaining > 0 else {
+            return now
+        }
+
+        let remainingApplicationCount = max(1, appCount - appIndex)
+        let fairShare = remaining / Double(remainingApplicationCount)
+        return now.addingTimeInterval(fairShare)
+    }
+
+    private func entries(
+        for app: NSRunningApplication,
+        recordsForApplication: [WindowSwitcherWindowRecord],
+        axDeadline: Date
+    ) -> [WindowSwitcherAppEntry] {
+        let appID = Self.identifier(for: app)
+        let windows = windows(
+            for: app,
+            recordsForApplication: recordsForApplication,
+            axDeadline: axDeadline
+        )
+        guard !windows.isEmpty else {
+            return [Self.appEntry(for: app, id: appID)]
+        }
+
+        return Self.windowEntries(
+            processIdentifier: app.processIdentifier,
+            bundleIdentifier: app.bundleIdentifier,
+            appName: app.localizedName ?? "App",
+            icon: app.icon,
+            applicationLaunchDate: app.launchDate,
+            windows: windows
+        )
+    }
+
+    static func windowEntries(
+        processIdentifier: pid_t,
+        bundleIdentifier: String?,
+        appName: String,
+        icon: NSImage?,
+        applicationLaunchDate: Date? = nil,
+        windows: [WindowSwitcherWindowSnapshot]
+    ) -> [WindowSwitcherAppEntry] {
+        windows.enumerated().map { index, window in
             WindowSwitcherAppEntry(
-                id: "window:\(app.processIdentifier):\(index)",
-                processIdentifier: app.processIdentifier,
-                bundleIdentifier: app.bundleIdentifier,
-                appName: app.localizedName ?? "App",
-                windowTitle: window.title,
-                icon: app.icon,
+                id: window.windowNumber.map {
+                    "window:\(processIdentifier):cg:\($0)"
+                } ?? "window:\(processIdentifier):ax:\(index)",
+                processIdentifier: processIdentifier,
+                bundleIdentifier: bundleIdentifier,
+                appName: appName,
+                windowTitle: window.title.isEmpty ? nil : window.title,
+                icon: icon,
                 windowElement: window.element,
                 isMinimized: window.isMinimized,
+                windowNumber: window.windowNumber,
+                windowBounds: CGRect(origin: window.position, size: window.size),
+                applicationLaunchDate: applicationLaunchDate,
                 shortcutToken: nil
             )
         }
     }
 
     private static func appEntry(for app: NSRunningApplication, id: String) -> WindowSwitcherAppEntry {
-        WindowSwitcherAppEntry(
+        applicationEntry(
             id: id,
             processIdentifier: app.processIdentifier,
             bundleIdentifier: app.bundleIdentifier,
             appName: app.localizedName ?? "App",
-            windowTitle: nil,
             icon: app.icon,
+            applicationLaunchDate: app.launchDate
+        )
+    }
+
+    static func applicationEntry(
+        id: String,
+        processIdentifier: pid_t,
+        bundleIdentifier: String?,
+        appName: String,
+        icon: NSImage?,
+        applicationLaunchDate: Date? = nil
+    ) -> WindowSwitcherAppEntry {
+        WindowSwitcherAppEntry(
+            id: id,
+            processIdentifier: processIdentifier,
+            bundleIdentifier: bundleIdentifier,
+            appName: appName,
+            windowTitle: nil,
+            icon: icon,
             windowElement: nil,
             isMinimized: false,
+            windowNumber: nil,
+            windowBounds: nil,
+            applicationLaunchDate: applicationLaunchDate,
             shortcutToken: nil
         )
     }
 
-    private static func windows(for app: NSRunningApplication) -> [WindowSnapshot] {
-        let appElement = AXUIElementCreateApplication(app.processIdentifier)
-        AXUIElementSetMessagingTimeout(appElement, axTimeout)
-
-        var windows = copyWindows(from: appElement)
-        for attribute in [kAXMainWindowAttribute, kAXFocusedWindowAttribute] {
-            if let window = copyWindowAttribute(appElement, attribute as String) {
-                appendUnique(window, to: &windows)
-            }
+    private func windows(
+        for app: NSRunningApplication,
+        recordsForApplication: [WindowSwitcherWindowRecord],
+        axDeadline: Date
+    ) -> [WindowSwitcherWindowSnapshot] {
+        let recordsForApp = recordsForApplication
+        guard !Task.isCancelled else {
+            return []
+        }
+        guard Date() < axDeadline else {
+            return Self.coreGraphicsSnapshots(for: recordsForApp)
         }
 
-        return windows
-            .compactMap(windowSnapshot(for:))
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        let axWindows = Self.copyCandidateWindows(from: appElement, deadline: axDeadline)
+
+        var axSnapshots: [WindowSwitcherWindowSnapshot] = []
+        for window in axWindows {
+            guard !Task.isCancelled,
+                  Date() < axDeadline
+            else {
+                break
+            }
+            if let snapshot = Self.windowSnapshot(for: window, deadline: axDeadline) {
+                axSnapshots.append(snapshot)
+            }
+        }
+        guard !Task.isCancelled else {
+            return []
+        }
+
+        return Self.mergeWindowSnapshots(axSnapshots: axSnapshots, records: recordsForApp)
             .sorted { lhs, rhs in
                 if lhs.isMinimized != rhs.isMinimized {
                     return !lhs.isMinimized
@@ -267,11 +747,323 @@ final class WindowSwitcherAppCatalog {
                     return lhs.position.x < rhs.position.x
                 }
 
-                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+                let titleOrder = lhs.title.localizedCaseInsensitiveCompare(rhs.title)
+                if titleOrder != .orderedSame {
+                    return titleOrder == .orderedAscending
+                }
+
+                return (lhs.windowNumber ?? 0) < (rhs.windowNumber ?? 0)
             }
     }
 
-    private static func copyWindows(from appElement: AXUIElement) -> [AXUIElement] {
+    private static func coreGraphicsSnapshots(
+        for records: [WindowSwitcherWindowRecord]
+    ) -> [WindowSwitcherWindowSnapshot] {
+        records.map {
+            WindowSwitcherWindowSnapshot(
+                element: nil,
+                windowNumber: $0.windowNumber,
+                title: $0.title,
+                isMinimized: false,
+                position: $0.bounds.origin,
+                size: $0.bounds.size
+            )
+        }
+    }
+
+    static func mergeWindowSnapshots(
+        axSnapshots: [WindowSwitcherWindowSnapshot],
+        records: [WindowSwitcherWindowRecord]
+    ) -> [WindowSwitcherWindowSnapshot] {
+        var axSnapshotIndicesByKey: [WindowSwitcherWindowMatchKey: Set<Int>] = [:]
+        var axSnapshotIndicesByBounds: [WindowSwitcherWindowBoundsKey: Set<Int>] = [:]
+        for (index, snapshot) in axSnapshots.enumerated() {
+            let bounds = CGRect(origin: snapshot.position, size: snapshot.size)
+            let key = WindowSwitcherWindowMatchKey(
+                title: snapshot.title,
+                bounds: bounds
+            )
+            axSnapshotIndicesByKey[key, default: []].insert(index)
+            axSnapshotIndicesByBounds[WindowSwitcherWindowBoundsKey(bounds: bounds), default: []].insert(index)
+        }
+
+        var unmatchedRecordIndicesByKey: [WindowSwitcherWindowMatchKey: Set<Int>] = [:]
+        var unmatchedRecordIndicesByBounds: [WindowSwitcherWindowBoundsKey: Set<Int>] = [:]
+        var unmatchedOnScreenRecordCountByKey: [WindowSwitcherWindowMatchKey: Int] = [:]
+        var unmatchedOnScreenRecordCountByBounds: [WindowSwitcherWindowBoundsKey: Int] = [:]
+        for (index, record) in records.enumerated() {
+            let key = WindowSwitcherWindowMatchKey(title: record.title, bounds: record.bounds)
+            let boundsKey = WindowSwitcherWindowBoundsKey(bounds: record.bounds)
+            unmatchedRecordIndicesByKey[key, default: []].insert(index)
+            unmatchedRecordIndicesByBounds[boundsKey, default: []].insert(index)
+            if record.isOnScreen == true {
+                unmatchedOnScreenRecordCountByKey[key, default: 0] += 1
+                unmatchedOnScreenRecordCountByBounds[boundsKey, default: 0] += 1
+            }
+        }
+
+        var matchedAXSnapshotIndices = Array<Int?>(repeating: nil, count: records.count)
+        var remainingAXSnapshotIndicesByKey = axSnapshotIndicesByKey
+        var remainingAXSnapshotIndicesByBounds = axSnapshotIndicesByBounds
+
+        for recordIndex in records.indices {
+            let key = WindowSwitcherWindowMatchKey(
+                title: records[recordIndex].title,
+                bounds: records[recordIndex].bounds
+            )
+            guard let index = uniqueAXSnapshotIndex(
+                in: remainingAXSnapshotIndicesByKey[key],
+                forRecordAt: recordIndex,
+                recordIndices: unmatchedRecordIndicesByKey[key],
+                onScreenRecordCount: unmatchedOnScreenRecordCountByKey[key] ?? 0,
+                records: records
+            ) else {
+                continue
+            }
+
+            matchedAXSnapshotIndices[recordIndex] = index
+            let boundsKey = WindowSwitcherWindowBoundsKey(bounds: records[recordIndex].bounds)
+            remainingAXSnapshotIndicesByKey[key]?.remove(index)
+            remainingAXSnapshotIndicesByBounds[boundsKey]?.remove(index)
+            unmatchedRecordIndicesByKey[key]?.remove(recordIndex)
+            unmatchedRecordIndicesByBounds[boundsKey]?.remove(recordIndex)
+            if records[recordIndex].isOnScreen == true {
+                unmatchedOnScreenRecordCountByKey[key, default: 0] -= 1
+                unmatchedOnScreenRecordCountByBounds[boundsKey, default: 0] -= 1
+            }
+        }
+
+        for recordIndex in records.indices where matchedAXSnapshotIndices[recordIndex] == nil {
+            let record = records[recordIndex]
+            let boundsKey = WindowSwitcherWindowBoundsKey(bounds: record.bounds)
+            guard let candidateIndex = uniqueAXSnapshotIndex(
+                in: remainingAXSnapshotIndicesByBounds[boundsKey],
+                forRecordAt: recordIndex,
+                recordIndices: unmatchedRecordIndicesByBounds[boundsKey],
+                onScreenRecordCount: unmatchedOnScreenRecordCountByBounds[boundsKey] ?? 0,
+                records: records
+            ),
+            record.title.isEmpty || axSnapshots[candidateIndex].title.isEmpty
+            else {
+                continue
+            }
+
+            matchedAXSnapshotIndices[recordIndex] = candidateIndex
+            remainingAXSnapshotIndicesByBounds[boundsKey]?.remove(candidateIndex)
+            unmatchedRecordIndicesByBounds[boundsKey]?.remove(recordIndex)
+            if record.isOnScreen == true {
+                unmatchedOnScreenRecordCountByBounds[boundsKey, default: 0] -= 1
+            }
+        }
+
+        var merged: [WindowSwitcherWindowSnapshot] = []
+        for (recordIndex, record) in records.enumerated() {
+            if let index = matchedAXSnapshotIndices[recordIndex] {
+                let snapshot = axSnapshots[index]
+                merged.append(
+                    WindowSwitcherWindowSnapshot(
+                        element: snapshot.element,
+                        windowNumber: record.windowNumber,
+                        title: snapshot.title,
+                        isMinimized: snapshot.isMinimized,
+                        position: snapshot.position,
+                        size: snapshot.size
+                    )
+                )
+                continue
+            }
+
+            merged.append(
+                WindowSwitcherWindowSnapshot(
+                    element: nil,
+                    windowNumber: record.windowNumber,
+                    title: record.title,
+                    isMinimized: false,
+                    position: record.bounds.origin,
+                    size: record.bounds.size
+                )
+            )
+        }
+
+        for boundsKey in remainingAXSnapshotIndicesByBounds.keys {
+            guard let candidateIndices = remainingAXSnapshotIndicesByBounds[boundsKey],
+                  !candidateIndices.isEmpty
+            else {
+                continue
+            }
+
+            let recordIndices = unmatchedRecordIndicesByBounds[boundsKey] ?? []
+            let axOnlyIndices = Self.axOnlySnapshotIndices(
+                candidateIndices: candidateIndices,
+                recordIndices: recordIndices,
+                axSnapshots: axSnapshots,
+                records: records
+            )
+            for index in axOnlyIndices {
+                merged.append(axSnapshots[index])
+            }
+        }
+
+        return merged
+    }
+
+    private static func axOnlySnapshotIndices(
+        candidateIndices: Set<Int>,
+        recordIndices: Set<Int>,
+        axSnapshots: [WindowSwitcherWindowSnapshot],
+        records: [WindowSwitcherWindowRecord]
+    ) -> [Int] {
+        let sortedCandidateIndices = candidateIndices.sorted()
+        guard !recordIndices.isEmpty else {
+            return sortedCandidateIndices
+        }
+
+        var axTitleCounts: [String: Int] = [:]
+        var titlelessAXCount = 0
+        for index in candidateIndices {
+            let title = axSnapshots[index].title
+            if title.isEmpty {
+                titlelessAXCount += 1
+            } else {
+                axTitleCounts[title, default: 0] += 1
+            }
+        }
+
+        var recordTitleCounts: [String: Int] = [:]
+        var titlelessRecordCount = 0
+        for index in recordIndices {
+            let title = records[index].title
+            if title.isEmpty {
+                titlelessRecordCount += 1
+            } else {
+                recordTitleCounts[title, default: 0] += 1
+            }
+        }
+
+        let exactMatchCount = axTitleCounts.reduce(into: 0) { count, pair in
+            count += min(pair.value, recordTitleCounts[pair.key] ?? 0)
+        }
+        let remainingAXCount = candidateIndices.count - exactMatchCount
+        let remainingRecordCount = recordIndices.count - exactMatchCount
+        let wildcardMatchCount: Int
+        if titlelessAXCount > 0 && titlelessRecordCount > 0 {
+            wildcardMatchCount = min(remainingAXCount, remainingRecordCount)
+        } else if titlelessAXCount > 0 {
+            wildcardMatchCount = min(titlelessAXCount, remainingRecordCount)
+        } else if titlelessRecordCount > 0 {
+            wildcardMatchCount = min(remainingAXCount, titlelessRecordCount)
+        } else {
+            wildcardMatchCount = 0
+        }
+        let maximumCompatibleCount = exactMatchCount + wildcardMatchCount
+        let maximumAXOnlyCount = max(0, candidateIndices.count - maximumCompatibleCount)
+        guard maximumAXOnlyCount > 0 else {
+            return []
+        }
+
+        var residualRecordTitleCounts = recordTitleCounts
+        for (title, candidateCount) in axTitleCounts {
+            residualRecordTitleCounts[title] = max(
+                0,
+                (residualRecordTitleCounts[title] ?? 0) - candidateCount
+            )
+        }
+
+        var forcedAXOnlyIndices: [Int] = []
+        var compatibleIndices: [Int] = []
+        for index in sortedCandidateIndices {
+            let title = axSnapshots[index].title
+            let canMatchResidualRecord = title.isEmpty
+                || titlelessRecordCount > 0
+                || (residualRecordTitleCounts[title] ?? 0) > 0
+            if canMatchResidualRecord {
+                compatibleIndices.append(index)
+            } else {
+                forcedAXOnlyIndices.append(index)
+            }
+        }
+
+        return Array((forcedAXOnlyIndices + compatibleIndices).prefix(maximumAXOnlyCount))
+    }
+
+    private static func uniqueAXSnapshotIndex(
+        in candidateIndices: Set<Int>?,
+        forRecordAt recordIndex: Int,
+        recordIndices: Set<Int>?,
+        onScreenRecordCount: Int,
+        records: [WindowSwitcherWindowRecord]
+    ) -> Int? {
+        guard let candidateIndices,
+              candidateIndices.count == 1,
+              let candidateIndex = candidateIndices.first,
+              let recordIndices,
+              recordIndices.contains(recordIndex)
+        else {
+            return nil
+        }
+
+        guard recordIndices.count > 1 else {
+            return candidateIndex
+        }
+
+        guard onScreenRecordCount == 1,
+              records[recordIndex].isOnScreen == true
+        else {
+            return nil
+        }
+
+        return candidateIndex
+    }
+
+    private static func matches(
+        _ snapshot: WindowSwitcherWindowSnapshot,
+        title: String?,
+        bounds: CGRect
+    ) -> Bool {
+        guard snapshot.position == bounds.origin,
+              snapshot.size == bounds.size
+        else {
+            return false
+        }
+
+        guard let title, !title.isEmpty else {
+            return true
+        }
+
+        return snapshot.title == title
+    }
+
+    static func axTimeout(forRemaining remaining: TimeInterval) -> Float? {
+        guard remaining > 0 else {
+            return nil
+        }
+
+        return min(axTimeout, Float(remaining))
+    }
+
+    private static func setAXMessagingTimeout(
+        on element: AXUIElement,
+        deadline: Date?
+    ) -> Bool {
+        guard let deadline else {
+            return AXUIElementSetMessagingTimeout(element, axTimeout) == .success
+        }
+
+        guard let timeout = axTimeout(forRemaining: deadline.timeIntervalSinceNow) else {
+            return false
+        }
+
+        return AXUIElementSetMessagingTimeout(element, timeout) == .success
+    }
+
+    private static func copyWindows(
+        from appElement: AXUIElement,
+        deadline: Date? = nil
+    ) -> [AXUIElement] {
+        guard setAXMessagingTimeout(on: appElement, deadline: deadline) else {
+            return []
+        }
+
         var value: CFTypeRef?
         let result = AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value)
         guard result == .success,
@@ -283,8 +1075,34 @@ final class WindowSwitcherAppCatalog {
         return windows
     }
 
-    private static func windowSnapshot(for window: AXUIElement) -> WindowSnapshot? {
-        AXUIElementSetMessagingTimeout(window, axTimeout)
+    private static func copyCandidateWindows(
+        from appElement: AXUIElement,
+        deadline: Date? = nil
+    ) -> [AXUIElement] {
+        var windows = copyWindows(from: appElement, deadline: deadline)
+        for attribute in [kAXMainWindowAttribute, kAXFocusedWindowAttribute] {
+            guard deadline.map({ Date() < $0 }) ?? true else {
+                break
+            }
+
+            if let window = copyWindowAttribute(
+                appElement,
+                attribute as String,
+                deadline: deadline
+            ) {
+                appendUnique(window, to: &windows)
+            }
+        }
+        return windows
+    }
+
+    private static func windowSnapshot(
+        for window: AXUIElement,
+        deadline: Date? = nil
+    ) -> WindowSwitcherWindowSnapshot? {
+        guard setAXMessagingTimeout(on: window, deadline: deadline) else {
+            return nil
+        }
 
         let attributes = [
             kAXRoleAttribute,
@@ -315,11 +1133,13 @@ final class WindowSwitcherAppCatalog {
             return nil
         }
 
-        return WindowSnapshot(
+        return WindowSwitcherWindowSnapshot(
             element: window,
+            windowNumber: nil,
             title: values[2] as? String ?? "",
             isMinimized: isMinimized,
-            position: decodePoint(values[4])
+            position: decodePoint(values[4]),
+            size: size
         )
     }
 
@@ -338,7 +1158,8 @@ final class WindowSwitcherAppCatalog {
     }
 
     private static func isSwitchableWindowSize(_ size: CGSize) -> Bool {
-        size.width >= minimumWindowSize.width && size.height >= minimumWindowSize.height
+        size.width >= WindowSwitcherWindowRecord.minimumWindowSize.width
+            && size.height >= WindowSwitcherWindowRecord.minimumWindowSize.height
     }
 
     private static func decodePoint(_ value: Any) -> CGPoint {
@@ -363,7 +1184,15 @@ final class WindowSwitcherAppCatalog {
         return size
     }
 
-    private static func copyWindowAttribute(_ appElement: AXUIElement, _ attribute: String) -> AXUIElement? {
+    private static func copyWindowAttribute(
+        _ appElement: AXUIElement,
+        _ attribute: String,
+        deadline: Date? = nil
+    ) -> AXUIElement? {
+        guard setAXMessagingTimeout(on: appElement, deadline: deadline) else {
+            return nil
+        }
+
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(appElement, attribute as CFString, &value) == .success,
               let value,
@@ -375,12 +1204,169 @@ final class WindowSwitcherAppCatalog {
         return (value as! AXUIElement)
     }
 
+    private func windowSnapshot(
+        for app: WindowSwitcherApplicationControlling,
+        matching entry: WindowSwitcherAppEntry,
+        deadline: Date
+    ) -> WindowSwitcherWindowSnapshot? {
+        guard let bounds = entry.windowBounds else {
+            return nil
+        }
+
+        if let activationWindowSnapshotProvider {
+            return activationWindowSnapshotProvider(app.processIdentifier, entry)
+        }
+
+        guard let app = app as? NSRunningApplication else {
+            return nil
+        }
+
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        let windows = Self.copyCandidateWindows(from: appElement, deadline: deadline)
+
+        return Self.firstMatchingWindow(
+            in: windows,
+            title: entry.windowTitle,
+            bounds: bounds,
+            deadline: deadline,
+            now: { Date() },
+            snapshotProvider: { window in
+                Self.windowSnapshot(for: window, deadline: deadline)
+            }
+        )
+    }
+
+    static func firstMatchingWindow(
+        in windows: [AXUIElement],
+        title: String?,
+        bounds: CGRect,
+        deadline: Date,
+        now: () -> Date,
+        snapshotProvider: (AXUIElement) -> WindowSwitcherWindowSnapshot?
+    ) -> WindowSwitcherWindowSnapshot? {
+        var matchingSnapshot: WindowSwitcherWindowSnapshot?
+        for window in windows {
+            guard !Task.isCancelled,
+                  now() < deadline
+            else {
+                return nil
+            }
+
+            guard let snapshot = snapshotProvider(window),
+                  Self.matches(snapshot, title: title, bounds: bounds)
+            else {
+                continue
+            }
+
+            guard matchingSnapshot == nil else {
+                return nil
+            }
+
+            matchingSnapshot = snapshot
+        }
+
+        return matchingSnapshot
+    }
+
+    private func focusWindow(
+        _ window: AXUIElement,
+        isMinimized: Bool,
+        deadline: Date
+    ) {
+        if let focusWindowHandler {
+            focusWindowHandler(window, isMinimized)
+        } else {
+            Self.focusWindow(window, isMinimized: isMinimized, deadline: deadline)
+        }
+    }
+
+    private static func focusWindow(
+        _ window: AXUIElement,
+        isMinimized: Bool,
+        deadline: Date
+    ) {
+        if isMinimized {
+            guard setAXAttributeValue(
+                window,
+                kAXMinimizedAttribute as CFString,
+                value: kCFBooleanFalse,
+                deadline: deadline
+            ) else {
+                return
+            }
+        }
+
+        guard setAXAttributeValue(
+            window,
+            kAXMainAttribute as CFString,
+            value: kCFBooleanTrue,
+            deadline: deadline
+        ),
+        setAXAttributeValue(
+            window,
+            kAXFocusedAttribute as CFString,
+            value: kCFBooleanTrue,
+            deadline: deadline
+        ) else {
+            return
+        }
+
+        guard !Task.isCancelled,
+              setAXMessagingTimeout(on: window, deadline: deadline)
+        else {
+            return
+        }
+        guard AXUIElementPerformAction(window, kAXRaiseAction as CFString) == .success else {
+            return
+        }
+    }
+
+    private static func setAXAttributeValue(
+        _ element: AXUIElement,
+        _ attribute: CFString,
+        value: CFTypeRef,
+        deadline: Date
+    ) -> Bool {
+        guard !Task.isCancelled,
+              setAXMessagingTimeout(on: element, deadline: deadline)
+        else {
+            return false
+        }
+
+        return AXUIElementSetAttributeValue(element, attribute, value) == .success
+    }
+
     private static func appendUnique(_ window: AXUIElement, to windows: inout [AXUIElement]) {
         guard !windows.contains(where: { CFEqual($0, window) }) else {
             return
         }
 
         windows.append(window)
+    }
+
+    private static func isCurrentApplication(
+        _ app: WindowSwitcherApplicationControlling,
+        for entry: WindowSwitcherAppEntry
+    ) -> Bool {
+        guard app.processIdentifier == entry.processIdentifier,
+              !app.isTerminated
+        else {
+            return false
+        }
+
+        if let currentLaunchDate = app.launchDate,
+           let expectedLaunchDate = entry.applicationLaunchDate,
+           currentLaunchDate != expectedLaunchDate {
+            return false
+        }
+
+        guard let expectedBundleIdentifier = entry.bundleIdentifier,
+              !expectedBundleIdentifier.isEmpty
+        else {
+            return true
+        }
+
+        return app.bundleIdentifier == expectedBundleIdentifier
     }
 
     nonisolated private static func identifier(for app: NSRunningApplication) -> String {

--- a/Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift
+++ b/Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift
@@ -1289,7 +1289,7 @@ final class WindowSwitcherAppCatalog {
             window,
             isMinimized: isMinimized,
             deadline: deadline,
-            setAttributeValue: setAXAttributeValue,
+            writeAttribute: setAXAttributeValue,
             performRaise: { element, deadline in
                 guard !Task.isCancelled,
                       setAXMessagingTimeout(on: element, deadline: deadline)
@@ -1306,11 +1306,11 @@ final class WindowSwitcherAppCatalog {
         _ window: AXUIElement,
         isMinimized: Bool,
         deadline: Date,
-        setAttributeValue: (AXUIElement, CFString, CFTypeRef, Date) -> Bool,
+        writeAttribute: (AXUIElement, CFString, CFTypeRef, Date) -> Bool,
         performRaise: (AXUIElement, Date) -> Bool
     ) {
         if isMinimized {
-            guard setAXAttributeValue(
+            guard writeAttribute(
                 window,
                 kAXMinimizedAttribute as CFString,
                 kCFBooleanFalse,
@@ -1320,7 +1320,7 @@ final class WindowSwitcherAppCatalog {
             }
         }
 
-        _ = setAttributeValue(
+        _ = writeAttribute(
             window,
             kAXMainAttribute as CFString,
             kCFBooleanTrue,
@@ -1330,7 +1330,7 @@ final class WindowSwitcherAppCatalog {
             return
         }
 
-        _ = setAttributeValue(
+        _ = writeAttribute(
             window,
             kAXFocusedAttribute as CFString,
             kCFBooleanTrue,

--- a/Plugins/WindowSwitcher/Sources/WindowSwitcherModels.swift
+++ b/Plugins/WindowSwitcher/Sources/WindowSwitcherModels.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ApplicationServices
 import Carbon.HIToolbox
+import CoreGraphics
 import Foundation
 import MacToolsPluginKit
 
@@ -249,9 +250,14 @@ final class WindowSwitcherStore: ObservableObject {
         identities: [String],
         current: WindowSwitcherShortcutAssignment.Result
     ) -> Bool {
+        let activeIdentities = Set(identities)
         let conflictsWithSavedManualBinding = current.bindingState.manual.contains {
             identity, assignedToken in
             identity != targetIdentity
+                && !WindowSwitcherShortcutAssignment.isUnresolvedLegacyIdentity(
+                    identity,
+                    activeIdentities: activeIdentities
+                )
                 && WindowSwitcherShortcutAssignment.normalizedManualToken(assignedToken) == token
         }
         let conflictsWithRunningEntry = current.entries.enumerated().contains { index, entry in
@@ -278,7 +284,38 @@ struct WindowSwitcherAppEntry: Identifiable {
     let icon: NSImage?
     let windowElement: AXUIElement?
     let isMinimized: Bool
+    let windowNumber: CGWindowID?
+    let windowBounds: CGRect?
+    let applicationLaunchDate: Date?
     var shortcutToken: String?
+
+    init(
+        id: String,
+        processIdentifier: pid_t,
+        bundleIdentifier: String?,
+        appName: String,
+        windowTitle: String?,
+        icon: NSImage?,
+        windowElement: AXUIElement?,
+        isMinimized: Bool,
+        windowNumber: CGWindowID?,
+        windowBounds: CGRect?,
+        applicationLaunchDate: Date? = nil,
+        shortcutToken: String?
+    ) {
+        self.id = id
+        self.processIdentifier = processIdentifier
+        self.bundleIdentifier = bundleIdentifier
+        self.appName = appName
+        self.windowTitle = windowTitle
+        self.icon = icon
+        self.windowElement = windowElement
+        self.isMinimized = isMinimized
+        self.windowNumber = windowNumber
+        self.windowBounds = windowBounds
+        self.applicationLaunchDate = applicationLaunchDate
+        self.shortcutToken = shortcutToken
+    }
 
     var displayName: String {
         guard let title = cleanWindowTitle else {
@@ -303,7 +340,7 @@ struct WindowSwitcherAppEntry: Identifiable {
     }
 
     var isWindowEntry: Bool {
-        windowElement != nil
+        windowElement != nil || windowNumber != nil
     }
 
     var appIdentifier: String {
@@ -388,6 +425,7 @@ enum WindowSwitcherShortcutAssignment {
     private struct Target {
         let index: Int
         let identity: String
+        let legacyIdentity: String?
         let preferredToken: String?
     }
 
@@ -412,14 +450,25 @@ enum WindowSwitcherShortcutAssignment {
         }
 
         let targets = assignmentTargets(for: entries)
-        let reservedManualTokens = Set(bindingState.manual.values.compactMap(normalizedManualToken))
+        let resolvedBindingState = migrateUnambiguousLegacyBindings(
+            from: bindingState,
+            targets: targets
+        )
+        let activeIdentities = Set(targets.map(\.identity))
+        let reservedManualTokens = Set<String>(resolvedBindingState.manual.compactMap { identity, rawToken in
+            guard !isUnresolvedLegacyIdentity(identity, activeIdentities: activeIdentities) else {
+                return nil
+            }
+
+            return normalizedManualToken(rawToken)
+        })
         let availableTokens = shortcutTokens(count: maximumShortcutCount)
         var assignedTokens = Array<String?>(repeating: nil, count: entries.count)
         var activeManualTokens = Set<String>()
         var usedTokens = reservedManualTokens
 
         for target in targets {
-            guard let token = bindingState.manual[target.identity].flatMap(normalizedManualToken),
+            guard let token = resolvedBindingState.manual[target.identity].flatMap(normalizedManualToken),
                   activeManualTokens.insert(token).inserted
             else {
                 continue
@@ -429,7 +478,7 @@ enum WindowSwitcherShortcutAssignment {
         }
 
         for target in targets where assignedTokens[target.index] == nil {
-            guard let token = bindingState.automatic[target.identity].flatMap(normalizedShortcutToken),
+            guard let token = resolvedBindingState.automatic[target.identity].flatMap(normalizedShortcutToken),
                   !usedTokens.contains(token)
             else {
                 continue
@@ -465,7 +514,7 @@ enum WindowSwitcherShortcutAssignment {
             return copy
         }
         let updatedState = updatedBindingState(
-            from: bindingState,
+            from: resolvedBindingState,
             targets: targets,
             assignedTokens: assignedTokens
         )
@@ -492,19 +541,98 @@ enum WindowSwitcherShortcutAssignment {
 
     private static func assignmentTargets(for entries: [WindowSwitcherAppEntry]) -> [Target] {
         var appOccurrences: [String: Int] = [:]
+        var axWindowOccurrences: [String: Int] = [:]
+        let windowCounts = entries.reduce(into: [String: Int]()) { counts, entry in
+            guard entry.isWindowEntry else {
+                return
+            }
+
+            counts[entry.appIdentifier, default: 0] += 1
+        }
 
         return entries.enumerated().map { index, entry in
             let appIdentifier = entry.appIdentifier
-            let occurrence = appOccurrences[appIdentifier, default: 0]
-            appOccurrences[appIdentifier] = occurrence + 1
+            let ordinalIdentity: String?
+            let preferredToken: String?
+            if entry.windowElement != nil {
+                let occurrence = axWindowOccurrences[appIdentifier, default: 0]
+                axWindowOccurrences[appIdentifier] = occurrence + 1
+                ordinalIdentity = nil
+                preferredToken = occurrence == 0 ? preferredSingleKeyToken(for: entry) : nil
+            } else if entry.windowNumber != nil {
+                ordinalIdentity = nil
+                preferredToken = nil
+            } else {
+                let occurrence = appOccurrences[appIdentifier, default: 0]
+                appOccurrences[appIdentifier] = occurrence + 1
+                ordinalIdentity = occurrence == 0
+                    ? appIdentifier
+                    : "\(appIdentifier)#window:\(occurrence + 1)"
+                preferredToken = occurrence == 0 ? preferredSingleKeyToken(for: entry) : nil
+            }
+
+            let identity: String
+            if let windowNumber = entry.windowNumber {
+                identity = "window:\(entry.processIdentifier):cg:\(windowNumber)"
+            } else if entry.windowElement != nil {
+                identity = "window:\(entry.processIdentifier):ax:\(entry.id)"
+            } else {
+                identity = ordinalIdentity ?? appIdentifier
+            }
+
             return Target(
                 index: index,
-                identity: occurrence == 0
+                identity: identity,
+                legacyIdentity: entry.isWindowEntry && windowCounts[appIdentifier] == 1
                     ? appIdentifier
-                    : "\(appIdentifier)#window:\(occurrence + 1)",
-                preferredToken: occurrence == 0 ? preferredSingleKeyToken(for: entry) : nil
+                    : nil,
+                preferredToken: preferredToken
             )
         }
+    }
+
+    private static func migrateUnambiguousLegacyBindings(
+        from bindingState: WindowSwitcherShortcutBindingState,
+        targets: [Target]
+    ) -> WindowSwitcherShortcutBindingState {
+        var state = bindingState
+
+        for target in targets {
+            guard let legacyIdentity = target.legacyIdentity,
+                  state.manual[target.identity] == nil,
+                  let token = state.manual.removeValue(forKey: legacyIdentity)
+            else {
+                continue
+            }
+
+            state.manual[target.identity] = token
+        }
+
+        for target in targets {
+            guard let legacyIdentity = target.legacyIdentity,
+                  state.automatic[target.identity] == nil,
+                  let token = state.automatic.removeValue(forKey: legacyIdentity)
+            else {
+                continue
+            }
+
+            state.automatic[target.identity] = token
+        }
+
+        return state
+    }
+
+    static func isUnresolvedLegacyIdentity(
+        _ identity: String,
+        activeIdentities: Set<String>
+    ) -> Bool {
+        guard !activeIdentities.contains(identity) else {
+            return false
+        }
+
+        return identity.contains("#window:")
+            || identity.hasPrefix("bundle:")
+            || identity.hasPrefix("pid:")
     }
 
     private static func updatedBindingState(
@@ -516,8 +644,12 @@ enum WindowSwitcherShortcutAssignment {
         state.version = WindowSwitcherShortcutBindingState.currentVersion
         let validManualBindings = state.manual.compactMapValues(normalizedManualToken)
         state.manual = validManualBindings
-        let manualIdentities = Set(validManualBindings.keys)
-        let manualTokens = Set(validManualBindings.values)
+        let activeTargetIdentities = Set(targets.map(\.identity))
+        let effectiveManualBindings = validManualBindings.filter { identity, _ in
+            !isUnresolvedLegacyIdentity(identity, activeIdentities: activeTargetIdentities)
+        }
+        let manualIdentities = Set(effectiveManualBindings.keys)
+        let manualTokens = Set(effectiveManualBindings.values)
         var activeTokens = Set<String>()
         var activeIdentities = Set<String>()
 
@@ -539,6 +671,10 @@ enum WindowSwitcherShortcutAssignment {
         for (identity, rawToken) in state.automatic {
             guard let token = normalizedShortcutToken(rawToken) else {
                 state.automatic.removeValue(forKey: identity)
+                continue
+            }
+
+            if isUnresolvedLegacyIdentity(identity, activeIdentities: activeTargetIdentities) {
                 continue
             }
 

--- a/Plugins/WindowSwitcher/Sources/WindowSwitcherModels.swift
+++ b/Plugins/WindowSwitcher/Sources/WindowSwitcherModels.swift
@@ -97,11 +97,18 @@ final class WindowSwitcherStore: ObservableObject {
     @Published private(set) var shortcutBindings: WindowSwitcherShortcutBindingState
 
     private let storage: PluginStorage
+    private let processIsRunning: (pid_t) -> Bool
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
-    init(storage: PluginStorage) {
+    init(
+        storage: PluginStorage,
+        processIsRunning: @escaping (pid_t) -> Bool = {
+            NSRunningApplication(processIdentifier: $0)?.isTerminated == false
+        }
+    ) {
         self.storage = storage
+        self.processIsRunning = processIsRunning
         if let data = storage.data(forKey: Keys.configuration),
            let loaded = try? decoder.decode(WindowSwitcherConfiguration.self, from: data) {
             self.configuration = loaded
@@ -154,6 +161,7 @@ final class WindowSwitcherStore: ObservableObject {
     }
 
     func assignShortcuts(to entries: [WindowSwitcherAppEntry]) -> [WindowSwitcherAppEntry] {
+        removeExpiredWindowBindings(for: entries)
         let result = WindowSwitcherShortcutAssignment.assignShortcuts(
             to: entries,
             bindingState: shortcutBindings
@@ -172,6 +180,7 @@ final class WindowSwitcherStore: ObservableObject {
         for entryID: String,
         in entries: [WindowSwitcherAppEntry]
     ) -> WindowSwitcherShortcutCustomizationResult {
+        removeExpiredWindowBindings(for: entries)
         let identities = WindowSwitcherShortcutAssignment.identities(for: entries)
         guard let targetIndex = entries.firstIndex(where: { $0.id == entryID }),
               identities.indices.contains(targetIndex)
@@ -221,6 +230,7 @@ final class WindowSwitcherStore: ObservableObject {
         for entryID: String,
         in entries: [WindowSwitcherAppEntry]
     ) -> Bool {
+        removeExpiredWindowBindings(for: entries)
         guard let token = WindowSwitcherShortcutAssignment.normalizedManualToken(rawToken) else {
             return true
         }
@@ -272,6 +282,40 @@ final class WindowSwitcherStore: ObservableObject {
         }
 
         storage.set(data, forKey: Keys.shortcutBindings)
+    }
+
+    private func removeExpiredWindowBindings(for entries: [WindowSwitcherAppEntry]) {
+        let activeProcessIdentifiers = Set(entries.compactMap { entry in
+            entry.isWindowEntry ? entry.processIdentifier : nil
+        })
+        let previousState = shortcutBindings
+
+        shortcutBindings.manual = shortcutBindings.manual.filter { identity, _ in
+            !isExpiredWindowIdentity(identity, activeProcessIdentifiers: activeProcessIdentifiers)
+        }
+        shortcutBindings.automatic = shortcutBindings.automatic.filter { identity, _ in
+            !isExpiredWindowIdentity(identity, activeProcessIdentifiers: activeProcessIdentifiers)
+        }
+
+        if shortcutBindings != previousState {
+            persistShortcutBindings()
+        }
+    }
+
+    private func isExpiredWindowIdentity(
+        _ identity: String,
+        activeProcessIdentifiers: Set<pid_t>
+    ) -> Bool {
+        let components = identity.split(separator: ":", omittingEmptySubsequences: false)
+        guard components.count >= 4,
+              components[0] == "window",
+              let processIdentifier = pid_t(components[1]),
+              !activeProcessIdentifiers.contains(processIdentifier)
+        else {
+            return false
+        }
+
+        return !processIsRunning(processIdentifier)
     }
 }
 

--- a/Plugins/WindowSwitcher/Sources/WindowSwitcherOverlayController.swift
+++ b/Plugins/WindowSwitcher/Sources/WindowSwitcherOverlayController.swift
@@ -105,6 +105,14 @@ final class WindowSwitcherOverlayController: NSObject, NSWindowDelegate {
         panel?.isVisible ?? false
     }
 
+    var displayedEntries: [WindowSwitcherAppEntry] {
+        model.entries
+    }
+
+    var selectedEntryID: String? {
+        model.selectedID
+    }
+
     func showDirect(
         entries: [WindowSwitcherAppEntry],
         selectedID: String?,
@@ -156,9 +164,13 @@ final class WindowSwitcherOverlayController: NSObject, NSWindowDelegate {
     }
 
     func hide() {
+        model.entries.removeAll()
+        model.selectedID = nil
         model.recordingEntryID = nil
         model.recordingCandidate = nil
         model.recordingHasConflict = false
+        model.shortcutText = ""
+        model.columnCount = 1
         removeKeyMonitor()
         removeClickMonitor()
         isClosing = true

--- a/Plugins/WindowSwitcher/Sources/WindowSwitcherPlugin.swift
+++ b/Plugins/WindowSwitcher/Sources/WindowSwitcherPlugin.swift
@@ -48,12 +48,21 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
     private let appCatalog: WindowSwitcherAppCatalog
     private let overlayController: WindowSwitcherOverlayController
     private let shortcutTap: WindowSwitcherShortcutTap
+    private let sessionEntriesProvider: (@MainActor () async -> [WindowSwitcherAppEntry])?
     private let accessibilityTrusted: @MainActor () -> Bool
     private let requestAccessibilityTrust: @MainActor (Bool) -> Bool
 
     private var isAccessibilityGranted: Bool
     private var lastErrorMessage: String?
     private var session: Session?
+    private var isPreparingSession = false
+    private var pendingDirectRelease = false
+    private var pendingDirectAdvance = 0
+    private var pendingDirectReversed = false
+    private var sessionPreparationGeneration: UInt64 = 0
+    private var sessionPreparationTask: Task<Void, Never>?
+    private var activationGeneration: UInt64 = 0
+    private var activationTask: Task<Void, Never>?
 
     init(
         context: PluginRuntimeContext = PluginRuntimeContext(pluginID: WindowSwitcherConstants.pluginID),
@@ -61,6 +70,7 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
         appCatalog: WindowSwitcherAppCatalog = WindowSwitcherAppCatalog(),
         overlayController: WindowSwitcherOverlayController = WindowSwitcherOverlayController(),
         shortcutTap: WindowSwitcherShortcutTap = WindowSwitcherShortcutTap(),
+        sessionEntriesProvider: (@MainActor () async -> [WindowSwitcherAppEntry])? = nil,
         accessibilityTrusted: @escaping @MainActor () -> Bool = WindowSwitcherAccessibilityCheck.isTrusted,
         requestAccessibilityTrust: @escaping @MainActor (Bool) -> Bool = WindowSwitcherAccessibilityCheck.requestTrust(prompt:)
     ) {
@@ -69,6 +79,7 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
         self.appCatalog = appCatalog
         self.overlayController = overlayController
         self.shortcutTap = shortcutTap
+        self.sessionEntriesProvider = sessionEntriesProvider
         self.accessibilityTrusted = accessibilityTrusted
         self.requestAccessibilityTrust = requestAccessibilityTrust
         self.isAccessibilityGranted = accessibilityTrusted()
@@ -104,6 +115,9 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
         }
         self.shortcutTap.onShortcutReleased = { [weak self] in
             self?.handleShortcutReleased()
+        }
+        self.shortcutTap.onAccessibilityRevoked = { [weak self] in
+            self?.refreshAccessibilityPermission()
         }
         self.shortcutTap.onEscape = { [weak self] in
             self?.cancelSession()
@@ -204,17 +218,15 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
         }
         // Canonical actions have no key-up phase. Always open the interactive
         // chooser instead of starting a direct-cycle session that could never commit.
-        beginKeyWindowSession()
-        let succeeded: Bool
-        if case .keyWindow? = session {
-            succeeded = true
-        } else {
-            succeeded = false
-        }
-        return ActionExecutionHandle {
-            succeeded
-                ? .succeeded()
-                : .failed(message: PluginKitLocalization.actionUnavailable)
+        return ActionExecutionHandle { @MainActor [weak self] in
+            guard let self,
+                  let generation = self.beginSessionPreparation(),
+                  await self.beginKeyWindowSession(generation: generation)
+            else {
+                return .failed(message: PluginKitLocalization.actionUnavailable)
+            }
+
+            return .succeeded()
         }
     }
 
@@ -290,8 +302,8 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
     }
 
     func activate(context: PluginRuntimeContext) {
-        appCatalog.start()
         refreshAccessibilityPermission()
+        syncCatalogDiscovery()
         syncShortcutTap()
     }
 
@@ -300,10 +312,13 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
         appCatalog.stop()
         overlayController.hide()
         session = nil
+        invalidateSessionPreparation()
+        invalidateActivation()
     }
 
     func refresh() {
         refreshAccessibilityPermission()
+        syncCatalogDiscovery()
         syncShortcutTap()
         onStateChange?()
     }
@@ -385,8 +400,11 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
 
         if previous && !isAccessibilityGranted {
             shortcutTap.stop()
+            appCatalog.stop()
             overlayController.hide()
             session = nil
+            invalidateSessionPreparation()
+            invalidateActivation()
             if store.configuration.isEnabled {
                 lastErrorMessage = localization.string(
                     "error.accessibilityRevoked",
@@ -395,6 +413,7 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
             }
         } else if !previous && isAccessibilityGranted {
             lastErrorMessage = nil
+            syncCatalogDiscovery()
             syncShortcutTap()
         }
 
@@ -436,16 +455,33 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
     private func configurationDidChange() {
         overlayController.hide()
         session = nil
+        invalidateSessionPreparation()
+        invalidateActivation()
         if !store.configuration.isEnabled {
             lastErrorMessage = nil
         }
+        syncCatalogDiscovery()
         syncShortcutTap()
         onStateChange?()
     }
 
-    private func handleShortcutPressed(reversed: Bool, isRepeat: Bool) {
+    func handleShortcutPressed(reversed: Bool, isRepeat: Bool) {
         guard store.configuration.isEnabled else {
             return
+        }
+
+        var startsNewGesture = false
+        if !isRepeat, session == nil {
+            if isPreparingSession, pendingDirectRelease {
+                pendingDirectRelease = false
+                pendingDirectAdvance = 0
+                pendingDirectReversed = reversed
+                startsNewGesture = true
+            } else if !isPreparingSession {
+                pendingDirectRelease = false
+                pendingDirectAdvance = 0
+                pendingDirectReversed = false
+            }
         }
 
         guard ensureAccessibilityForInvocation() else {
@@ -454,12 +490,16 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
 
         switch store.configuration.mode {
         case .keyWindow:
-            beginKeyWindowSession()
+            requestKeyWindowSession()
         case .directCycle:
             if case .direct = session {
                 advanceDirectSession(by: reversed ? -1 : 1)
+            } else if isPreparingSession {
+                if !startsNewGesture {
+                    pendingDirectAdvance = pendingDirectAdvance &+ (reversed ? -1 : 1)
+                }
             } else {
-                beginDirectSession(reversed: reversed)
+                requestDirectSession(reversed: reversed)
             }
         }
     }
@@ -469,20 +509,69 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
             return
         }
 
+        refreshAccessibilityPermission()
+        guard isAccessibilityGranted else {
+            cancelSession()
+            return
+        }
+
         guard case .direct = session else {
+            if store.configuration.mode == .directCycle, isPreparingSession {
+                pendingDirectRelease = true
+            }
             return
         }
 
         commitDirectSession()
     }
 
-    private func beginDirectSession(reversed: Bool) {
-        let entries = appCatalog.entries(sortMode: store.configuration.sortMode)
-        guard !entries.isEmpty else {
+    private func requestDirectSession(reversed: Bool) {
+        guard let generation = beginSessionPreparation() else {
+            return
+        }
+        pendingDirectReversed = reversed
+
+        sessionPreparationTask = Task { @MainActor [weak self] in
+            await self?.beginDirectSession(generation: generation)
+        }
+    }
+
+    private func beginDirectSession(generation: UInt64) async {
+        guard generation == sessionPreparationGeneration,
+              isPreparingSession
+        else {
             return
         }
 
-        let selectedIndex = initialDirectSelectionIndex(in: entries, reversed: reversed)
+        defer {
+            if generation == sessionPreparationGeneration {
+                isPreparingSession = false
+                sessionPreparationTask = nil
+                pendingDirectAdvance = 0
+                pendingDirectReversed = false
+            }
+        }
+        let entries = await sessionEntries()
+        refreshAccessibilityPermission()
+        guard generation == sessionPreparationGeneration,
+              !Task.isCancelled,
+              store.configuration.isEnabled,
+              isAccessibilityGranted,
+              !entries.isEmpty
+        else {
+            return
+        }
+
+        let initialIndex = initialDirectSelectionIndex(
+            in: entries,
+            reversed: pendingDirectReversed
+        )
+        let selectedIndex = Self.directSelectionIndex(
+            startingAt: initialIndex,
+            advancingBy: pendingDirectAdvance,
+            count: entries.count
+        )
+        pendingDirectAdvance = 0
 
         session = .direct(entries: entries, selectedIndex: selectedIndex)
         overlayController.showDirect(
@@ -490,6 +579,11 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
             selectedID: entries[selectedIndex].id,
             shortcutText: currentShortcutText
         )
+
+        if pendingDirectRelease {
+            pendingDirectRelease = false
+            commitDirectSession()
+        }
     }
 
     private func advanceDirectSession(by delta: Int) {
@@ -499,7 +593,11 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
             return
         }
 
-        let nextIndex = (selectedIndex + delta + entries.count) % entries.count
+        let nextIndex = Self.directSelectionIndex(
+            startingAt: selectedIndex,
+            advancingBy: delta,
+            count: entries.count
+        )
         session = .direct(entries: entries, selectedIndex: nextIndex)
         overlayController.updateDirectSelection(selectedID: entries[nextIndex].id)
     }
@@ -515,23 +613,52 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
         let entry = entries[selectedIndex]
         overlayController.hide()
         session = nil
-        appCatalog.activate(entry)
+        requestActivation(for: entry)
     }
 
-    private func beginKeyWindowSession() {
-        guard ensureAccessibilityForInvocation() else {
+    private func requestKeyWindowSession() {
+        guard let generation = beginSessionPreparation() else {
             return
+        }
+
+        sessionPreparationTask = Task { @MainActor [weak self] in
+            _ = await self?.beginKeyWindowSession(generation: generation)
+        }
+    }
+
+    private func beginKeyWindowSession(generation: UInt64) async -> Bool {
+        guard generation == sessionPreparationGeneration,
+              isPreparingSession
+        else {
+            return false
+        }
+
+        defer {
+            if generation == sessionPreparationGeneration {
+                isPreparingSession = false
+                sessionPreparationTask = nil
+            }
+        }
+
+        guard ensureAccessibilityForInvocation() else {
+            return false
         }
 
         if case .keyWindow(_) = session, overlayController.isVisible {
-            return
+            return true
         }
 
         let entries = store.assignShortcuts(
-            to: appCatalog.entries(sortMode: store.configuration.sortMode)
+            to: await appCatalog.entries(sortMode: store.configuration.sortMode)
         )
-        guard !entries.isEmpty else {
-            return
+        refreshAccessibilityPermission()
+        guard generation == sessionPreparationGeneration,
+              !Task.isCancelled,
+              store.configuration.isEnabled,
+              isAccessibilityGranted,
+              !entries.isEmpty
+        else {
+            return false
         }
 
         session = .keyWindow(entries: entries)
@@ -539,6 +666,7 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
             entries: entries,
             shortcutText: currentShortcutText
         )
+        return true
     }
 
     private func initialDirectSelectionIndex(in entries: [WindowSwitcherAppEntry], reversed: Bool) -> Int {
@@ -550,12 +678,40 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
             entries.firstIndex { $0.appIdentifier == appID }
         } ?? 0
         let delta = reversed ? -1 : 1
-        return (anchorIndex + delta + entries.count) % entries.count
+        return Self.directSelectionIndex(
+            startingAt: anchorIndex,
+            advancingBy: delta,
+            count: entries.count
+        )
+    }
+
+    static func directSelectionIndex(startingAt index: Int, advancingBy delta: Int, count: Int) -> Int {
+        guard count > 0 else {
+            return 0
+        }
+
+        let normalizedDelta = delta % count
+        return (index + normalizedDelta + count) % count
+    }
+
+    private func sessionEntries() async -> [WindowSwitcherAppEntry] {
+        if let sessionEntriesProvider {
+            return await sessionEntriesProvider()
+        }
+
+        return await appCatalog.entries(sortMode: store.configuration.sortMode)
     }
 
     private func select(_ entry: WindowSwitcherAppEntry) {
+        refreshAccessibilityPermission()
+        guard store.configuration.isEnabled,
+              isAccessibilityGranted
+        else {
+            return
+        }
+
         session = nil
-        appCatalog.activate(entry)
+        requestActivation(for: entry)
     }
 
     private func quit(_ entry: WindowSwitcherAppEntry) {
@@ -582,6 +738,34 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
     private func cancelSession() {
         overlayController.hide()
         session = nil
+        invalidateSessionPreparation()
+        invalidateActivation()
+    }
+
+    private func requestActivation(for entry: WindowSwitcherAppEntry) {
+        activationGeneration &+= 1
+        let generation = activationGeneration
+        activationTask?.cancel()
+        activationTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+
+            await self.appCatalog.activate(entry)
+            guard !Task.isCancelled,
+                  self.activationGeneration == generation
+            else {
+                return
+            }
+
+            self.activationTask = nil
+        }
+    }
+
+    private func invalidateActivation() {
+        activationGeneration &+= 1
+        activationTask?.cancel()
+        activationTask = nil
     }
 
     private func removeEntries(forAppIdentifier appIdentifier: String) {
@@ -639,6 +823,7 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
         isAccessibilityGranted = requestAccessibilityTrust(true)
         if isAccessibilityGranted {
             lastErrorMessage = nil
+            syncCatalogDiscovery()
             syncShortcutTap()
         } else {
             lastErrorMessage = localization.string(
@@ -656,6 +841,35 @@ final class WindowSwitcherPlugin: MacToolsPlugin, AccessibilityPermissionRefresh
         } else {
             shortcutTap.stop()
         }
+    }
+
+    private func syncCatalogDiscovery() {
+        if store.configuration.isEnabled && isAccessibilityGranted {
+            appCatalog.start()
+        } else {
+            appCatalog.stop()
+        }
+    }
+
+    private func beginSessionPreparation() -> UInt64? {
+        guard !isPreparingSession else {
+            return nil
+        }
+
+        invalidateActivation()
+        isPreparingSession = true
+        pendingDirectAdvance = 0
+        return sessionPreparationGeneration
+    }
+
+    private func invalidateSessionPreparation() {
+        sessionPreparationGeneration &+= 1
+        sessionPreparationTask?.cancel()
+        sessionPreparationTask = nil
+        isPreparingSession = false
+        pendingDirectRelease = false
+        pendingDirectAdvance = 0
+        pendingDirectReversed = false
     }
 
     private var currentShortcutText: String {

--- a/Plugins/WindowSwitcher/Sources/WindowSwitcherShortcutTap.swift
+++ b/Plugins/WindowSwitcher/Sources/WindowSwitcherShortcutTap.swift
@@ -7,17 +7,24 @@ final class WindowSwitcherShortcutTap: @unchecked Sendable {
     var onShortcutPressed: @MainActor (_ reversed: Bool, _ isRepeat: Bool) -> Void = { _, _ in }
     var onShortcutReleased: @MainActor () -> Void = {}
     var onEscape: @MainActor () -> Void = {}
+    var onAccessibilityRevoked: @MainActor () -> Void = {}
 
     private let lock = NSLock()
     private let userDefaults: UserDefaults
+    private let accessibilityTrusted: @Sendable () -> Bool
     private var currentBinding: ShortcutBinding?
     private var activeModifiers: ShortcutModifiers?
+    private var didReportAccessibilityRevocation = false
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var defaultsObserver: NSObjectProtocol?
 
-    init(userDefaults: UserDefaults = .standard) {
+    init(
+        userDefaults: UserDefaults = .standard,
+        accessibilityTrusted: @escaping @Sendable () -> Bool = { AXIsProcessTrusted() }
+    ) {
         self.userDefaults = userDefaults
+        self.accessibilityTrusted = accessibilityTrusted
         self.currentBinding = WindowSwitcherShortcutBindingStore.resolvedBinding(userDefaults: userDefaults)
     }
 
@@ -67,6 +74,7 @@ final class WindowSwitcherShortcutTap: @unchecked Sendable {
             runLoopSource = nil
             defaultsObserver = nil
             activeModifiers = nil
+            didReportAccessibilityRevocation = false
             return state
         }
 
@@ -123,7 +131,25 @@ final class WindowSwitcherShortcutTap: @unchecked Sendable {
         }
     }
 
-    private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+    func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        guard accessibilityTrusted() else {
+            let shouldNotify = lock.withLock {
+                activeModifiers = nil
+                guard !didReportAccessibilityRevocation else {
+                    return false
+                }
+
+                didReportAccessibilityRevocation = true
+                return true
+            }
+            if shouldNotify {
+                Task { @MainActor in
+                    self.onAccessibilityRevoked()
+                }
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let tap = lock.withLock({ tap }) {
                 CGEvent.tapEnable(tap: tap, enable: true)
@@ -131,9 +157,8 @@ final class WindowSwitcherShortcutTap: @unchecked Sendable {
             return Unmanaged.passUnretained(event)
         }
 
-        guard AXIsProcessTrusted() else {
-            setActiveModifiers(nil)
-            return Unmanaged.passUnretained(event)
+        lock.withLock {
+            didReportAccessibilityRevocation = false
         }
 
         switch type {

--- a/Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift
+++ b/Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift
@@ -2297,7 +2297,7 @@ final class WindowSwitcherPluginTests: XCTestCase {
             window,
             isMinimized: false,
             deadline: Date().addingTimeInterval(1),
-            setAttributeValue: { _, attribute, _, _ in
+            writeAttribute: { _, attribute, _, _ in
                 writtenAttributes.append(attribute as String)
                 return attribute as String != kAXFocusedAttribute as String
             },

--- a/Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift
+++ b/Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Carbon.HIToolbox
+import CoreGraphics
 import XCTest
 import MacToolsPluginKit
 @testable import MacTools
@@ -48,6 +49,166 @@ private final class WindowSwitcherMemoryStorage: PluginStorage {
 
         values[key] = value
         values.removeValue(forKey: legacyKey)
+    }
+}
+
+private final class WindowSwitcherWindowRecordProviderHarness: @unchecked Sendable {
+    let releaseFirstInvocation = DispatchSemaphore(value: 0)
+    let firstInvocationFinished = DispatchSemaphore(value: 0)
+
+    private let lock = NSLock()
+    private let firstRecords: [WindowSwitcherWindowRecord]
+    private let laterRecords: [WindowSwitcherWindowRecord]
+    private var invocationCount = 0
+
+    init(
+        firstRecords: [WindowSwitcherWindowRecord],
+        laterRecords: [WindowSwitcherWindowRecord]
+    ) {
+        self.firstRecords = firstRecords
+        self.laterRecords = laterRecords
+    }
+
+    func records() -> [WindowSwitcherWindowRecord] {
+        lock.lock()
+        invocationCount += 1
+        let invocation = invocationCount
+        lock.unlock()
+
+        guard invocation == 1 else {
+            return laterRecords
+        }
+
+        _ = releaseFirstInvocation.wait(timeout: .now() + .seconds(5))
+        firstInvocationFinished.signal()
+        return firstRecords
+    }
+
+    func hasAtLeastInvocations(_ count: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return invocationCount >= count
+    }
+}
+
+private final class WindowSwitcherActivationRecordProviderHarness: @unchecked Sendable {
+    let releaseSecondInvocation = DispatchSemaphore(value: 0)
+
+    private let lock = NSLock()
+    private let initialRecords: [WindowSwitcherWindowRecord]
+    private var invocationCount = 0
+
+    init(initialRecords: [WindowSwitcherWindowRecord]) {
+        self.initialRecords = initialRecords
+    }
+
+    func records() -> [WindowSwitcherWindowRecord] {
+        lock.lock()
+        invocationCount += 1
+        let invocation = invocationCount
+        lock.unlock()
+
+        guard invocation > 1 else {
+            return initialRecords
+        }
+
+        _ = releaseSecondInvocation.wait(timeout: .now() + .seconds(5))
+        return initialRecords
+    }
+}
+
+private final class WindowSwitcherAccessibilityHarness: @unchecked Sendable {
+    private let lock = NSLock()
+    private var trusted = true
+    private var checks = 0
+
+    var isTrusted: Bool {
+        get {
+            lock.withLock { trusted }
+        }
+        set {
+            lock.withLock {
+                trusted = newValue
+            }
+        }
+    }
+
+    var checkCount: Int {
+        lock.withLock { checks }
+    }
+
+    func check() -> Bool {
+        lock.withLock {
+            checks += 1
+            return trusted
+        }
+    }
+}
+
+@MainActor
+private final class WindowSwitcherApplicationHarness: WindowSwitcherApplicationControlling {
+    let processIdentifier: pid_t
+    let bundleIdentifier: String?
+    let launchDate: Date?
+    var isTerminated = false
+    private(set) var unhideCount = 0
+    private(set) var activationOptions: NSApplication.ActivationOptions?
+    private(set) var terminateCount = 0
+
+    init(
+        processIdentifier: pid_t,
+        bundleIdentifier: String? = "com.example.window-switcher",
+        launchDate: Date? = nil
+    ) {
+        self.processIdentifier = processIdentifier
+        self.bundleIdentifier = bundleIdentifier
+        self.launchDate = launchDate
+    }
+
+    @discardableResult
+    func unhide() -> Bool {
+        unhideCount += 1
+        return true
+    }
+
+    @discardableResult
+    func activate(options: NSApplication.ActivationOptions) -> Bool {
+        activationOptions = options
+        return true
+    }
+
+    @discardableResult
+    func terminate() -> Bool {
+        terminateCount += 1
+        isTerminated = true
+        return true
+    }
+}
+
+@MainActor
+private final class WindowSwitcherDirectEntriesProviderHarness {
+    let entries: [WindowSwitcherAppEntry]
+    private(set) var didStart = false
+    private var continuation: CheckedContinuation<[WindowSwitcherAppEntry], Never>?
+
+    init(entries: [WindowSwitcherAppEntry]) {
+        self.entries = entries
+    }
+
+    func load() async -> [WindowSwitcherAppEntry] {
+        didStart = true
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func release() {
+        guard let continuation else {
+            return
+        }
+
+        self.continuation = nil
+        continuation.resume(returning: entries)
     }
 }
 
@@ -118,7 +279,10 @@ final class WindowSwitcherPluginTests: XCTestCase {
 
     func testWorkspaceNotificationHopsSafelyToMainActor() async {
         let center = NotificationCenter()
-        let catalog = WindowSwitcherAppCatalog(notificationCenter: center)
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: center,
+            windowRecordProvider: { [] }
+        )
         let changed = expectation(description: "catalog reports a workspace change")
         catalog.onChange = {
             XCTAssertTrue(Thread.isMainThread)
@@ -130,6 +294,1577 @@ final class WindowSwitcherPluginTests: XCTestCase {
 
         await fulfillment(of: [changed], timeout: 1)
         catalog.stop()
+    }
+
+    func testStaleWindowRecordRefreshCannotReplaceNewerSnapshot() async {
+        let firstRecord = WindowSwitcherWindowRecord(
+            windowNumber: 901,
+            processIdentifier: 321,
+            title: "stale snapshot",
+            isOnScreen: false,
+            bounds: CGRect(x: 20, y: 40, width: 900, height: 700)
+        )
+        let laterRecord = WindowSwitcherWindowRecord(
+            windowNumber: 902,
+            processIdentifier: 321,
+            title: "current snapshot",
+            isOnScreen: false,
+            bounds: CGRect(x: 40, y: 60, width: 900, height: 700)
+        )
+        let harness = WindowSwitcherWindowRecordProviderHarness(
+            firstRecords: [firstRecord],
+            laterRecords: [laterRecord]
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: { harness.records() }
+        )
+        defer {
+            harness.releaseFirstInvocation.signal()
+            catalog.stop()
+        }
+
+        catalog.start()
+        let pendingWindowNumbers = Task { @MainActor in
+            await catalog.windowRecordsSnapshot().map(\.windowNumber)
+        }
+        for _ in 0..<100 where !harness.hasAtLeastInvocations(1) {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(harness.hasAtLeastInvocations(1))
+
+        catalog.stop()
+        harness.releaseFirstInvocation.signal()
+        XCTAssertEqual(
+            harness.firstInvocationFinished.wait(timeout: .now() + .seconds(1)),
+            .success
+        )
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+        catalog.start()
+        let currentWindowNumbersTask = Task { @MainActor in
+            await catalog.windowRecordsSnapshot().map(\.windowNumber)
+        }
+        for _ in 0..<100 where !harness.hasAtLeastInvocations(2) {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(harness.hasAtLeastInvocations(2))
+        let currentWindowNumbers = await currentWindowNumbersTask.value
+        let windowNumbers = await pendingWindowNumbers.value
+        XCTAssertTrue(currentWindowNumbers.contains(laterRecord.windowNumber))
+        XCTAssertFalse(windowNumbers.contains(firstRecord.windowNumber))
+    }
+
+    func testCancelledWindowRecordRefreshDoesNotBlockTheNextSnapshot() async {
+        let firstRecord = WindowSwitcherWindowRecord(
+            windowNumber: 903,
+            processIdentifier: 321,
+            title: "blocked snapshot",
+            isOnScreen: false,
+            bounds: CGRect(x: 20, y: 40, width: 900, height: 700)
+        )
+        let harness = WindowSwitcherWindowRecordProviderHarness(
+            firstRecords: [firstRecord],
+            laterRecords: []
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: { harness.records() }
+        )
+        defer {
+            harness.releaseFirstInvocation.signal()
+            catalog.stop()
+        }
+
+        catalog.start()
+        let pendingSnapshot = Task { @MainActor in
+            await catalog.windowRecordsSnapshot()
+        }
+        for _ in 0..<100 where !harness.hasAtLeastInvocations(1) {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(harness.hasAtLeastInvocations(1))
+
+        pendingSnapshot.cancel()
+        let cancelledSnapshot = await pendingSnapshot.value
+        XCTAssertTrue(cancelledSnapshot.isEmpty)
+
+        let nextSnapshot = Task { @MainActor in
+            await catalog.windowRecordsSnapshot()
+        }
+        let currentSnapshot = await nextSnapshot.value
+        XCTAssertTrue(currentSnapshot.isEmpty)
+    }
+
+    func testTimedOutWindowRecordRefreshReturnsWithoutWaitingForProvider() async {
+        let harness = WindowSwitcherWindowRecordProviderHarness(
+            firstRecords: [
+                WindowSwitcherWindowRecord(
+                    windowNumber: 904,
+                    processIdentifier: 321,
+                    title: "timed out snapshot",
+                    isOnScreen: false,
+                    bounds: CGRect(x: 20, y: 40, width: 900, height: 700)
+                ),
+            ],
+            laterRecords: []
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: { harness.records() },
+            windowRecordRefreshTimeout: 0.01
+        )
+        defer {
+            harness.releaseFirstInvocation.signal()
+            catalog.stop()
+        }
+
+        catalog.start()
+        let completed = expectation(description: "timed-out refresh returns a fallback snapshot")
+        var snapshot: [WindowSwitcherWindowRecord]?
+        Task { @MainActor in
+            snapshot = await catalog.windowRecordsSnapshot()
+            completed.fulfill()
+        }
+        await fulfillment(of: [completed], timeout: 1)
+
+        XCTAssertTrue(snapshot?.isEmpty == true)
+    }
+
+    func testTimedOutWindowRecordRefreshAllowsOneBoundedReplacement() async {
+        let laterRecord = WindowSwitcherWindowRecord(
+            windowNumber: 905,
+            processIdentifier: 321,
+            title: "replacement snapshot",
+            isOnScreen: false,
+            bounds: CGRect(x: 40, y: 60, width: 900, height: 700)
+        )
+        let harness = WindowSwitcherWindowRecordProviderHarness(
+            firstRecords: [],
+            laterRecords: [laterRecord]
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: { harness.records() },
+            windowRecordRefreshTimeout: 0.01
+        )
+        defer {
+            harness.releaseFirstInvocation.signal()
+            catalog.stop()
+        }
+
+        catalog.start()
+        let firstSnapshot = await catalog.windowRecordsSnapshot()
+        XCTAssertTrue(firstSnapshot.isEmpty)
+
+        let replacementSnapshot = await catalog.windowRecordsSnapshot()
+        XCTAssertEqual(replacementSnapshot.map(\.windowNumber), [laterRecord.windowNumber])
+        XCTAssertTrue(harness.hasAtLeastInvocations(2))
+    }
+
+    func testDirectCycleQueuesPressesWhileAllSpaceSnapshotIsPreparing() async {
+        let expectedEntries = (0..<4).map { index in
+            makeEntry(
+                index: index,
+                appName: "Test window " + String(index),
+                bundleIdentifier: "com.example.window-switcher-test-" + String(index)
+            )
+        }
+        let harness = WindowSwitcherDirectEntriesProviderHarness(entries: expectedEntries)
+        let overlay = WindowSwitcherOverlayController()
+        let plugin = WindowSwitcherPlugin(
+            context: PluginRuntimeContext(
+                pluginID: WindowSwitcherConstants.pluginID,
+                storage: WindowSwitcherMemoryStorage()
+            ),
+            overlayController: overlay,
+            sessionEntriesProvider: { await harness.load() },
+            accessibilityTrusted: { true }
+        )
+        plugin.store.setMode(.directCycle)
+        defer {
+            harness.release()
+            plugin.deactivate(reason: .hostShutdown)
+        }
+
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .pressed
+        )
+        for _ in 0..<100 where !harness.didStart {
+            await Task.yield()
+        }
+        XCTAssertTrue(harness.didStart)
+
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .pressed
+        )
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .pressed
+        )
+        harness.release()
+
+        for _ in 0..<100 where !overlay.isVisible {
+            await Task.yield()
+        }
+        XCTAssertTrue(overlay.isVisible)
+
+        let entries = overlay.displayedEntries
+        guard !entries.isEmpty,
+              let selectedID = overlay.selectedEntryID else {
+            return XCTFail("Expected the direct-cycle overlay to expose a selected entry.")
+        }
+
+        let initialIndex = WindowSwitcherPlugin.directSelectionIndex(
+            startingAt: 0,
+            advancingBy: 1,
+            count: entries.count
+        )
+        let expectedIndex = WindowSwitcherPlugin.directSelectionIndex(
+            startingAt: initialIndex,
+            advancingBy: 2,
+            count: entries.count
+        )
+        XCTAssertEqual(selectedID, entries[expectedIndex].id)
+    }
+
+    func testDirectCycleReleaseRechecksAccessibilityPermission() async {
+        let entries = (0..<2).map { index in
+            makeEntry(
+                index: index,
+                appName: "Permission test window " + String(index),
+                bundleIdentifier: "com.example.window-switcher-permission-test-" + String(index)
+            )
+        }
+        let harness = WindowSwitcherDirectEntriesProviderHarness(entries: entries)
+        let overlay = WindowSwitcherOverlayController()
+        let accessibility = WindowSwitcherAccessibilityHarness()
+        let plugin = WindowSwitcherPlugin(
+            context: PluginRuntimeContext(
+                pluginID: WindowSwitcherConstants.pluginID,
+                storage: WindowSwitcherMemoryStorage()
+            ),
+            overlayController: overlay,
+            sessionEntriesProvider: { await harness.load() },
+            accessibilityTrusted: { accessibility.check() }
+        )
+        plugin.store.setMode(.directCycle)
+        defer {
+            harness.release()
+            plugin.deactivate(reason: .hostShutdown)
+        }
+
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .pressed
+        )
+        for _ in 0..<100 where !harness.didStart {
+            await Task.yield()
+        }
+        XCTAssertTrue(harness.didStart)
+        harness.release()
+
+        for _ in 0..<100 where !overlay.isVisible {
+            await Task.yield()
+        }
+        XCTAssertTrue(overlay.isVisible)
+
+        let checksBeforeRelease = accessibility.checkCount
+        accessibility.isTrusted = false
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .released
+        )
+
+        XCTAssertGreaterThan(accessibility.checkCount, checksBeforeRelease)
+        XCTAssertFalse(overlay.isVisible)
+        XCTAssertFalse(
+            plugin.permissionState(for: WindowSwitcherConstants.accessibilityPermissionID).isGranted
+        )
+    }
+
+    func testDirectCycleNewPressAfterPendingReleaseStartsANewGesture() async {
+        let entries = (0..<3).map { index in
+            makeEntry(
+                index: index,
+                appName: "Repress test window " + String(index),
+                bundleIdentifier: "com.example.window-switcher-repress-test-" + String(index)
+            )
+        }
+        let harness = WindowSwitcherDirectEntriesProviderHarness(entries: entries)
+        let overlay = WindowSwitcherOverlayController()
+        let plugin = WindowSwitcherPlugin(
+            context: PluginRuntimeContext(
+                pluginID: WindowSwitcherConstants.pluginID,
+                storage: WindowSwitcherMemoryStorage()
+            ),
+            overlayController: overlay,
+            sessionEntriesProvider: { await harness.load() },
+            accessibilityTrusted: { true }
+        )
+        plugin.store.setMode(.directCycle)
+        defer {
+            harness.release()
+            plugin.deactivate(reason: .hostShutdown)
+        }
+
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .pressed
+        )
+        for _ in 0..<100 where !harness.didStart {
+            await Task.yield()
+        }
+        XCTAssertTrue(harness.didStart)
+
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .released
+        )
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .pressed
+        )
+        harness.release()
+
+        for _ in 0..<100 where !overlay.isVisible {
+            await Task.yield()
+        }
+        XCTAssertTrue(overlay.isVisible)
+        XCTAssertEqual(overlay.selectedEntryID, entries[1].id)
+    }
+
+    func testDirectCycleReversedRepressUsesOneInitialStep() async {
+        let entries = (0..<3).map { index in
+            makeEntry(
+                index: index,
+                appName: "Reverse repress test window " + String(index),
+                bundleIdentifier: "com.example.window-switcher-reverse-repress-test-" + String(index)
+            )
+        }
+        let harness = WindowSwitcherDirectEntriesProviderHarness(entries: entries)
+        let overlay = WindowSwitcherOverlayController()
+        let plugin = WindowSwitcherPlugin(
+            context: PluginRuntimeContext(
+                pluginID: WindowSwitcherConstants.pluginID,
+                storage: WindowSwitcherMemoryStorage()
+            ),
+            overlayController: overlay,
+            sessionEntriesProvider: { await harness.load() },
+            accessibilityTrusted: { true }
+        )
+        plugin.store.setMode(.directCycle)
+        defer {
+            harness.release()
+            plugin.deactivate(reason: .hostShutdown)
+        }
+
+        plugin.handleShortcutPressed(reversed: false, isRepeat: false)
+        for _ in 0..<100 where !harness.didStart {
+            await Task.yield()
+        }
+        XCTAssertTrue(harness.didStart)
+
+        plugin.handleShortcutEvent(
+            id: WindowSwitcherConstants.shortcutActionID,
+            phase: .released
+        )
+        plugin.handleShortcutPressed(reversed: true, isRepeat: false)
+        harness.release()
+
+        for _ in 0..<100 where !overlay.isVisible {
+            await Task.yield()
+        }
+        XCTAssertTrue(overlay.isVisible)
+        XCTAssertEqual(overlay.selectedEntryID, entries[2].id)
+    }
+
+    func testShortcutTapReportsAccessibilityRevocationToPlugin() async throws {
+        let accessibility = WindowSwitcherAccessibilityHarness()
+        let tapDefaults = try XCTUnwrap(
+            UserDefaults(suiteName: "WindowSwitcherPluginTests-tap-" + UUID().uuidString)
+        )
+        let tap = WindowSwitcherShortcutTap(
+            userDefaults: tapDefaults,
+            accessibilityTrusted: { accessibility.check() }
+        )
+        let plugin = WindowSwitcherPlugin(
+            context: PluginRuntimeContext(
+                pluginID: WindowSwitcherConstants.pluginID,
+                storage: WindowSwitcherMemoryStorage()
+            ),
+            shortcutTap: tap,
+            accessibilityTrusted: { accessibility.check() }
+        )
+
+        accessibility.isTrusted = false
+        let event = try XCTUnwrap(CGEvent(source: nil))
+        _ = tap.handle(type: .keyDown, event: event)
+
+        for _ in 0..<100 where plugin.permissionState(
+            for: WindowSwitcherConstants.accessibilityPermissionID
+        ).isGranted {
+            await Task.yield()
+        }
+
+        XCTAssertGreaterThan(accessibility.checkCount, 0)
+        XCTAssertFalse(
+            plugin.permissionState(for: WindowSwitcherConstants.accessibilityPermissionID).isGranted
+        )
+    }
+
+    func testShortcutTapReportsAccessibilityRevocationWhenTapIsDisabled() async throws {
+        let accessibility = WindowSwitcherAccessibilityHarness()
+        let tapDefaults = try XCTUnwrap(
+            UserDefaults(suiteName: "WindowSwitcherPluginTests-disabled-tap-" + UUID().uuidString)
+        )
+        let tap = WindowSwitcherShortcutTap(
+            userDefaults: tapDefaults,
+            accessibilityTrusted: { accessibility.check() }
+        )
+        let plugin = WindowSwitcherPlugin(
+            context: PluginRuntimeContext(
+                pluginID: WindowSwitcherConstants.pluginID,
+                storage: WindowSwitcherMemoryStorage()
+            ),
+            shortcutTap: tap,
+            accessibilityTrusted: { accessibility.check() }
+        )
+
+        accessibility.isTrusted = false
+        let event = try XCTUnwrap(CGEvent(source: nil))
+        _ = tap.handle(type: .tapDisabledByTimeout, event: event)
+
+        for _ in 0..<100 where plugin.permissionState(
+            for: WindowSwitcherConstants.accessibilityPermissionID
+        ).isGranted {
+            await Task.yield()
+        }
+
+        XCTAssertGreaterThan(accessibility.checkCount, 0)
+        XCTAssertFalse(
+            plugin.permissionState(for: WindowSwitcherConstants.accessibilityPermissionID).isGranted
+        )
+    }
+
+    func testWindowRecordsKeepInactiveSpaceAndSameApplicationWindowsDistinct() {
+        let records = WindowSwitcherWindowRecord.parse([
+            windowInfo(
+                number: 101,
+                ownerPID: 321,
+                title: "Finder — Space 1",
+                isOnscreen: true,
+                bounds: CGRect(x: 20, y: 40, width: 900, height: 700)
+            ),
+            windowInfo(
+                number: 102,
+                ownerPID: 321,
+                title: "Finder — Space 2",
+                isOnscreen: false,
+                bounds: CGRect(x: 40, y: 60, width: 900, height: 700)
+            ),
+        ])
+
+        XCTAssertEqual(records.map(\.windowNumber), [101, 102])
+        XCTAssertEqual(records.map(\.processIdentifier), [321, 321])
+        XCTAssertEqual(records.map(\.title), ["Finder — Space 1", "Finder — Space 2"])
+        XCTAssertEqual(records.map(\.isOnScreen), [true, false])
+    }
+
+    func testAllSpaceRecordsPreferAXMetadataAndKeepCoreGraphicsWindows() {
+        let records = WindowSwitcherWindowRecord.parse([
+            windowInfo(
+                number: 301,
+                ownerPID: 321,
+                title: "Shared title",
+                isOnscreen: true,
+                bounds: CGRect(x: 20, y: 40, width: 900, height: 700)
+            ),
+            windowInfo(
+                number: 302,
+                ownerPID: 321,
+                title: "Inactive Space window",
+                isOnscreen: false,
+                bounds: CGRect(x: 40, y: 60, width: 900, height: 700)
+            ),
+        ])
+        let axSnapshot = WindowSwitcherWindowSnapshot(
+            element: nil,
+            windowNumber: nil,
+            title: "Shared title",
+            isMinimized: true,
+            position: CGPoint(x: 20, y: 40),
+            size: CGSize(width: 900, height: 700)
+        )
+
+        let merged = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: [axSnapshot],
+            records: records
+        )
+
+        XCTAssertEqual(merged.map(\.windowNumber), [301, 302])
+        XCTAssertEqual(merged.map(\.title), ["Shared title", "Inactive Space window"])
+        XCTAssertTrue(merged[0].isMinimized)
+        XCTAssertNil(merged[1].element)
+
+        let entries = WindowSwitcherAppCatalog.windowEntries(
+            processIdentifier: 321,
+            bundleIdentifier: "com.example.Finder",
+            appName: "Finder",
+            icon: nil,
+            windows: merged
+        )
+        XCTAssertEqual(entries.map(\.id), ["window:321:cg:301", "window:321:cg:302"])
+        XCTAssertTrue(entries.allSatisfy(\.isWindowEntry))
+
+        let mixedEntries = WindowSwitcherAppCatalog.windowEntries(
+            processIdentifier: 321,
+            bundleIdentifier: "com.example.Finder",
+            appName: "Finder",
+            icon: nil,
+            windows: [
+                merged[0],
+                WindowSwitcherWindowSnapshot(
+                    element: nil,
+                    windowNumber: nil,
+                    title: "AX-only window",
+                    isMinimized: false,
+                    position: CGPoint(x: 60, y: 80),
+                    size: CGSize(width: 900, height: 700)
+                ),
+            ]
+        )
+        XCTAssertEqual(mixedEntries.map(\.id), ["window:321:cg:301", "window:321:ax:1"])
+        XCTAssertEqual(Set(mixedEntries.map(\.id)).count, mixedEntries.count)
+
+        let applicationEntry = WindowSwitcherAppCatalog.applicationEntry(
+            id: "bundle:com.example.Finder",
+            processIdentifier: 321,
+            bundleIdentifier: "com.example.Finder",
+            appName: "Finder",
+            icon: nil
+        )
+        XCTAssertFalse(applicationEntry.isWindowEntry)
+        XCTAssertEqual(applicationEntry.displayName, "Finder")
+    }
+
+    func testAllSpaceMergeUsesUniqueGeometryWhenCoreGraphicsTitleIsMissing() {
+        var titlelessRecord = windowInfo(
+            number: 303,
+            ownerPID: 321,
+            title: "",
+            isOnscreen: true,
+            bounds: CGRect(x: 80, y: 100, width: 900, height: 700)
+        )
+        titlelessRecord.removeValue(forKey: kCGWindowName as String)
+
+        let axWindow = WindowSwitcherWindowSnapshot(
+            element: AXUIElementCreateSystemWide(),
+            windowNumber: nil,
+            title: "Window title from AX",
+            isMinimized: false,
+            position: CGPoint(x: 80, y: 100),
+            size: CGSize(width: 900, height: 700)
+        )
+        let merged = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: [axWindow],
+            records: WindowSwitcherWindowRecord.parse([titlelessRecord])
+        )
+
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(merged.first?.windowNumber, 303)
+        XCTAssertEqual(merged.first?.title, "Window title from AX")
+        XCTAssertNotNil(merged.first?.element)
+    }
+
+    func testAllSpaceMergePrioritizesExactTitleBeforeGeometryFallback() {
+        let bounds = CGRect(x: 100, y: 120, width: 900, height: 700)
+        var titlelessRecord = windowInfo(
+            number: 309,
+            ownerPID: 321,
+            title: "",
+            isOnscreen: true,
+            bounds: bounds
+        )
+        titlelessRecord.removeValue(forKey: kCGWindowName as String)
+        let exactRecord = windowInfo(
+            number: 310,
+            ownerPID: 321,
+            title: "Exact title",
+            isOnscreen: true,
+            bounds: bounds
+        )
+        let records = WindowSwitcherWindowRecord.parse([titlelessRecord, exactRecord])
+        let axWindow = WindowSwitcherWindowSnapshot(
+            element: AXUIElementCreateSystemWide(),
+            windowNumber: nil,
+            title: "Exact title",
+            isMinimized: false,
+            position: bounds.origin,
+            size: bounds.size
+        )
+
+        let merged = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: [axWindow],
+            records: records
+        )
+        let reversed = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: [axWindow],
+            records: Array(records.reversed())
+        )
+
+        XCTAssertNil(merged[0].element)
+        XCTAssertNotNil(merged[1].element)
+        XCTAssertNotNil(reversed[0].element)
+        XCTAssertNil(reversed[1].element)
+    }
+
+    func testAllSpaceMergeUsesOnScreenRecordWhenMetadataIsOtherwiseAmbiguous() {
+        let bounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        let records = WindowSwitcherWindowRecord.parse([
+            windowInfo(
+                number: 304,
+                ownerPID: 321,
+                title: "Duplicate title",
+                isOnscreen: false,
+                bounds: bounds
+            ),
+            windowInfo(
+                number: 305,
+                ownerPID: 321,
+                title: "Duplicate title",
+                isOnscreen: true,
+                bounds: bounds
+            ),
+        ])
+        let axWindow = WindowSwitcherWindowSnapshot(
+            element: AXUIElementCreateSystemWide(),
+            windowNumber: nil,
+            title: "Duplicate title",
+            isMinimized: false,
+            position: bounds.origin,
+            size: bounds.size
+        )
+
+        let merged = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: [axWindow],
+            records: records
+        )
+
+        XCTAssertEqual(merged.map(\.windowNumber), [304, 305])
+        XCTAssertNil(merged[0].element)
+        XCTAssertNotNil(merged[1].element)
+
+        let reversed = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: [axWindow],
+            records: Array(records.reversed())
+        )
+
+        XCTAssertEqual(reversed.map(\.windowNumber), [305, 304])
+        XCTAssertNotNil(reversed[0].element)
+        XCTAssertNil(reversed[1].element)
+    }
+
+    func testAllSpaceMergeDoesNotGuessWhenOnScreenMetadataIsUnknown() {
+        let bounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        var unknownRecord = windowInfo(
+            number: 306,
+            ownerPID: 321,
+            title: "Duplicate title",
+            isOnscreen: false,
+            bounds: bounds
+        )
+        unknownRecord.removeValue(forKey: kCGWindowIsOnscreen as String)
+        let records = WindowSwitcherWindowRecord.parse([
+            unknownRecord,
+            windowInfo(
+                number: 307,
+                ownerPID: 321,
+                title: "Duplicate title",
+                isOnscreen: true,
+                bounds: bounds
+            ),
+        ])
+        let axWindow = WindowSwitcherWindowSnapshot(
+            element: AXUIElementCreateSystemWide(),
+            windowNumber: nil,
+            title: "Duplicate title",
+            isMinimized: false,
+            position: bounds.origin,
+            size: bounds.size
+        )
+
+        let merged = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: [axWindow],
+            records: records
+        )
+
+        XCTAssertNil(records[0].isOnScreen)
+        XCTAssertEqual(merged.map(\.windowNumber), [306, 307])
+        XCTAssertNil(merged[0].element)
+        XCTAssertNotNil(merged[1].element)
+
+        var malformedRecord = windowInfo(
+            number: 308,
+            ownerPID: 321,
+            title: "Malformed on-screen value",
+            isOnscreen: false,
+            bounds: bounds
+        )
+        malformedRecord[kCGWindowIsOnscreen as String] = NSNumber(value: 1)
+        let malformed = WindowSwitcherWindowRecord.parse([malformedRecord])
+        XCTAssertNil(malformed.first?.isOnScreen)
+    }
+
+    func testAllSpaceMergePreservesAXOnlyWindowsWhenAXHasMoreCandidates() {
+        let bounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        let records = WindowSwitcherWindowRecord.parse([
+            windowInfo(
+                number: 311,
+                ownerPID: 321,
+                title: "Duplicate title",
+                isOnscreen: false,
+                bounds: bounds
+            ),
+        ])
+        let axWindows = [
+            WindowSwitcherWindowSnapshot(
+                element: AXUIElementCreateSystemWide(),
+                windowNumber: nil,
+                title: "Duplicate title",
+                isMinimized: false,
+                position: bounds.origin,
+                size: bounds.size
+            ),
+            WindowSwitcherWindowSnapshot(
+                element: AXUIElementCreateApplication(1),
+                windowNumber: nil,
+                title: "Duplicate title",
+                isMinimized: true,
+                position: bounds.origin,
+                size: bounds.size
+            ),
+        ]
+
+        let merged = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: axWindows,
+            records: records
+        )
+        let reversed = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: Array(axWindows.reversed()),
+            records: records
+        )
+
+        XCTAssertEqual(merged.count, 2)
+        XCTAssertEqual(merged.filter { $0.windowNumber != nil }.count, 1)
+        XCTAssertEqual(merged.filter { $0.element != nil }.count, 1)
+        XCTAssertEqual(reversed.count, 2)
+        XCTAssertEqual(reversed.filter { $0.windowNumber != nil }.count, 1)
+        XCTAssertEqual(reversed.filter { $0.element != nil }.count, 1)
+    }
+
+    func testAllSpaceMergePreservesDistinctAXOnlyTitleWithSharedBounds() {
+        let bounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        let records = WindowSwitcherWindowRecord.parse([
+            windowInfo(
+                number: 314,
+                ownerPID: 321,
+                title: "First title",
+                isOnscreen: false,
+                bounds: bounds
+            ),
+            windowInfo(
+                number: 315,
+                ownerPID: 321,
+                title: "Second title",
+                isOnscreen: false,
+                bounds: bounds
+            ),
+        ])
+        let axSnapshots = [
+            WindowSwitcherWindowSnapshot(
+                element: AXUIElementCreateSystemWide(),
+                windowNumber: nil,
+                title: "First title",
+                isMinimized: false,
+                position: bounds.origin,
+                size: bounds.size
+            ),
+            WindowSwitcherWindowSnapshot(
+                element: AXUIElementCreateApplication(1),
+                windowNumber: nil,
+                title: "AX-only title",
+                isMinimized: false,
+                position: bounds.origin,
+                size: bounds.size
+            ),
+        ]
+
+        let merged = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+            axSnapshots: axSnapshots,
+            records: records
+        )
+
+        XCTAssertEqual(merged.count, 3)
+        XCTAssertEqual(merged.map(\.title), ["First title", "Second title", "AX-only title"])
+        XCTAssertEqual(merged.filter { $0.element != nil }.count, 2)
+        XCTAssertNil(merged[1].element)
+    }
+
+    func testAllSpaceMergeMatchesResidualGeometryAfterExactTitleMatch() {
+        let bounds = CGRect(x: 120, y: 140, width: 900, height: 700)
+        var titlelessRecord = windowInfo(
+            number: 312,
+            ownerPID: 321,
+            title: "",
+            isOnscreen: true,
+            bounds: bounds
+        )
+        titlelessRecord.removeValue(forKey: kCGWindowName as String)
+        let exactRecord = windowInfo(
+            number: 313,
+            ownerPID: 321,
+            title: "Exact title",
+            isOnscreen: true,
+            bounds: bounds
+        )
+        let records = WindowSwitcherWindowRecord.parse([titlelessRecord, exactRecord])
+        let axSnapshots = [
+            WindowSwitcherWindowSnapshot(
+                element: AXUIElementCreateSystemWide(),
+                windowNumber: nil,
+                title: "Exact title",
+                isMinimized: false,
+                position: bounds.origin,
+                size: bounds.size
+            ),
+            WindowSwitcherWindowSnapshot(
+                element: AXUIElementCreateApplication(1),
+                windowNumber: nil,
+                title: "Residual title",
+                isMinimized: true,
+                position: bounds.origin,
+                size: bounds.size
+            ),
+        ]
+
+        for (candidateRecords, candidates) in [
+            (records, axSnapshots),
+            (Array(records.reversed()), Array(axSnapshots.reversed())),
+        ] {
+            let merged = WindowSwitcherAppCatalog.mergeWindowSnapshots(
+                axSnapshots: candidates,
+                records: candidateRecords
+            )
+
+            XCTAssertEqual(merged.count, 2)
+            let exact = merged.first { $0.windowNumber == 313 }
+            let residual = merged.first { $0.windowNumber == 312 }
+            XCTAssertEqual(exact?.title, "Exact title")
+            XCTAssertNotNil(exact?.element)
+            XCTAssertEqual(residual?.title, "Residual title")
+            XCTAssertTrue(residual?.isMinimized == true)
+            XCTAssertNotNil(residual?.element)
+        }
+    }
+
+    func testAXTimeoutIsCappedByRemainingGlobalBudget() throws {
+        XCTAssertEqual(
+            try XCTUnwrap(WindowSwitcherAppCatalog.axTimeout(forRemaining: 0.5)),
+            0.2,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(WindowSwitcherAppCatalog.axTimeout(forRemaining: 0.05)),
+            0.05,
+            accuracy: 0.0001
+        )
+        XCTAssertNil(WindowSwitcherAppCatalog.axTimeout(forRemaining: 0))
+        XCTAssertNil(WindowSwitcherAppCatalog.axTimeout(forRemaining: -0.1))
+    }
+
+    func testAXSessionBudgetAllocatesADeadlineToEveryApplication() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let sessionDeadline = now.addingTimeInterval(1)
+
+        let firstDeadline = WindowSwitcherAppCatalog.axDeadline(
+            sessionDeadline: sessionDeadline,
+            appIndex: 0,
+            appCount: 2,
+            now: now
+        )
+        let secondDeadline = WindowSwitcherAppCatalog.axDeadline(
+            sessionDeadline: sessionDeadline,
+            appIndex: 1,
+            appCount: 2,
+            now: now.addingTimeInterval(0.5)
+        )
+
+        XCTAssertEqual(firstDeadline.timeIntervalSince(now), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(secondDeadline, sessionDeadline)
+    }
+
+    func testAXFallbackLookupStopsWhenItsDeadlineIsReached() {
+        let candidate = AXUIElementCreateSystemWide()
+        let snapshot = WindowSwitcherWindowSnapshot(
+            element: candidate,
+            windowNumber: nil,
+            title: "different title",
+            isMinimized: false,
+            position: CGPoint(x: 80, y: 100),
+            size: CGSize(width: 900, height: 700)
+        )
+        let deadline = Date(timeIntervalSince1970: 10)
+        var nowCallCount = 0
+        var snapshotCallCount = 0
+
+        let result = WindowSwitcherAppCatalog.firstMatchingWindow(
+            in: [candidate, candidate],
+            title: "requested title",
+            bounds: CGRect(x: 80, y: 100, width: 900, height: 700),
+            deadline: deadline,
+            now: {
+                nowCallCount += 1
+                return nowCallCount == 1
+                    ? Date(timeIntervalSince1970: 9)
+                    : Date(timeIntervalSince1970: 11)
+            },
+            snapshotProvider: { _ in
+                snapshotCallCount += 1
+                return snapshot
+            }
+        )
+
+        XCTAssertNil(result)
+        XCTAssertEqual(snapshotCallCount, 1)
+    }
+
+    func testAXFallbackLookupPreservesMinimizedState() {
+        let candidate = AXUIElementCreateSystemWide()
+        let snapshot = WindowSwitcherWindowSnapshot(
+            element: candidate,
+            windowNumber: nil,
+            title: "requested title",
+            isMinimized: true,
+            position: CGPoint(x: 80, y: 100),
+            size: CGSize(width: 900, height: 700)
+        )
+
+        let result = WindowSwitcherAppCatalog.firstMatchingWindow(
+            in: [candidate],
+            title: "requested title",
+            bounds: CGRect(x: 80, y: 100, width: 900, height: 700),
+            deadline: Date().addingTimeInterval(1),
+            now: { Date() },
+            snapshotProvider: { _ in snapshot }
+        )
+
+        XCTAssertTrue(result?.isMinimized == true)
+        XCTAssertNotNil(result?.element)
+    }
+
+    func testAXFallbackLookupRejectsAmbiguousMatches() {
+        let candidate = AXUIElementCreateSystemWide()
+        let snapshot = WindowSwitcherWindowSnapshot(
+            element: candidate,
+            windowNumber: nil,
+            title: "requested title",
+            isMinimized: false,
+            position: CGPoint(x: 80, y: 100),
+            size: CGSize(width: 900, height: 700)
+        )
+        var snapshotCallCount = 0
+
+        let result = WindowSwitcherAppCatalog.firstMatchingWindow(
+            in: [candidate, candidate],
+            title: "requested title",
+            bounds: CGRect(x: 80, y: 100, width: 900, height: 700),
+            deadline: Date().addingTimeInterval(1),
+            now: { Date() },
+            snapshotProvider: { _ in
+                snapshotCallCount += 1
+                return snapshot
+            }
+        )
+
+        XCTAssertNil(result)
+        XCTAssertEqual(snapshotCallCount, 2)
+    }
+
+    func testActivationFallbackUsesCurrentAXMinimizedState() async {
+        let processIdentifier: pid_t = 321
+        let launchDate = Date(timeIntervalSince1970: 3_000)
+        let bounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: launchDate
+        )
+        let windowElement = AXUIElementCreateSystemWide()
+        let snapshot = WindowSwitcherWindowSnapshot(
+            element: windowElement,
+            windowNumber: nil,
+            title: "Restored title",
+            isMinimized: true,
+            position: bounds.origin,
+            size: bounds.size
+        )
+        var focusedMinimizedStates: [Bool] = []
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: {
+                [
+                    WindowSwitcherWindowRecord(
+                        windowNumber: 701,
+                        processIdentifier: processIdentifier,
+                        title: "Restored title",
+                        isOnScreen: true,
+                        bounds: bounds
+                    ),
+                ]
+            },
+            applicationProvider: { _ in application },
+            activationWindowSnapshotProvider: { _, _ in snapshot },
+            focusWindowHandler: { focusedWindow, isMinimized in
+                XCTAssertTrue(CFEqual(focusedWindow, windowElement))
+                focusedMinimizedStates.append(isMinimized)
+            }
+        )
+        let entry = WindowSwitcherAppEntry(
+            id: "window:321:cg:701",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            windowTitle: "Restored title",
+            icon: nil,
+            windowElement: nil,
+            isMinimized: false,
+            windowNumber: 701,
+            windowBounds: bounds,
+            applicationLaunchDate: launchDate,
+            shortcutToken: nil
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.unhideCount, 1)
+        XCTAssertEqual(application.activationOptions, [.activateAllWindows])
+        XCTAssertEqual(focusedMinimizedStates, [true])
+    }
+
+    func testActivationFallbackLeavesCGOnlyEntryUnfocusedWhenAXLookupFindsNoMatch() async {
+        let processIdentifier: pid_t = 322
+        let launchDate = Date(timeIntervalSince1970: 3_001)
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: launchDate
+        )
+        var focusCount = 0
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: {
+                [
+                    WindowSwitcherWindowRecord(
+                        windowNumber: 702,
+                        processIdentifier: processIdentifier,
+                        title: "Unavailable title",
+                        isOnScreen: true,
+                        bounds: CGRect(x: 80, y: 100, width: 900, height: 700)
+                    ),
+                ]
+            },
+            applicationProvider: { _ in application },
+            activationWindowSnapshotProvider: { _, _ in nil },
+            focusWindowHandler: { _, _ in
+                focusCount += 1
+            }
+        )
+        let entry = WindowSwitcherAppEntry(
+            id: "window:322:cg:702",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            windowTitle: "Unavailable title",
+            icon: nil,
+            windowElement: nil,
+            isMinimized: false,
+            windowNumber: 702,
+            windowBounds: CGRect(x: 80, y: 100, width: 900, height: 700),
+            applicationLaunchDate: launchDate,
+            shortcutToken: nil
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.activationOptions, [.activateAllWindows])
+        XCTAssertEqual(focusCount, 0)
+    }
+
+    func testActivationAXBackedEntryDoesNotRequireUnchangedCoreGraphicsBounds() async {
+        let processIdentifier: pid_t = 325
+        let launchDate = Date(timeIntervalSince1970: 3_003)
+        let expectedBounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: launchDate
+        )
+        let windowElement = AXUIElementCreateSystemWide()
+        var focusedMinimizedStates: [Bool] = []
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: {
+                [
+                    WindowSwitcherWindowRecord(
+                        windowNumber: 704,
+                        processIdentifier: processIdentifier,
+                        title: "Moved title",
+                        isOnScreen: true,
+                        bounds: CGRect(x: 90, y: 110, width: 900, height: 700)
+                    ),
+                ]
+            },
+            applicationProvider: { _ in application },
+            focusWindowHandler: { focusedWindow, isMinimized in
+                XCTAssertTrue(CFEqual(focusedWindow, windowElement))
+                focusedMinimizedStates.append(isMinimized)
+            }
+        )
+        let entry = WindowSwitcherAppEntry(
+            id: "window:325:cg:704",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            windowTitle: "Moved title",
+            icon: nil,
+            windowElement: windowElement,
+            isMinimized: true,
+            windowNumber: 704,
+            windowBounds: expectedBounds,
+            applicationLaunchDate: launchDate,
+            shortcutToken: nil
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.unhideCount, 1)
+        XCTAssertEqual(application.activationOptions, [])
+        XCTAssertEqual(focusedMinimizedStates, [true])
+    }
+
+    func testActivationRejectsAReusedProcessBeforeAnyApplicationSideEffect() async {
+        let processIdentifier: pid_t = 323
+        let currentLaunchDate = Date(timeIntervalSince1970: 2_000)
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: currentLaunchDate
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: { [] },
+            applicationProvider: { _ in application }
+        )
+        let entry = WindowSwitcherAppEntry(
+            id: "app:323",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            windowTitle: nil,
+            icon: nil,
+            windowElement: nil,
+            isMinimized: false,
+            windowNumber: nil,
+            windowBounds: nil,
+            applicationLaunchDate: currentLaunchDate.addingTimeInterval(-1),
+            shortcutToken: nil
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.unhideCount, 0)
+        XCTAssertNil(application.activationOptions)
+    }
+
+    func testActivationAllowsApplicationWhenLaunchDateIsUnavailable() async {
+        let processIdentifier: pid_t = 327
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: nil
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            applicationProvider: { _ in application }
+        )
+        let entry = WindowSwitcherAppCatalog.applicationEntry(
+            id: "app:327",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            icon: nil,
+            applicationLaunchDate: nil
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.unhideCount, 1)
+        XCTAssertEqual(application.activationOptions, [])
+    }
+
+    func testActivationAllowsApplicationWhenCurrentLaunchDateIsUnavailable() async {
+        let processIdentifier: pid_t = 328
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: nil
+        )
+        let entry = WindowSwitcherAppCatalog.applicationEntry(
+            id: "app:328",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            icon: nil,
+            applicationLaunchDate: Date(timeIntervalSince1970: 3_004)
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            applicationProvider: { _ in application }
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.unhideCount, 1)
+        XCTAssertEqual(application.activationOptions, [])
+    }
+
+    func testActivationAllowsApplicationWhenEntryLaunchDateIsUnavailable() async {
+        let processIdentifier: pid_t = 329
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: Date(timeIntervalSince1970: 3_005)
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            applicationProvider: { _ in application }
+        )
+        let entry = WindowSwitcherAppCatalog.applicationEntry(
+            id: "app:329",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            icon: nil,
+            applicationLaunchDate: nil
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.unhideCount, 1)
+        XCTAssertEqual(application.activationOptions, [])
+    }
+
+    func testCancelledApplicationActivationDoesNotPerformSideEffects() async {
+        let processIdentifier: pid_t = 330
+        let application = WindowSwitcherApplicationHarness(processIdentifier: processIdentifier)
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            applicationProvider: { _ in application }
+        )
+        let entry = WindowSwitcherAppCatalog.applicationEntry(
+            id: "app:330",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            icon: nil
+        )
+        let task = Task { @MainActor in
+            await Task.yield()
+            await catalog.activate(entry)
+        }
+
+        task.cancel()
+        await task.value
+
+        XCTAssertEqual(application.unhideCount, 0)
+        XCTAssertNil(application.activationOptions)
+    }
+
+    func testCancelledAXActivationDoesNotPerformSideEffects() async {
+        let processIdentifier: pid_t = 331
+        let application = WindowSwitcherApplicationHarness(processIdentifier: processIdentifier)
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            applicationProvider: { _ in application }
+        )
+        let entry = WindowSwitcherAppEntry(
+            id: "window:331:ax:0",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            windowTitle: "AX window",
+            icon: nil,
+            windowElement: AXUIElementCreateSystemWide(),
+            isMinimized: false,
+            windowNumber: nil,
+            windowBounds: CGRect(x: 80, y: 100, width: 900, height: 700),
+            shortcutToken: nil
+        )
+        let task = Task { @MainActor in
+            await Task.yield()
+            await catalog.activate(entry)
+        }
+
+        task.cancel()
+        await task.value
+
+        XCTAssertEqual(application.unhideCount, 0)
+        XCTAssertNil(application.activationOptions)
+    }
+
+    func testActivationRejectsStaleCoreGraphicsWindowBeforeUnhiding() async {
+        let processIdentifier: pid_t = 324
+        let launchDate = Date(timeIntervalSince1970: 3_002)
+        let expectedBounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: launchDate
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: {
+                [
+                    WindowSwitcherWindowRecord(
+                        windowNumber: 703,
+                        processIdentifier: processIdentifier,
+                        title: "Current title",
+                        isOnScreen: true,
+                        bounds: CGRect(x: 90, y: 110, width: 900, height: 700)
+                    ),
+                ]
+            },
+            applicationProvider: { _ in application }
+        )
+        let entry = WindowSwitcherAppEntry(
+            id: "window:324:cg:703",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            windowTitle: "Current title",
+            icon: nil,
+            windowElement: nil,
+            isMinimized: false,
+            windowNumber: 703,
+            windowBounds: expectedBounds,
+            applicationLaunchDate: launchDate,
+            shortcutToken: nil
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.unhideCount, 0)
+        XCTAssertNil(application.activationOptions)
+    }
+
+    func testActivationRejectsCachedCoreGraphicsWindowAfterRefreshTimeout() async {
+        let processIdentifier: pid_t = 326
+        let launchDate = Date(timeIntervalSince1970: 3_004)
+        let bounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        let record = WindowSwitcherWindowRecord(
+            windowNumber: 705,
+            processIdentifier: processIdentifier,
+            title: "Cached title",
+            isOnScreen: true,
+            bounds: bounds
+        )
+        let harness = WindowSwitcherActivationRecordProviderHarness(initialRecords: [record])
+        let application = WindowSwitcherApplicationHarness(
+            processIdentifier: processIdentifier,
+            launchDate: launchDate
+        )
+        let catalog = WindowSwitcherAppCatalog(
+            notificationCenter: NotificationCenter(),
+            windowRecordProvider: { harness.records() },
+            windowRecordRefreshTimeout: 0.01,
+            applicationProvider: { _ in application }
+        )
+        defer {
+            harness.releaseSecondInvocation.signal()
+            catalog.stop()
+        }
+
+        let initialSnapshot = await catalog.windowRecordsSnapshot()
+        XCTAssertEqual(initialSnapshot.map(\.windowNumber), [705])
+        let entry = WindowSwitcherAppEntry(
+            id: "window:326:cg:705",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.window-switcher",
+            appName: "Window Switcher test app",
+            windowTitle: "Cached title",
+            icon: nil,
+            windowElement: nil,
+            isMinimized: false,
+            windowNumber: 705,
+            windowBounds: bounds,
+            applicationLaunchDate: launchDate,
+            shortcutToken: nil
+        )
+
+        await catalog.activate(entry)
+
+        XCTAssertEqual(application.unhideCount, 0)
+        XCTAssertNil(application.activationOptions)
+    }
+
+    func testWindowRecordsIgnoreNonSwitchableOrTransparentWindows() {
+        var missingAlpha = windowInfo(
+            number: 204,
+            ownerPID: 321,
+            title: "Missing alpha",
+            isOnscreen: true,
+            bounds: CGRect(x: 20, y: 40, width: 900, height: 700)
+        )
+        missingAlpha.removeValue(forKey: kCGWindowAlpha as String)
+        var booleanNumber = windowInfo(
+            number: 205,
+            ownerPID: 321,
+            title: "Boolean number",
+            isOnscreen: true,
+            bounds: CGRect(x: 20, y: 40, width: 900, height: 700)
+        )
+        booleanNumber[kCGWindowNumber as String] = true
+        let nonFiniteBounds = windowInfo(
+            number: 206,
+            ownerPID: 321,
+            title: "Non-finite bounds",
+            isOnscreen: true,
+            bounds: CGRect(x: CGFloat.infinity, y: 40, width: 900, height: 700)
+        )
+
+        let records = WindowSwitcherWindowRecord.parse([
+            windowInfo(
+                number: 201,
+                ownerPID: 321,
+                title: "Too small",
+                isOnscreen: true,
+                bounds: CGRect(x: 20, y: 40, width: 79, height: 60)
+            ),
+            windowInfo(
+                number: 202,
+                ownerPID: 321,
+                title: "Transparent",
+                isOnscreen: false,
+                bounds: CGRect(x: 20, y: 40, width: 900, height: 700),
+                alpha: 0
+            ),
+            windowInfo(
+                number: 203,
+                ownerPID: 321,
+                title: "Menu",
+                isOnscreen: true,
+                bounds: CGRect(x: 20, y: 40, width: 900, height: 700),
+                layer: 1
+            ),
+            missingAlpha,
+            booleanNumber,
+            nonFiniteBounds,
+        ])
+
+        XCTAssertTrue(records.isEmpty)
+    }
+
+    func testWindowRecordParserRejectsMalformedRequiredMetadataIndividually() {
+        let valid = windowInfo(
+            number: 250,
+            ownerPID: 321,
+            title: "Valid",
+            isOnscreen: true,
+            bounds: CGRect(x: 20, y: 40, width: 900, height: 700)
+        )
+        XCTAssertEqual(WindowSwitcherWindowRecord.parse([valid]).count, 1)
+
+        var missingNumber = valid
+        missingNumber.removeValue(forKey: kCGWindowNumber as String)
+        var fractionalNumber = valid
+        fractionalNumber[kCGWindowNumber as String] = 250.5
+        var missingOwner = valid
+        missingOwner.removeValue(forKey: kCGWindowOwnerPID as String)
+        var booleanOwner = valid
+        booleanOwner[kCGWindowOwnerPID as String] = true
+        var fractionalOwner = valid
+        fractionalOwner[kCGWindowOwnerPID as String] = 321.5
+        var missingLayer = valid
+        missingLayer.removeValue(forKey: kCGWindowLayer as String)
+        var booleanLayer = valid
+        booleanLayer[kCGWindowLayer as String] = false
+        var fractionalLayer = valid
+        fractionalLayer[kCGWindowLayer as String] = 0.5
+        var missingAlpha = valid
+        missingAlpha.removeValue(forKey: kCGWindowAlpha as String)
+        var booleanAlpha = valid
+        booleanAlpha[kCGWindowAlpha as String] = true
+        var nonFiniteAlpha = valid
+        nonFiniteAlpha[kCGWindowAlpha as String] = NSNumber(value: Double.nan)
+        var outOfRangeAlpha = valid
+        outOfRangeAlpha[kCGWindowAlpha as String] = 1.1
+        var missingBounds = valid
+        missingBounds.removeValue(forKey: kCGWindowBounds as String)
+        var malformedBounds = valid
+        malformedBounds[kCGWindowBounds as String] = NSNull()
+
+        let malformedCases = [
+            ("missing window number", missingNumber),
+            ("fractional window number", fractionalNumber),
+            ("missing owner PID", missingOwner),
+            ("boolean owner PID", booleanOwner),
+            ("fractional owner PID", fractionalOwner),
+            ("missing layer", missingLayer),
+            ("boolean layer", booleanLayer),
+            ("fractional layer", fractionalLayer),
+            ("missing alpha", missingAlpha),
+            ("boolean alpha", booleanAlpha),
+            ("non-finite alpha", nonFiniteAlpha),
+            ("out-of-range alpha", outOfRangeAlpha),
+            ("missing bounds", missingBounds),
+            ("malformed bounds", malformedBounds),
+        ]
+
+        for (label, item) in malformedCases {
+            XCTAssertTrue(
+                WindowSwitcherWindowRecord.parse([item]).isEmpty,
+                "Expected \(label) to be rejected."
+            )
+        }
+    }
+
+    func testWindowRecordParserKeepsAllEligibleWindowsForOneApplication() {
+        let records = (0..<65).map { index in
+            windowInfo(
+                number: 1_000 + index,
+                ownerPID: 321,
+                title: "Window (index)",
+                isOnscreen: index == 0,
+                bounds: CGRect(x: CGFloat(index), y: 40, width: 900, height: 700)
+            )
+        }
+
+        XCTAssertEqual(WindowSwitcherWindowRecord.parse(records).count, 65)
+    }
+
+    func testWindowEntryIsWindowWhenOnlySystemWindowNumberIsAvailable() {
+        let entry = WindowSwitcherAppEntry(
+            id: "window:321:102",
+            processIdentifier: 321,
+            bundleIdentifier: "com.apple.finder",
+            appName: "Finder",
+            windowTitle: "Finder — Space 2",
+            icon: nil,
+            windowElement: nil,
+            isMinimized: false,
+            windowNumber: 102,
+            windowBounds: CGRect(x: 40, y: 60, width: 900, height: 700),
+            shortcutToken: nil
+        )
+
+        XCTAssertTrue(entry.isWindowEntry)
+        XCTAssertEqual(entry.displayName, "Finder — Space 2")
     }
 
     func testModePersists() {
@@ -365,6 +2100,194 @@ final class WindowSwitcherPluginTests: XCTestCase {
         )
     }
 
+    func testLegacySingleWindowShortcutMigratesToStableAXIdentity() throws {
+        let entry = try XCTUnwrap(
+            WindowSwitcherAppCatalog.windowEntries(
+                processIdentifier: 321,
+                bundleIdentifier: "com.apple.Safari",
+                appName: "Safari",
+                icon: nil,
+                windows: [
+                    WindowSwitcherWindowSnapshot(
+                        element: AXUIElementCreateSystemWide(),
+                        windowNumber: nil,
+                        title: "Only window",
+                        isMinimized: false,
+                        position: CGPoint(x: 80, y: 100),
+                        size: CGSize(width: 900, height: 700)
+                    ),
+                ]
+            ).first
+        )
+        let storage = WindowSwitcherMemoryStorage()
+        let legacyState = WindowSwitcherShortcutBindingState(
+            manual: ["bundle:com.apple.Safari": "q"]
+        )
+        storage.set(
+            try JSONEncoder().encode(legacyState),
+            forKey: "shortcut-bindings"
+        )
+
+        let store = WindowSwitcherStore(storage: storage)
+        let assigned = store.assignShortcuts(to: [entry])
+
+        XCTAssertEqual(assigned[0].shortcutToken, "q")
+        XCTAssertEqual(
+            store.shortcutBindings.manual["window:321:ax:\(entry.id)"],
+            "q"
+        )
+        XCTAssertNil(store.shortcutBindings.manual["bundle:com.apple.Safari"])
+    }
+
+    func testAmbiguousLegacyFirstWindowShortcutCanBeExplicitlyReassigned() throws {
+        let entries = WindowSwitcherAppCatalog.windowEntries(
+            processIdentifier: 321,
+            bundleIdentifier: "com.apple.Safari",
+            appName: "Safari",
+            icon: nil,
+            windows: [
+                WindowSwitcherWindowSnapshot(
+                    element: nil,
+                    windowNumber: 401,
+                    title: "First window",
+                    isMinimized: false,
+                    position: CGPoint(x: 80, y: 100),
+                    size: CGSize(width: 900, height: 700)
+                ),
+                WindowSwitcherWindowSnapshot(
+                    element: nil,
+                    windowNumber: 402,
+                    title: "Second window",
+                    isMinimized: false,
+                    position: CGPoint(x: 100, y: 120),
+                    size: CGSize(width: 900, height: 700)
+                ),
+            ]
+        )
+        let storage = WindowSwitcherMemoryStorage()
+        let legacyState = WindowSwitcherShortcutBindingState(
+            manual: ["bundle:com.apple.Safari": "q"]
+        )
+        storage.set(
+            try JSONEncoder().encode(legacyState),
+            forKey: "shortcut-bindings"
+        )
+
+        let store = WindowSwitcherStore(storage: storage)
+        let assigned = store.assignShortcuts(to: entries)
+        XCTAssertFalse(assigned.contains { $0.shortcutToken == "q" })
+
+        guard case let .updated(reassigned) = store.setManualShortcut(
+            "q",
+            for: entries[1].id,
+            in: assigned
+        ) else {
+            return XCTFail("Expected explicit reassignment of the legacy shortcut.")
+        }
+
+        XCTAssertEqual(reassigned[1].shortcutToken, "q")
+        XCTAssertEqual(store.shortcutBindings.manual["window:321:cg:402"], "q")
+        XCTAssertEqual(store.shortcutBindings.manual["bundle:com.apple.Safari"], "q")
+    }
+
+    func testWindowShortcutIdentityUsesCoreGraphicsNumberAcrossSpaceInsertion() throws {
+        let bounds = CGRect(x: 80, y: 100, width: 900, height: 700)
+        let first = WindowSwitcherAppCatalog.windowEntries(
+            processIdentifier: 321,
+            bundleIdentifier: "com.apple.Safari",
+            appName: "Safari",
+            icon: nil,
+            windows: [
+                WindowSwitcherWindowSnapshot(
+                    element: AXUIElementCreateSystemWide(),
+                    windowNumber: 401,
+                    title: "First window",
+                    isMinimized: false,
+                    position: bounds.origin,
+                    size: bounds.size
+                ),
+            ]
+        )[0]
+        let second = WindowSwitcherAppCatalog.windowEntries(
+            processIdentifier: 321,
+            bundleIdentifier: "com.apple.Safari",
+            appName: "Safari",
+            icon: nil,
+            windows: [
+                WindowSwitcherWindowSnapshot(
+                    element: AXUIElementCreateSystemWide(),
+                    windowNumber: 402,
+                    title: "Second window",
+                    isMinimized: false,
+                    position: CGPoint(x: 100, y: 120),
+                    size: bounds.size
+                ),
+            ]
+        )[0]
+        let inactiveSpaceWindow = WindowSwitcherAppCatalog.windowEntries(
+            processIdentifier: 321,
+            bundleIdentifier: "com.apple.Safari",
+            appName: "Safari",
+            icon: nil,
+            windows: [
+                WindowSwitcherWindowSnapshot(
+                    element: nil,
+                    windowNumber: 403,
+                    title: "Inactive Space window",
+                    isMinimized: false,
+                    position: CGPoint(x: 120, y: 140),
+                    size: bounds.size
+                ),
+            ]
+        )[0]
+
+        let storage = WindowSwitcherMemoryStorage()
+        let store = WindowSwitcherStore(storage: storage)
+        let initialEntries = store.assignShortcuts(to: [first, second])
+        guard case .updated = store.setManualShortcut("q", for: second.id, in: initialEntries) else {
+            return XCTFail("Expected a saved shortcut for the second window.")
+        }
+
+        let reorderedEntries = store.assignShortcuts(to: [inactiveSpaceWindow, first, second])
+        XCTAssertEqual(reorderedEntries[2].shortcutToken, "q")
+        XCTAssertEqual(store.shortcutBindings.manual["window:321:cg:402"], "q")
+
+        let legacyStorage = WindowSwitcherMemoryStorage()
+        let legacyState = WindowSwitcherShortcutBindingState(
+            manual: ["bundle:com.apple.Safari#window:2": "q"]
+        )
+        legacyStorage.set(
+            try JSONEncoder().encode(legacyState),
+            forKey: "shortcut-bindings"
+        )
+        let migratedStore = WindowSwitcherStore(storage: legacyStorage)
+        let migratedEntries = migratedStore.assignShortcuts(
+            to: [inactiveSpaceWindow, first, second]
+        )
+
+        XCTAssertNotEqual(migratedEntries[2].shortcutToken, "q")
+        XCTAssertNil(migratedStore.shortcutBindings.manual["window:321:cg:402"])
+        XCTAssertEqual(
+            migratedStore.shortcutBindings.manual["bundle:com.apple.Safari#window:2"],
+            "q"
+        )
+
+        guard case let .updated(reassignedEntries) = migratedStore.setManualShortcut(
+            "q",
+            for: migratedEntries[2].id,
+            in: migratedEntries
+        ) else {
+            return XCTFail("Expected explicit reassignment of the legacy shortcut.")
+        }
+
+        XCTAssertEqual(reassignedEntries[2].shortcutToken, "q")
+        XCTAssertEqual(migratedStore.shortcutBindings.manual["window:321:cg:402"], "q")
+        XCTAssertEqual(
+            migratedStore.shortcutBindings.manual["bundle:com.apple.Safari#window:2"],
+            "q"
+        )
+    }
+
     private func makeEntry(
         index: Int,
         appName: String,
@@ -379,7 +2302,29 @@ final class WindowSwitcherPluginTests: XCTestCase {
             icon: nil,
             windowElement: nil,
             isMinimized: false,
+            windowNumber: nil,
+            windowBounds: nil,
             shortcutToken: nil
         )
+    }
+
+    private func windowInfo(
+        number: Int,
+        ownerPID: Int,
+        title: String,
+        isOnscreen: Bool,
+        bounds: CGRect,
+        layer: Int = 0,
+        alpha: Double = 1
+    ) -> [String: Any] {
+        [
+            kCGWindowNumber as String: number,
+            kCGWindowOwnerPID as String: ownerPID,
+            kCGWindowLayer as String: layer,
+            kCGWindowAlpha as String: alpha,
+            kCGWindowName as String: title,
+            kCGWindowIsOnscreen as String: isOnscreen,
+            kCGWindowBounds as String: bounds.dictionaryRepresentation,
+        ]
     }
 }

--- a/Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift
+++ b/Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift
@@ -2288,6 +2288,77 @@ final class WindowSwitcherPluginTests: XCTestCase {
         )
     }
 
+    func testFocusStillRaisesWindowWhenFocusedAttributeIsReadOnly() {
+        let window = AXUIElementCreateSystemWide()
+        var writtenAttributes: [String] = []
+        var didRaise = false
+
+        WindowSwitcherAppCatalog.focusWindow(
+            window,
+            isMinimized: false,
+            deadline: Date().addingTimeInterval(1),
+            setAttributeValue: { _, attribute, _, _ in
+                writtenAttributes.append(attribute as String)
+                return attribute as String != kAXFocusedAttribute as String
+            },
+            performRaise: { _, _ in
+                didRaise = true
+                return true
+            }
+        )
+
+        XCTAssertEqual(
+            writtenAttributes,
+            [kAXMainAttribute as String, kAXFocusedAttribute as String]
+        )
+        XCTAssertTrue(didRaise)
+    }
+
+    func testRestartedApplicationReleasesExpiredWindowShortcutForReassignment() {
+        let storage = WindowSwitcherMemoryStorage()
+        let oldState = WindowSwitcherShortcutBindingState(
+            manual: ["window:321:cg:401": "q"]
+        )
+        storage.set(try? JSONEncoder().encode(oldState), forKey: "shortcut-bindings")
+        let store = WindowSwitcherStore(storage: storage, processIsRunning: { _ in false })
+        let restartedEntry = makeWindowEntry(
+            processIdentifier: 654,
+            windowNumber: 501,
+            title: "Restarted window"
+        )
+        let entries = store.assignShortcuts(to: [restartedEntry])
+
+        guard case let .updated(reassigned) = store.setManualShortcut(
+            "q",
+            for: restartedEntry.id,
+            in: entries
+        ) else {
+            return XCTFail("Expected the expired shortcut to be reassigned after restart.")
+        }
+
+        XCTAssertEqual(reassigned[0].shortcutToken, "q")
+        XCTAssertNil(store.shortcutBindings.manual["window:321:cg:401"])
+        XCTAssertEqual(store.shortcutBindings.manual["window:654:cg:501"], "q")
+    }
+
+    func testTemporarilyMissingWindowKeepsShortcutWhileProcessIsRunning() {
+        let storage = WindowSwitcherMemoryStorage()
+        let oldState = WindowSwitcherShortcutBindingState(
+            manual: ["window:321:cg:401": "q"]
+        )
+        storage.set(try? JSONEncoder().encode(oldState), forKey: "shortcut-bindings")
+        let store = WindowSwitcherStore(storage: storage, processIsRunning: { $0 == 321 })
+        let visibleEntry = makeWindowEntry(
+            processIdentifier: 654,
+            windowNumber: 501,
+            title: "Visible window"
+        )
+        let entries = store.assignShortcuts(to: [visibleEntry])
+
+        XCTAssertTrue(store.hasShortcutConflict("q", for: visibleEntry.id, in: entries))
+        XCTAssertEqual(store.shortcutBindings.manual["window:321:cg:401"], "q")
+    }
+
     private func makeEntry(
         index: Int,
         appName: String,
@@ -2304,6 +2375,26 @@ final class WindowSwitcherPluginTests: XCTestCase {
             isMinimized: false,
             windowNumber: nil,
             windowBounds: nil,
+            shortcutToken: nil
+        )
+    }
+
+    private func makeWindowEntry(
+        processIdentifier: pid_t,
+        windowNumber: CGWindowID,
+        title: String
+    ) -> WindowSwitcherAppEntry {
+        WindowSwitcherAppEntry(
+            id: "window-\(processIdentifier)-\(windowNumber)",
+            processIdentifier: processIdentifier,
+            bundleIdentifier: "com.example.WindowApp",
+            appName: "Window App",
+            windowTitle: title,
+            icon: nil,
+            windowElement: nil,
+            isMinimized: false,
+            windowNumber: windowNumber,
+            windowBounds: CGRect(x: 80, y: 100, width: 900, height: 700),
             shortcutToken: nil
         )
     }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@
 | Menu Bar Icon Customization | Use local images or lightweight GIF/MP4 animations as the menu bar icon, choose static or animated icons from the online gallery with clear animation badges, preserve original colors and transparency on local import, automatically adapt monochrome gallery icons to the menu bar appearance, restore the default icon, and preview every source with the same standard icon height and content inset as the default. |
 | Localization | Follow the system language by default, or choose a fixed app language in Settings > General > Appearance; the picker shows each language in the system language and its native spelling, while menu-bar action buttons and the Actions, Run Links, Automation, and Action Grid surfaces adapt their copy, accessibility labels, and layout to the selected language. |
 
+> **Window Switcher:** The catalog includes eligible windows from inactive macOS Spaces, so switching does not depend on the current Space.
+
 > **Shortcut settings:** Plugin and app shortcut rows keep the action icon/name beside the recorder field, wrapping groups between rows without splitting an individual shortcut control.
 
 > **System Status:** Both dashboard entry points keep readings current while open. Detail statistics use all retained readings in the selected range, independent of chart simplification, and pinned readings stay fixed until they leave that range. Expanded metric settings adapt to narrower windows. An optional global shortcut shows the menu-bar overview when available and otherwise opens the dashboard. The updated plugin requires MacTools 1.2.1 or later.

--- a/changes/unreleased/window-switcher-multi-space.md
+++ b/changes/unreleased/window-switcher-multi-space.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: fixed
+area: Window Switcher
+---
+
+Window Switcher now includes eligible windows from inactive macOS Spaces and keeps same-application windows as separate switchable entries.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -6,3 +6,4 @@
 - [App Reopen Recovery](app-reopen-recovery.md)
 - [Input Remapping](input-remapping.md)
 - [zsh Config Editor Stability](zsh-config-editor-stability.md)
+- [Window Switcher multi-Space window discovery](window-switcher-multi-space.md)

--- a/docs/features/window-switcher-multi-space.md
+++ b/docs/features/window-switcher-multi-space.md
@@ -1,0 +1,174 @@
+# Feature — Window Switcher multi-Space window discovery
+
+Last verified: 2026-08-31
+
+Status: ready-for-publish
+Source of truth: yes
+
+## Summary
+
+- Window Switcher must list eligible windows located on every macOS Space, not only the active Space.
+- Existing application ordering, per-window shortcut assignment semantics, accessibility permission handling, and AX-based activation remain unchanged when their data is available.
+- The correction is limited to cached discovery and activation fallback for windows that are not exposed by the active Space's Accessibility window list.
+- CoreGraphics discovery runs off the main actor; each session awaits the current snapshot before AX enrichment.
+- Missing CoreGraphics titles use unique geometry matching only when the AX candidate is unambiguous; CG-backed and AX-only entry IDs use disjoint namespaces.
+- Duplicate title-and-geometry metadata never relies on enumeration order; a sole on-screen CoreGraphics record may receive the sole AX candidate, otherwise entries remain CG-only.
+- Exact title-and-geometry matches are resolved before titleless geometry fallbacks; when AX exposes more indistinguishable candidates than CoreGraphics, only the cardinality surplus is retained as AX-only entries.
+- Post-activation AX fallback lookup uses the same cancellation and bounded deadline and focuses from the current AX minimized state.
+- Direct-cycle presses received while the initial catalog scan is pending are accumulated and applied before the overlay is shown.
+
+## User flow
+
+1. The user opens Finder windows A, B, and C across two Spaces.
+2. The user invokes Window Switcher from either Space.
+3. The switcher shows all three Finder windows, including windows on the inactive Space.
+4. Selecting a window activates its application and uses its Accessibility element for precise focus when macOS exposes that element.
+
+## Acceptance criteria
+
+- [x] A window belonging to an inactive Space is present in the Window Switcher catalog.
+- [x] Windows from the active and inactive Spaces remain distinct entries when they belong to the same application.
+- [ ] Selecting an entry still restores an unminimized AX window and raises/focuses it when an AX element is available.
+- [x] Applications without a discoverable window keep the existing application-level fallback entry.
+- [x] Missing required window-list identity, process, geometry, layer, or alpha metadata fails closed; optional title or on-screen metadata may use safe fallbacks without crashing the plugin.
+
+## Definition of done
+
+- [x] The catalog discovers all-space windows through a public macOS API and merges them with existing AX snapshots.
+- [x] A focused regression test covers an off-active-Space window record and duplicate same-application windows.
+- [x] Targeted tests, plugin build, repository PR checks, whitespace checks, and the separate standards/spec/security reviews pass.
+- [x] Manual macOS acceptance is recorded, including any unavailable interaction evidence.
+- [x] README and the unreleased changelog describe the corrected user-visible behavior.
+- [ ] The change is published as one focused pull request closing issue #357.
+
+## Business rules
+
+| Rule | Markdown | Centralized code | Consumers |
+|---|---|---|---|
+| Eligible windows from inactive Spaces are included | This file | `WindowSwitcherAppCatalog` and its window-record parser | Window Switcher catalog, key-selection panel, direct-cycle mode |
+| AX metadata and activation remain preferred when available | This file | `WindowSwitcherAppCatalog` | Window Switcher activation |
+| A missing AX element does not remove a discoverable window | This file | `WindowSwitcherAppCatalog` and `WindowSwitcherAppEntry` | Window Switcher catalog and shortcut assignment |
+
+## Decisions
+
+| Date | Decision | Reason | Impact |
+|---|---|---|---|
+| 2026-08-31 | Refresh the `CGWindowListCopyWindowInfo` all-window snapshot off the main actor and await the current refresh before building a session | The issue requires cross-Space discovery without adding a synchronous global scan to the shortcut-opening path | Catalog refreshes stay responsive and each new session uses a fresh system snapshot |
+| 2026-08-31 | Keep AX elements optional for records discovered only by CoreGraphics | macOS may not expose an inactive-Space window through Accessibility until its application is activated | The app is activated with the existing safe fallback; exact AX focus remains used whenever available |
+| 2026-08-31 | Correlate AX and CoreGraphics records only through public title, position, and size attributes | The Accessibility SDK does not expose a documented window-number attribute | The system window number is retained for entry identity; exact post-activation focus remains best-effort when metadata matches |
+| 2026-08-31 | Use the system window number in window-entry and shortcut-binding identities when available; migrate a legacy application binding only when exactly one current window proves the target, otherwise keep legacy ordinal and application bindings unresolved until explicit reassignment | Array indexes change as Spaces and window order change, and persisted ordinal data cannot prove which current window it represented | Stable entries cannot retarget an old shortcut; the sole provable legacy target keeps its manual binding, while ambiguous legacy bindings remain stored but are not silently assigned |
+| 2026-08-31 | Restrict CoreGraphics-only records to regular-app, layer-zero, positive-alpha, minimum-sized windows | CoreGraphics does not provide the Accessibility role/subrole used by the existing AX filter | Inactive-Space records remain discoverable without adding system or menu-bar surfaces |
+| 2026-08-31 | Do not silently cap eligible CoreGraphics or Accessibility windows | A hidden cap would violate the all-eligible-window contract and drop valid same-application windows | All valid records are retained; each catalog session shares one cancellation-aware AX time budget |
+| 2026-08-31 | Use unique geometry matching only for an unambiguous missing-title candidate | `kCGWindowName` is optional and exact title matching can duplicate an active window | AX metadata is preferred without guessing between same-geometry windows |
+| 2026-08-31 | Give CG-backed and AX-only entries disjoint IDs | A numeric window number can equal an AX-only array index | SwiftUI selection and entry lookup remain unambiguous |
+| 2026-08-31 | Bound post-activation AX fallback and use its current minimized state | A slow AX server or stale CG state must not freeze activation or prevent deminimization | The app activation fallback remains safe and bounded while current AX state is honored |
+| 2026-08-31 | Reject ambiguous AX matches and use `isOnScreen` only when it identifies one record among otherwise identical CoreGraphics candidates | `optionAll` order is not a stable identity across Spaces | An ambiguous window stays safely CG-only instead of receiving the wrong AX element |
+| 2026-08-31 | Accumulate direct-cycle deltas while the initial session is preparing | All-Space discovery is asynchronous and later key presses must not disappear | Repeated presses preserve their requested movement before the overlay is displayed |
+| 2026-08-31 | Treat a new press after a pending release as a new direct-cycle gesture | A slow all-Space snapshot must not auto-commit a gesture that the user already released | The pending release is cleared and the new press controls whether the prepared overlay remains visible |
+| 2026-08-31 | Reconcile Accessibility revocation at the event-tap boundary | Permission can disappear between the last plugin refresh and a global input event | The tap stops consuming shortcut state and notifies the plugin to cancel the active session |
+| 2026-08-31 | Resolve exact AX/CG metadata matches before titleless geometry fallbacks and preserve only cardinality-surplus AX candidates | Optional titles and duplicate bounds cannot provide a stable cross-API identity | A titleless record cannot steal an exact match, and extra AX windows remain switchable without duplicating every ambiguous candidate |
+| 2026-08-31 | Inject application activation, post-activation lookup, and focus callbacks at the catalog boundary | CG-only activation is platform-dependent and cannot be exercised safely with live applications in unit tests | The fallback contract is testable without launching or focusing a real user application |
+| 2026-08-31 | Require a completed CoreGraphics refresh before CG-only activation and allow AX-backed entries to tolerate geometry drift | Cached records must not authorize a stale window, while AX already provides the stronger activation handle | Timeout or saturation fails closed for CG-only activation; valid AX-backed focus is not rejected solely because the window moved |
+| 2026-08-31 | Invalidate late refreshes by generation, permit a bounded replacement, and cap record lookup by PID before AX enrichment | A cancelled synchronous provider cannot be interrupted, but a timed-out provider must not permanently block recovery or accumulate without bound | Catalog sessions remain responsive, stale results cannot overwrite newer snapshots, and the all-eligible-window contract is preserved |
+| 2026-08-31 | Treat an unavailable application launch date as an optional identity value, while requiring matching PID, termination state, bundle identity, and any dates exposed by both snapshots | `NSRunningApplication.launchDate` is optional for legitimate running applications | Missing dates do not block normal activation; an observed launch-date mismatch still rejects a reused process |
+
+## Plan
+
+- [x] P001 — Revalidate issue #357, the canonical repository, concurrent PRs, and GitButler state.
+- [x] P002 — Define the all-Space discovery, AX enrichment, fallback activation, and regression-test contract.
+- [x] P003 — Implement the catalog change and focused tests.
+- [x] P004 — Update README/changelog and complete targeted plus PR verification.
+- [ ] P005 — Publish one focused PR and confirm it remotely.
+
+## TODO
+
+- [x] F001 — Add an injectable all-window CoreGraphics record provider and safe parser — files: `Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift` — status: done
+- [x] F002 — Merge CoreGraphics records with AX snapshots and preserve activation fallbacks — files: `Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift`, `Plugins/WindowSwitcher/Sources/WindowSwitcherModels.swift` — status: done
+- [x] F003 — Add regression coverage for inactive-Space and same-application windows — files: `Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift` — status: done
+- [x] F004 — Document the corrected behavior — files: `README.md`, `changes/unreleased/window-switcher-multi-space.md` — status: done
+
+## Journal impl Codex
+
+- 2026-08-31 — Plan created from issue #357. The scoped seam is the existing Window Switcher catalog; no manifest, PluginKit, dependency, or version change is planned.
+- 2026-08-31 — Added `WindowSwitcherWindowRecord.parse` and an injected `.optionAll` CoreGraphics provider. Records are filtered to minimum-sized layer-zero windows, retain offscreen status, and are deduplicated by system window number; the provider runs off the main actor and each session awaits its current refresh.
+- 2026-08-31 — `WindowSwitcherAppCatalog` now merges all-space records with AX snapshots through public title/position/size metadata, keeps AX focus/raise behavior, and falls back to `.activateAllWindows` plus a post-activation AX lookup for a CoreGraphics-only window.
+- 2026-08-31 — Added focused parser/model regression tests and updated README plus the plugin changelog. The focused tests and `make build-plugin PLUGIN=WindowSwitcher` passed; unrelated compile warnings remain outside this change and will be attributed in the PR gate record.
+- 2026-08-31 — `make ci` passed all 195 script tests and changelog validation, but the repository XCTest phase reported six failures outside WindowSwitcher (`DiskCleanPluginTests` x3, `AppleShortcutsCommandRunnerTests` x2, and `PluginPackageManifestTests` x1). The standalone PluginKit v5 compatibility check passed.
+- 2026-08-31 — Manual system inspection created Finder windows on two existing Spaces: the real CoreGraphics inventory returned 6 Finder windows with `.optionAll` and 2 with `.optionOnScreenOnly`. `make run` could not install the Debug app because the existing installer rejected the signed-but-missing `MacToolsTests.xctest`; launching the built app directly exposed no accessible Window Switcher overlay, so end-to-end visual selection remains unverified.
+- 2026-08-31 — Standards/spec review required explicit bounded-snapshot rationale, strict numeric metadata parsing, AX/CG merge coverage, and an accurate shortcut-identity limitation. The implementation and tests now include those constraints; exact visual selection of a CG-only inactive-Space window remains platform/session dependent.
+- 2026-08-31 — Follow-up spec review found optional CoreGraphics titles could duplicate AX windows and mixed CG/AX-only IDs could collide. The merge now uses unique geometry matching only when a title is missing, entry IDs use disjoint namespaces, and final entry/application fallback conversion is covered by tests.
+- 2026-08-31 — Final targeted verification passed 33 Window Switcher tests, `make build-plugin PLUGIN=WindowSwitcher`, `make script-tests` (195 tests), and the standalone PluginKit v5 compatibility check. The global XCTest phase still has five unrelated failures; the exact list is recorded in the final PR gate.
+- 2026-08-31 — The latest `make ci` XCTest phase failed only outside Window Switcher: `DiskCleanPluginTests.testCleanActionTitleReportsSelectionAndRemovalMode`, `DiskCleanPluginTests.testConfirmingPhaseReplacesCleanActionWithConfirmAndCancel`, `DiskCleanPluginTests.testTrashCompletionSubtitleDoesNotClaimSpaceWasReclaimed`, `PluginPackageManifestTests.testRichProjectedManifestDecodesProductMetadata`, and `DeviceBatteryCommandRunnerTests.testFiltersOutputWhileDrainingPipe`. The Window Switcher class remained green.
+- 2026-08-31 — Final review follow-up identified ambiguous AX/CG correlation and dropped direct-cycle presses during asynchronous preparation. The merge now requires an unambiguous candidate (or one sole on-screen record), post-activation lookup rejects multiple matches, and preparation accumulates cycle deltas; focused regressions cover reversed record order and a controlled slow provider.
+- 2026-08-31 — Security follow-up identified a permission race on direct-cycle key-up. Release now refreshes Accessibility permission before activation and cancels when it is no longer granted; the focused suite covers this race with a controlled permission harness.
+- 2026-08-31 — Replaced external-application-dependent direct-cycle regressions with a suspendable injected entry provider. Queueing and permission-revocation tests now run deterministically without `XCTSkip` when no regular application is available.
+- 2026-08-31 — Isolated the stale-refresh race test from `NSWorkspace` as well; it now asserts the injected record snapshot directly and runs on every test host.
+- 2026-08-31 — Tightened optional `isOnScreen` handling so missing or malformed values never become implicit `true`; ambiguous duplicate metadata remains CoreGraphics-only unless exactly one candidate is explicitly on screen.
+- 2026-08-31 — Added one session-wide AX enrichment deadline, a deterministic re-press regression, and event-tap revocation propagation; the stale-refresh test now waits for the newer snapshot before releasing the older provider call.
+- 2026-08-31 — Final hardening verification passed 36 Window Switcher tests, `make build-plugin PLUGIN=WindowSwitcher`, `make script-tests` (196 tests), and the standalone PluginKit v5 compatibility check. The latest global `make ci` XCTest phase reported ten failures outside Window Switcher: four `SystemStatusPluginTests`, three `DiskCleanPluginTests`, one `PluginPackageManifestTests`, and one `AppleShortcutsCommandRunnerTests` failure reported twice by the runner.
+- 2026-08-31 — Sol contract review found ordering-dependent titleless geometry correlation, dropped AX-only surplus candidates, and direct-cycle re-press double counting. The merge now resolves exact matches first and retains only cardinality-surplus AX candidates; direct-cycle re-presses use one initial step, with deterministic reverse-direction coverage.
+- 2026-08-31 — Added an injectable activation boundary and integration regressions for `.activateAllWindows`, current AX minimized state, and no-match CG-only fallback. The focused class now contains 41 tests; final repository gates are rerun after this hardening.
+- 2026-08-31 — Final hardening resolves mixed titleless/cardinality merge cases, filters consumed AX candidates during geometry fallback, caps every AX messaging timeout by the shared deadline, and handles tap-disabled events after Accessibility revocation without re-enabling the tap. The focused class now contains 44 passing tests; `make build-plugin PLUGIN=WindowSwitcher`, `make script-tests` (196 tests), and PluginKit v5 compatibility pass. The latest `make ci` script phase passes; its XCTest phase still reports eight failures outside Window Switcher: four `SystemStatusPluginTests`, three `DiskCleanPluginTests`, and one `PluginPackageManifestTests`.
+- 2026-08-31 — Final review hardening adds stable CoreGraphics window-number shortcut identities with controlled legacy AX migration, preserves distinct AX-only titles sharing bounds, skips CG revalidation for AX-backed entries, rejects stale cached records after refresh timeout, and owns cancellable activation tasks. The focused class now contains 51 passing tests; plugin build, script checks (196), and PluginKit v5 compatibility were rerun successfully.
+- 2026-08-31 — Review follow-up removed automatic legacy ordinal migration so an ordering change cannot retarget a saved shortcut; legacy ordinal keys remain available for explicit reassignment. Application identity now compares optional launch dates directly, allowing the legitimate both-missing case while retaining PID, termination, bundle, and mismatch checks. The focused class now contains 52 passing tests.
+- 2026-08-31 — Final review follow-up migrates a legacy first-window binding only when the current catalog has exactly one window for that application, leaves ambiguous legacy keys available for explicit reassignment, cancels application-level and AX-backed activations before any side effect, and compares launch dates only when both snapshots expose one. The focused class now contains 57 passing tests; the plugin build, script checks (196), and PluginKit v5 compatibility check pass.
+- 2026-08-31 — Added explicit reassignment coverage for an ambiguous legacy first-window shortcut. The focused class now contains 58 passing tests. `make ci` again passed all 196 script checks, while its global XCTest phase reported nine failures outside Window Switcher: `PluginPackageManifestTests` x1, `SystemStatusPluginTests` x4, `DiskCleanPluginTests` x3, and `DeviceBatteryCommandRunnerTests` x1. Whitespace and bounded Graphify checks pass; the final standards/spec review is clear, while the two final Sol review workers did not return a result after bounded waits and were stopped.
+- 2026-08-31 — Manual macOS acceptance used the installed Debug app with Accessibility granted. Its overlay listed two distinct Finder `Récents` entries while the live `.optionAll` CoreGraphics inventory identified one matching Finder record (`windowNumber 6617`) with `isOnScreen == false`; the active-Space record was `windowNumber 6681` with `isOnScreen == true`. The temporary `Control-Option-9` trigger was restored to the original `Command-Tab` binding. Selecting the exact inactive entry remains unverified through the accessibility driver, so it is recorded as a coverage limitation rather than a discovery-contract failure.
+- 2026-08-31 — Final local standards/spec review found no actionable divergence from issue #357 or repository conventions. Threat review of CoreGraphics/Accessibility metadata, process identity, activation, cancellation, and permission-loss boundaries found no actionable security vulnerability. The 58 focused Window Switcher tests, plugin build, script checks, and whitespace checks are green. Two bounded independent review workers did not return and were stopped without a verdict; their absence does not replace the completed local reviews.
+
+## Acceptance evidence
+
+- Automated evidence: parser, merge, activation fallback, stale-refresh, direct-cycle, permission, and shortcut-tap regressions are covered by the focused Window Switcher XCTest class; build and repository gates are recorded in the PR journal below.
+- Manual evidence and limitation: `make install-debug-app` installed the verified Debug app. With Accessibility granted, the real overlay listed two distinct Finder `Récents` entries while `.optionAll` reported one as `isOnScreen == false` (`windowNumber 6617`) and its active-Space peer as `isOnScreen == true` (`windowNumber 6681`). This proves inactive-Space discovery in the running UI. The accessibility driver could not reliably select the exact inactive entry, so AX restore/raise/focus and visual selection remain unverified; the corresponding focus acceptance criterion is intentionally unchecked.
+
+## Current files
+
+| Area | Files |
+|---|---|
+| Window discovery and activation | `Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift` |
+| Window entry model | `Plugins/WindowSwitcher/Sources/WindowSwitcherModels.swift` |
+| Shortcut and session lifecycle | `Plugins/WindowSwitcher/Sources/WindowSwitcherPlugin.swift` |
+| Overlay state and cleanup | `Plugins/WindowSwitcher/Sources/WindowSwitcherOverlayController.swift` |
+| Regression tests | `Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift` |
+| User-facing documentation | `README.md`, `changes/unreleased/` |
+
+## Files to create or modify
+
+- `Plugins/WindowSwitcher/Sources/WindowSwitcherAppCatalog.swift`
+- `Plugins/WindowSwitcher/Sources/WindowSwitcherModels.swift`
+- `Plugins/WindowSwitcher/Sources/WindowSwitcherPlugin.swift`
+- `Plugins/WindowSwitcher/Sources/WindowSwitcherOverlayController.swift`
+- `Plugins/WindowSwitcher/Sources/WindowSwitcherShortcutTap.swift`
+- `Plugins/WindowSwitcher/Tests/WindowSwitcherPluginTests.swift`
+- `README.md`
+- `changes/unreleased/window-switcher-multi-space.md`
+- `docs/features/INDEX.md`
+- `docs/features/window-switcher-multi-space.md`
+
+## Tests / QA
+
+- Focused XCTest for the injected window-record parser, all-Space merge, final entry conversion, and stale-refresh race.
+- `make build-plugin PLUGIN=WindowSwitcher`.
+- `make ci` before publication, with any unrelated pre-existing failures attributed precisely.
+- `git diff --check` and untracked-file whitespace validation.
+- Manual Finder windows across two Spaces and Window Switcher invocation; exact inactive-entry selection remains a documented accessibility-driver limitation.
+
+## Out of scope
+
+- Changing Window Switcher modes, shortcut semantics, plugin permissions, or UI layout.
+- Adding private macOS APIs, a new host/plugin protocol, a window manager, or Space navigation controls.
+- Changing other plugins or resolving unrelated open PRs and test failures.
+- Guaranteeing exact focus of a CoreGraphics-only window while macOS withholds its Accessibility element or changes its title/geometry; the public fallback activates the application and performs one immediate AX lookup when metadata matches.
+
+## Keep updated when
+
+- The discovery source, activation fallback, acceptance evidence, verification status, or publication state changes.
+- A new platform limitation or product decision is discovered.
+
+## History
+
+<!-- Read only for regression, audit, or an explicit request. -->
+
+| Date | Commit | Type | Notes |
+|---|---|---|---|
+| 2026-08-31 | `pending` | Bug fix | Cross-Space window discovery for issue #357 |

--- a/docs/features/window-switcher-multi-space.md
+++ b/docs/features/window-switcher-multi-space.md
@@ -2,7 +2,7 @@
 
 Last verified: 2026-08-31
 
-Status: ready-for-publish
+Status: published
 Source of truth: yes
 
 ## Summary
@@ -39,7 +39,7 @@ Source of truth: yes
 - [x] Targeted tests, plugin build, repository PR checks, whitespace checks, and the separate standards/spec/security reviews pass.
 - [x] Manual macOS acceptance is recorded, including any unavailable interaction evidence.
 - [x] README and the unreleased changelog describe the corrected user-visible behavior.
-- [ ] The change is published as one focused pull request closing issue #357.
+- [x] The change is published as one focused pull request closing issue #357.
 
 ## Business rules
 
@@ -78,7 +78,7 @@ Source of truth: yes
 - [x] P002 — Define the all-Space discovery, AX enrichment, fallback activation, and regression-test contract.
 - [x] P003 — Implement the catalog change and focused tests.
 - [x] P004 — Update README/changelog and complete targeted plus PR verification.
-- [ ] P005 — Publish one focused PR and confirm it remotely.
+- [x] P005 — Publish one focused PR and confirm it remotely.
 
 ## TODO
 
@@ -115,6 +115,7 @@ Source of truth: yes
 - 2026-08-31 — Added explicit reassignment coverage for an ambiguous legacy first-window shortcut. The focused class now contains 58 passing tests. `make ci` again passed all 196 script checks, while its global XCTest phase reported nine failures outside Window Switcher: `PluginPackageManifestTests` x1, `SystemStatusPluginTests` x4, `DiskCleanPluginTests` x3, and `DeviceBatteryCommandRunnerTests` x1. Whitespace and bounded Graphify checks pass; the final standards/spec review is clear, while the two final Sol review workers did not return a result after bounded waits and were stopped.
 - 2026-08-31 — Manual macOS acceptance used the installed Debug app with Accessibility granted. Its overlay listed two distinct Finder `Récents` entries while the live `.optionAll` CoreGraphics inventory identified one matching Finder record (`windowNumber 6617`) with `isOnScreen == false`; the active-Space record was `windowNumber 6681` with `isOnScreen == true`. The temporary `Control-Option-9` trigger was restored to the original `Command-Tab` binding. Selecting the exact inactive entry remains unverified through the accessibility driver, so it is recorded as a coverage limitation rather than a discovery-contract failure.
 - 2026-08-31 — Final local standards/spec review found no actionable divergence from issue #357 or repository conventions. Threat review of CoreGraphics/Accessibility metadata, process identity, activation, cancellation, and permission-loss boundaries found no actionable security vulnerability. The 58 focused Window Switcher tests, plugin build, script checks, and whitespace checks are green. Two bounded independent review workers did not return and were stopped without a verdict; their absence does not replace the completed local reviews.
+- 2026-08-31 — Published PR #376 from `codex/issue-357-window-switcher-spaces`; GitHub confirms its `main` base, open ready-for-review state, and `Closes #357` reference. GitButler `zz` is clean; concurrent stacks remain untouched.
 
 ## Acceptance evidence
 
@@ -171,4 +172,4 @@ Source of truth: yes
 
 | Date | Commit | Type | Notes |
 |---|---|---|---|
-| 2026-08-31 | `pending` | Bug fix | Cross-Space window discovery for issue #357 |
+| 2026-08-31 | `lsr` | Bug fix | Cross-Space window discovery for issue #357; published as PR #376 |


### PR DESCRIPTION
Closes #357

## Summary
- discover eligible layer-zero windows across every macOS Space with public CoreGraphics APIs
- merge CoreGraphics records with Accessibility metadata without ambiguous matching, and use a bounded fallback activation path
- keep per-window shortcuts stable across catalog changes and require explicit reassignment for ambiguous legacy bindings

## Scope
- Window Switcher plugin, focused regressions, README, feature record, and one unreleased plugin changelog
- no PluginKit API, dependency, version, or other-plugin changes

## Validation
- 58 focused `WindowSwitcherPluginTests` passing
- `make build-plugin PLUGIN=WindowSwitcher` passing
- `make script-tests` passing (196 tests)
- PluginKit v5 compatibility check passing
- whitespace checks passing
- manual macOS: with Accessibility granted, the installed Debug overlay listed two Finder `Récents` entries while CoreGraphics reported one as inactive-Space (`isOnScreen == false`, window 6617) and the active peer as on-screen (window 6681)

## Known repository-wide check
`make ci` script/changelog phase passes. Its XCTest phase still reports nine failures outside this diff: `PluginPackageManifestTests` x1, `SystemStatusPluginTests` x4, `DiskCleanPluginTests` x3, and `DeviceBatteryCommandRunnerTests` x1. The focused Window Switcher suite is green.

## Review
- standards/spec: clear
- security: clear
- exact inactive-entry selection remains unavailable through the accessibility driver; discovery is proven in the running overlay and activation paths are regression-tested.