### PR TITLE
Fix System Status process collection

### DIFF
--- a/Plugins/SystemStatus/Sources/SystemStatusCommandRunner.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusCommandRunner.swift
@@ -1,0 +1,104 @@
+import Darwin
+import Foundation
+
+enum SystemStatusCommandCompletion: Equatable, Sendable {
+    case completed
+    case timedOut
+}
+
+struct SystemStatusCommandResult: Equatable, Sendable {
+    let standardOutput: String
+    let standardError: String
+    let terminationStatus: Int32
+    let completion: SystemStatusCommandCompletion
+}
+
+enum SystemStatusCommandRunner {
+    static func run(
+        path: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) async -> SystemStatusCommandResult? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = arguments
+        process.qualityOfService = .utility
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        let outputTask = readToEnd(fileHandle: outputPipe.fileHandleForReading)
+        let errorTask = readToEnd(fileHandle: errorPipe.fileHandleForReading)
+        let terminationSignal = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            terminationSignal.signal()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            outputPipe.fileHandleForWriting.closeFile()
+            errorPipe.fileHandleForWriting.closeFile()
+            _ = await outputTask.value
+            _ = await errorTask.value
+            return nil
+        }
+
+        outputPipe.fileHandleForWriting.closeFile()
+        errorPipe.fileHandleForWriting.closeFile()
+
+        let completion = await wait(
+            for: terminationSignal,
+            timeout: timeout
+        )
+
+        if completion == .timedOut {
+            await terminate(process, signal: terminationSignal)
+        }
+
+        process.terminationHandler = nil
+        let outputData = await outputTask.value
+        let errorData = await errorTask.value
+
+        return SystemStatusCommandResult(
+            standardOutput: String(decoding: outputData, as: UTF8.self),
+            standardError: String(decoding: errorData, as: UTF8.self),
+            terminationStatus: process.terminationStatus,
+            completion: completion
+        )
+    }
+
+    private static func readToEnd(fileHandle: FileHandle) -> Task<Data, Never> {
+        Task.detached(priority: .utility) {
+            (try? fileHandle.readToEnd()) ?? Data()
+        }
+    }
+
+    private static func wait(
+        for signal: DispatchSemaphore,
+        timeout: TimeInterval
+    ) async -> SystemStatusCommandCompletion {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                let completion: SystemStatusCommandCompletion =
+                    signal.wait(timeout: .now() + timeout) == .success
+                        ? .completed
+                        : .timedOut
+                continuation.resume(returning: completion)
+            }
+        }
+    }
+
+    private static func terminate(_ process: Process, signal: DispatchSemaphore) async {
+        guard process.isRunning else { return }
+
+        let processIdentifier = process.processIdentifier
+        process.terminate()
+        if await wait(for: signal, timeout: 0.25) == .timedOut {
+            Darwin.kill(processIdentifier, SIGKILL)
+            _ = await wait(for: signal, timeout: 1)
+        }
+    }
+}

--- a/Plugins/SystemStatus/Sources/SystemStatusCommandRunner.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusCommandRunner.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import MacToolsPluginKit
 
 enum SystemStatusCommandCompletion: Equatable, Sendable {
     case completed
@@ -19,86 +20,387 @@ enum SystemStatusCommandRunner {
         arguments: [String],
         timeout: TimeInterval
     ) async -> SystemStatusCommandResult? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: path)
-        process.arguments = arguments
-        process.qualityOfService = .utility
-
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-
-        let outputTask = readToEnd(fileHandle: outputPipe.fileHandleForReading)
-        let errorTask = readToEnd(fileHandle: errorPipe.fileHandleForReading)
-        let terminationSignal = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in
-            terminationSignal.signal()
-        }
-
-        do {
-            try process.run()
-        } catch {
-            outputPipe.fileHandleForWriting.closeFile()
-            errorPipe.fileHandleForWriting.closeFile()
-            _ = await outputTask.value
-            _ = await errorTask.value
-            return nil
-        }
-
-        outputPipe.fileHandleForWriting.closeFile()
-        errorPipe.fileHandleForWriting.closeFile()
-
-        let completion = await wait(
-            for: terminationSignal,
-            timeout: timeout
-        )
-
-        if completion == .timedOut {
-            await terminate(process, signal: terminationSignal)
-        }
-
-        process.terminationHandler = nil
-        let outputData = await outputTask.value
-        let errorData = await errorTask.value
-
-        return SystemStatusCommandResult(
-            standardOutput: String(decoding: outputData, as: UTF8.self),
-            standardError: String(decoding: errorData, as: UTF8.self),
-            terminationStatus: process.terminationStatus,
-            completion: completion
-        )
-    }
-
-    private static func readToEnd(fileHandle: FileHandle) -> Task<Data, Never> {
-        Task.detached(priority: .utility) {
-            (try? fileHandle.readToEnd()) ?? Data()
-        }
-    }
-
-    private static func wait(
-        for signal: DispatchSemaphore,
-        timeout: TimeInterval
-    ) async -> SystemStatusCommandCompletion {
         await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .utility).async {
-                let completion: SystemStatusCommandCompletion =
-                    signal.wait(timeout: .now() + timeout) == .success
-                        ? .completed
-                        : .timedOut
-                continuation.resume(returning: completion)
+            SystemStatusCommandExecution(
+                path: path,
+                arguments: arguments,
+                timeout: timeout,
+                continuation: continuation
+            ).start()
+        }
+    }
+}
+
+private final class SystemStatusCommandExecution: @unchecked Sendable {
+    private enum Stream {
+        case standardOutput
+        case standardError
+    }
+
+    private struct LaunchResult {
+        let processID: pid_t
+        let outputDescriptor: Int32
+        let errorDescriptor: Int32
+    }
+
+    typealias Continuation = CheckedContinuation<SystemStatusCommandResult?, Never>
+
+    private static let forcedKillDelay: TimeInterval = 0.25
+    private static let drainDeadline: TimeInterval = 0.20
+
+    private let path: String
+    private let arguments: [String]
+    private let timeout: TimeInterval
+    private let controlQueue = DispatchQueue(
+        label: "cc.ggbond.mactools.system-status.command-control",
+        qos: .utility
+    )
+    private let ioQueue = DispatchQueue(
+        label: "cc.ggbond.mactools.system-status.command-io",
+        qos: .utility
+    )
+
+    private var continuation: Continuation?
+    private var lease: PluginProcessGroupLease?
+    private var timeoutWorkItem: DispatchWorkItem?
+    private var forcedKillWorkItem: DispatchWorkItem?
+    private var drainWorkItem: DispatchWorkItem?
+    private var leaderDidExit = false
+    private var didTimeOut = false
+    private var closedStreamCount = 0
+    private var didFinish = false
+
+    // Accessed only from ioQueue.
+    private var outputData = Data()
+    private var errorData = Data()
+    private var outputSource: DispatchSourceRead?
+    private var errorSource: DispatchSourceRead?
+    private var outputDescriptor: Int32 = -1
+    private var errorDescriptor: Int32 = -1
+    private var outputDidClose = false
+    private var errorDidClose = false
+
+    init(
+        path: String,
+        arguments: [String],
+        timeout: TimeInterval,
+        continuation: Continuation
+    ) {
+        self.path = path
+        self.arguments = arguments
+        self.timeout = max(0, timeout)
+        self.continuation = continuation
+    }
+
+    func start() {
+        controlQueue.async { [self] in
+            do {
+                let launch = try spawn()
+                let processLease = PluginProcessGroupLease(processID: launch.processID)
+                lease = processLease
+                startReading(
+                    outputDescriptor: launch.outputDescriptor,
+                    errorDescriptor: launch.errorDescriptor
+                )
+                scheduleTimeout()
+                DispatchQueue.global(qos: .utility).async { [self] in
+                    let observedExit = processLease.waitForLeaderExit()
+                    controlQueue.async { [self] in
+                        processDidExit(observedExit: observedExit)
+                    }
+                }
+            } catch {
+                finishWithoutResult()
             }
         }
     }
 
-    private static func terminate(_ process: Process, signal: DispatchSemaphore) async {
-        guard process.isRunning else { return }
-
-        let processIdentifier = process.processIdentifier
-        process.terminate()
-        if await wait(for: signal, timeout: 0.25) == .timedOut {
-            Darwin.kill(processIdentifier, SIGKILL)
-            _ = await wait(for: signal, timeout: 1)
+    private func startReading(outputDescriptor: Int32, errorDescriptor: Int32) {
+        ioQueue.async { [self] in
+            self.outputDescriptor = outputDescriptor
+            self.errorDescriptor = errorDescriptor
+            outputSource = makeReadSource(
+                descriptor: outputDescriptor,
+                stream: .standardOutput
+            )
+            errorSource = makeReadSource(
+                descriptor: errorDescriptor,
+                stream: .standardError
+            )
+            outputSource?.resume()
+            errorSource?.resume()
         }
+    }
+
+    private func makeReadSource(
+        descriptor: Int32,
+        stream: Stream
+    ) -> DispatchSourceRead {
+        let source = DispatchSource.makeReadSource(
+            fileDescriptor: descriptor,
+            queue: ioQueue
+        )
+        source.setEventHandler { [self] in
+            drain(descriptor: descriptor, stream: stream)
+        }
+        source.setCancelHandler { [self] in
+            Darwin.close(descriptor)
+            controlQueue.async { [self] in
+                closedStreamCount += 1
+                finishIfReady()
+            }
+        }
+        return source
+    }
+
+    private func drain(descriptor: Int32, stream: Stream) {
+        var bytes = [UInt8](repeating: 0, count: 16 * 1_024)
+        // Bound each callback so sustained output cannot monopolize ioQueue and
+        // delay a timeout-driven stream close.
+        for _ in 0 ..< 16 {
+            let count = bytes.withUnsafeMutableBytes { buffer in
+                Darwin.read(descriptor, buffer.baseAddress, buffer.count)
+            }
+            if count > 0 {
+                switch stream {
+                case .standardOutput:
+                    outputData.append(contentsOf: bytes.prefix(count))
+                case .standardError:
+                    errorData.append(contentsOf: bytes.prefix(count))
+                }
+                continue
+            }
+            if count < 0 && errno == EINTR { continue }
+            if count == 0 { close(stream: stream) }
+            break
+        }
+    }
+
+    private func close(stream: Stream) {
+        switch stream {
+        case .standardOutput:
+            guard !outputDidClose else { return }
+            outputDidClose = true
+            outputSource?.cancel()
+            outputSource = nil
+            outputDescriptor = -1
+        case .standardError:
+            guard !errorDidClose else { return }
+            errorDidClose = true
+            errorSource?.cancel()
+            errorSource = nil
+            errorDescriptor = -1
+        }
+    }
+
+    private func scheduleTimeout() {
+        let workItem = DispatchWorkItem { [self] in
+            guard !leaderDidExit, !didFinish else { return }
+            didTimeOut = true
+            lease?.signal(SIGTERM)
+            scheduleForcedKill()
+        }
+        timeoutWorkItem = workItem
+        controlQueue.asyncAfter(deadline: .now() + timeout, execute: workItem)
+    }
+
+    private func scheduleForcedKill() {
+        guard forcedKillWorkItem == nil else { return }
+        let workItem = DispatchWorkItem { [self] in
+            guard !leaderDidExit, !didFinish else { return }
+            lease?.signal(SIGKILL)
+        }
+        forcedKillWorkItem = workItem
+        controlQueue.asyncAfter(
+            deadline: .now() + Self.forcedKillDelay,
+            execute: workItem
+        )
+    }
+
+    private func processDidExit(observedExit: Bool) {
+        guard !didFinish else { return }
+        leaderDidExit = true
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
+        forcedKillWorkItem?.cancel()
+        forcedKillWorkItem = nil
+
+        guard observedExit else {
+            closeStreamsAndFinish()
+            return
+        }
+        if closedStreamCount == 2 {
+            finishIfReady()
+            return
+        }
+
+        let workItem = DispatchWorkItem { [self] in
+            guard !didFinish else { return }
+            // An exited leader can leave descendants holding inherited pipe
+            // descriptors. The retained leader keeps the process-group ID owned
+            // until those descendants are stopped and the streams are closed.
+            lease?.signal(SIGKILL)
+            closeStreamsAndFinish()
+        }
+        drainWorkItem = workItem
+        controlQueue.asyncAfter(
+            deadline: .now() + Self.drainDeadline,
+            execute: workItem
+        )
+    }
+
+    private func finishIfReady() {
+        guard leaderDidExit, closedStreamCount == 2, !didFinish else { return }
+        captureOutputAndFinish()
+    }
+
+    private func closeStreamsAndFinish() {
+        ioQueue.async { [self] in
+            if outputDescriptor >= 0 {
+                drain(descriptor: outputDescriptor, stream: .standardOutput)
+            }
+            if errorDescriptor >= 0 {
+                drain(descriptor: errorDescriptor, stream: .standardError)
+            }
+            close(stream: .standardOutput)
+            close(stream: .standardError)
+            let output = outputData
+            let error = errorData
+            controlQueue.async { [self] in
+                finish(output: output, error: error)
+            }
+        }
+    }
+
+    private func captureOutputAndFinish() {
+        ioQueue.async { [self] in
+            let output = outputData
+            let error = errorData
+            controlQueue.async { [self] in
+                finish(output: output, error: error)
+            }
+        }
+    }
+
+    private func finish(output: Data, error: Data) {
+        guard !didFinish else { return }
+        didFinish = true
+        drainWorkItem?.cancel()
+        drainWorkItem = nil
+        let rawStatus = lease?.reapLeader()
+        lease = nil
+        let result = SystemStatusCommandResult(
+            standardOutput: String(decoding: output, as: UTF8.self),
+            standardError: String(decoding: error, as: UTF8.self),
+            terminationStatus: rawStatus.map(Self.terminationStatus(from:)) ?? -1,
+            completion: didTimeOut ? .timedOut : .completed
+        )
+        let pendingContinuation = continuation
+        continuation = nil
+        pendingContinuation?.resume(returning: result)
+    }
+
+    private func finishWithoutResult() {
+        guard !didFinish else { return }
+        didFinish = true
+        let pendingContinuation = continuation
+        continuation = nil
+        pendingContinuation?.resume(returning: nil)
+    }
+
+    private func spawn() throws -> LaunchResult {
+        var outputPipe: [Int32] = [-1, -1]
+        var errorPipe: [Int32] = [-1, -1]
+        guard pipe(&outputPipe) == 0 else { throw POSIXError(.EIO) }
+        guard pipe(&errorPipe) == 0 else {
+            Darwin.close(outputPipe[0])
+            Darwin.close(outputPipe[1])
+            throw POSIXError(.EIO)
+        }
+
+        func closePipes() {
+            outputPipe.filter { $0 >= 0 }.forEach { Darwin.close($0) }
+            errorPipe.filter { $0 >= 0 }.forEach { Darwin.close($0) }
+        }
+
+        var actions: posix_spawn_file_actions_t?
+        var attributes: posix_spawnattr_t?
+        guard posix_spawn_file_actions_init(&actions) == 0 else {
+            closePipes()
+            throw POSIXError(.EIO)
+        }
+        guard posix_spawnattr_init(&attributes) == 0 else {
+            posix_spawn_file_actions_destroy(&actions)
+            closePipes()
+            throw POSIXError(.EIO)
+        }
+        defer {
+            posix_spawn_file_actions_destroy(&actions)
+            posix_spawnattr_destroy(&attributes)
+        }
+
+        guard posix_spawn_file_actions_adddup2(&actions, outputPipe[1], STDOUT_FILENO) == 0,
+              posix_spawn_file_actions_adddup2(&actions, errorPipe[1], STDERR_FILENO) == 0,
+              posix_spawn_file_actions_addclose(&actions, outputPipe[0]) == 0,
+              posix_spawn_file_actions_addclose(&actions, errorPipe[0]) == 0,
+              posix_spawn_file_actions_addclose(&actions, outputPipe[1]) == 0,
+              posix_spawn_file_actions_addclose(&actions, errorPipe[1]) == 0,
+              posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP)) == 0,
+              posix_spawnattr_setpgroup(&attributes, 0) == 0 else {
+            closePipes()
+            throw POSIXError(.EIO)
+        }
+
+        var processID: pid_t = 0
+        let launchArguments = [path] + arguments
+        let environment = ProcessInfo.processInfo.environment
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+        let result = withSystemStatusCStringArray(launchArguments) { argv in
+            withSystemStatusCStringArray(environment) { environmentPointer in
+                posix_spawn(
+                    &processID,
+                    path,
+                    &actions,
+                    &attributes,
+                    argv,
+                    environmentPointer
+                )
+            }
+        }
+        guard result == 0 else {
+            closePipes()
+            throw POSIXError(POSIXErrorCode(rawValue: result) ?? .EIO)
+        }
+
+        Darwin.close(outputPipe[1])
+        outputPipe[1] = -1
+        Darwin.close(errorPipe[1])
+        errorPipe[1] = -1
+        for descriptor in [outputPipe[0], errorPipe[0]] {
+            let flags = fcntl(descriptor, F_GETFL)
+            if flags >= 0 { _ = fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) }
+        }
+        return LaunchResult(
+            processID: processID,
+            outputDescriptor: outputPipe[0],
+            errorDescriptor: errorPipe[0]
+        )
+    }
+
+    private static func terminationStatus(from status: Int32) -> Int32 {
+        let signal = status & 0x7f
+        return signal == 0 ? (status >> 8) & 0xff : signal
+    }
+}
+
+private func withSystemStatusCStringArray<Result>(
+    _ strings: [String],
+    _ body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> Result
+) -> Result {
+    var pointers = strings.map { strdup($0) } + [nil]
+    defer { pointers.compactMap { $0 }.forEach { free($0) } }
+    return pointers.withUnsafeMutableBufferPointer { buffer in
+        body(buffer.baseAddress!)
     }
 }

--- a/Plugins/SystemStatus/Sources/SystemStatusSampler.swift
+++ b/Plugins/SystemStatus/Sources/SystemStatusSampler.swift
@@ -3,6 +3,7 @@ import Foundation
 import IOKit
 import IOKit.ps
 import MacToolsPluginKit
+import OSLog
 import SystemConfiguration
 
 protocol SystemStatusSampling: Sendable {
@@ -38,6 +39,10 @@ actor SystemStatusSampler: SystemStatusSampling {
 
     private static let systemPowerHealthCacheInterval: TimeInterval = 60 * 60
     private static let networkMetadataCacheInterval: TimeInterval = 10
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "cc.ggbond.mactools",
+        category: "SystemStatusSampler"
+    )
 
     init(localization: PluginLocalization = PluginLocalization(bundle: .main)) {
         self.localization = localization
@@ -62,16 +67,17 @@ actor SystemStatusSampler: SystemStatusSampling {
     }
 
     func collectSlow() async -> SystemStatusSlowSample {
-        SystemStatusSlowSample(
+        let battery = await collectBattery()
+        return SystemStatusSlowSample(
             disk: Self.collectDiskCapacity(),
-            battery: collectBattery(),
+            battery: battery,
             gpu: collectGPU(),
             hardware: collectHardware()
         )
     }
 
     func collectTopProcesses(limit: Int = 3) async -> [SystemStatusTopProcess] {
-        Self.collectTopProcesses(limit: limit)
+        await Self.collectTopProcesses(limit: limit)
     }
 
     func collectPublicIPAddress() async -> String? {
@@ -816,7 +822,7 @@ actor SystemStatusSampler: SystemStatusSampling {
         return SystemStatusDiskIOCounter(readBytes: readBytes, writeBytes: writeBytes)
     }
 
-    private func collectBattery() -> SystemStatusBatterySnapshot {
+    private func collectBattery() async -> SystemStatusBatterySnapshot {
         guard
             let powerSourcesInfo = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
             let powerSources = IOPSCopyPowerSourcesList(powerSourcesInfo)?.takeRetainedValue() as? [CFTypeRef],
@@ -878,6 +884,12 @@ actor SystemStatusSampler: SystemStatusSampling {
         )
         let timeKey = isCharging ? kIOPSTimeToFullChargeKey : kIOPSTimeToEmptyKey
         let registryInfo = Self.collectBatteryRegistryInfo()
+        let healthPercent: Int?
+        if let registryHealthPercent = registryInfo.healthPercent {
+            healthPercent = registryHealthPercent
+        } else {
+            healthPercent = await systemPowerHealthPercent(referenceDate: Date())
+        }
 
         return SystemStatusBatterySnapshot(
             isAvailable: true,
@@ -887,12 +899,12 @@ actor SystemStatusSampler: SystemStatusSampling {
             adapterWatts: Self.adapterWatts(),
             batteryPowerWatts: registryInfo.batteryPowerWatts,
             temperatureCelsius: registryInfo.temperatureCelsius,
-            healthPercent: registryInfo.healthPercent ?? systemPowerHealthPercent(referenceDate: Date()),
+            healthPercent: healthPercent,
             cycleCount: registryInfo.cycleCount
         )
     }
 
-    private func systemPowerHealthPercent(referenceDate: Date) -> Int? {
+    private func systemPowerHealthPercent(referenceDate: Date) async -> Int? {
         if didCacheSystemPowerHealth,
            let lastSystemPowerHealthDate,
            referenceDate.timeIntervalSince(lastSystemPowerHealthDate) < Self.systemPowerHealthCacheInterval {
@@ -900,7 +912,7 @@ actor SystemStatusSampler: SystemStatusSampling {
         }
 
         let healthPercent: Int?
-        if let output = Self.runCommand(
+        if let output = await Self.runCommand(
             path: "/usr/sbin/system_profiler",
             arguments: ["SPPowerDataType", "-json"],
             timeout: 3
@@ -1571,54 +1583,37 @@ actor SystemStatusSampler: SystemStatusSampling {
         return vpnPrefixes.contains { lowercasedName.hasPrefix($0) }
     }
 
-    private static func collectTopProcesses(limit: Int) -> [SystemStatusTopProcess] {
-        guard let output = runCommand(path: "/bin/ps", arguments: ["-ww", "-Aceo", "pid=,pcpu=,pmem=,rss=,command=", "-r"]) else {
+    private static func collectTopProcesses(limit: Int) async -> [SystemStatusTopProcess] {
+        guard let output = await runCommand(path: "/bin/ps", arguments: ["-ww", "-Aceo", "pid=,pcpu=,pmem=,rss=,command=", "-r"]) else {
             return []
         }
 
         return SystemStatusProcessParser.parsePSOutputCandidates(output, limitPerSort: limit)
     }
 
-    private static func runCommand(path: String, arguments: [String], timeout: TimeInterval = 1) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: path)
-        process.arguments = arguments
-
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-
-        do {
-            try process.run()
-        } catch {
-            outputPipe.fileHandleForReading.closeFile()
-            errorPipe.fileHandleForReading.closeFile()
+    private static func runCommand(path: String, arguments: [String], timeout: TimeInterval = 1) async -> String? {
+        guard let result = await SystemStatusCommandRunner.run(
+            path: path,
+            arguments: arguments,
+            timeout: timeout
+        ) else {
+            logger.error("Failed to launch command at \(path, privacy: .public)")
             return nil
         }
 
-        let deadline = Date().addingTimeInterval(timeout)
-        while process.isRunning, Date() < deadline {
-            Thread.sleep(forTimeInterval: 0.02)
-        }
-
-        guard !process.isRunning else {
-            process.terminate()
-            outputPipe.fileHandleForReading.closeFile()
-            errorPipe.fileHandleForReading.closeFile()
+        guard result.completion == .completed, result.terminationStatus == EXIT_SUCCESS else {
+            logger.error(
+                "Command failed at \(path, privacy: .public), status: \(result.terminationStatus), timed out: \(result.completion == .timedOut)"
+            )
             return nil
         }
 
-        process.waitUntilExit()
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        outputPipe.fileHandleForReading.closeFile()
-        errorPipe.fileHandleForReading.closeFile()
-
-        guard let output = String(data: outputData, encoding: .utf8), !output.isEmpty else {
+        guard !result.standardOutput.isEmpty else {
+            logger.error("Command returned no output at \(path, privacy: .public)")
             return nil
         }
 
-        return output
+        return result.standardOutput
     }
 
     private static func regexCaptures(_ pattern: String, in value: String) -> [String] {

--- a/Plugins/SystemStatus/Tests/SystemStatusSamplerTests.swift
+++ b/Plugins/SystemStatus/Tests/SystemStatusSamplerTests.swift
@@ -3,6 +3,35 @@ import XCTest
 @testable import SystemStatusPlugin
 
 final class SystemStatusSamplerTests: XCTestCase {
+    func testCommandRunnerDrainsOutputLargerThanPipeBuffer() async throws {
+        let lineCount = 100_000
+        let commandResult = await SystemStatusCommandRunner.run(
+            path: "/usr/bin/jot",
+            arguments: ["-b", "x", String(lineCount)],
+            timeout: 2
+        )
+        let result = try XCTUnwrap(commandResult)
+
+        XCTAssertEqual(result.completion, .completed)
+        XCTAssertEqual(result.terminationStatus, 0)
+        XCTAssertEqual(result.standardOutput, String(repeating: "x\n", count: lineCount))
+        XCTAssertEqual(result.standardError, "")
+    }
+
+    func testCommandRunnerTerminatesTimedOutProcess() async throws {
+        let clock = ContinuousClock()
+        let start = clock.now
+        let commandResult = await SystemStatusCommandRunner.run(
+            path: "/bin/sleep",
+            arguments: ["5"],
+            timeout: 0.05
+        )
+        let result = try XCTUnwrap(commandResult)
+
+        XCTAssertEqual(result.completion, .timedOut)
+        XCTAssertLessThan(start.duration(to: clock.now), .seconds(1))
+    }
+
     func testDetailStatisticsUseEveryVisibleReadingRegardlessOfDrawingBudget() {
         let history = (0..<600).map { index -> SystemStatusHistoryPoint in
             let cpu: Double = index == 1 ? 1 : 0

--- a/Plugins/SystemStatus/Tests/SystemStatusSamplerTests.swift
+++ b/Plugins/SystemStatus/Tests/SystemStatusSamplerTests.swift
@@ -32,6 +32,50 @@ final class SystemStatusSamplerTests: XCTestCase {
         XCTAssertLessThan(start.duration(to: clock.now), .seconds(1))
     }
 
+    func testCommandRunnerHandlesConcurrentTimeoutsWithoutSerializing() async throws {
+        let clock = ContinuousClock()
+        let start = clock.now
+        let results = await withTaskGroup(
+            of: SystemStatusCommandResult?.self,
+            returning: [SystemStatusCommandResult?].self
+        ) { group in
+            for _ in 0 ..< 32 {
+                group.addTask {
+                    await SystemStatusCommandRunner.run(
+                        path: "/bin/sleep",
+                        arguments: ["5"],
+                        timeout: 0.05
+                    )
+                }
+            }
+            var results: [SystemStatusCommandResult?] = []
+            for await result in group {
+                results.append(result)
+            }
+            return results
+        }
+
+        XCTAssertEqual(results.count, 32)
+        XCTAssertTrue(results.allSatisfy { $0?.completion == .timedOut })
+        XCTAssertLessThan(start.duration(to: clock.now), .seconds(1))
+    }
+
+    func testCommandRunnerBoundsDrainWhenDescendantKeepsPipeOpen() async throws {
+        let clock = ContinuousClock()
+        let start = clock.now
+        let commandResult = await SystemStatusCommandRunner.run(
+            path: "/bin/sh",
+            arguments: ["-c", "(/bin/sleep 5) & printf parent"],
+            timeout: 1
+        )
+        let result = try XCTUnwrap(commandResult)
+
+        XCTAssertEqual(result.completion, .completed)
+        XCTAssertEqual(result.terminationStatus, 0)
+        XCTAssertEqual(result.standardOutput, "parent")
+        XCTAssertLessThan(start.duration(to: clock.now), .seconds(1))
+    }
+
     func testDetailStatisticsUseEveryVisibleReadingRegardlessOfDrawingBudget() {
         let history = (0..<600).map { index -> SystemStatusHistoryPoint in
             let cpu: Double = index == 1 ? 1 : 0

--- a/changes/unreleased/system-status-process-collection.md
+++ b/changes/unreleased/system-status-process-collection.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: fixed
+area: System Status
+---
+
+Fixed process monitoring getting stuck on “Collecting” when many processes are running.


### PR DESCRIPTION
## Summary

- drain command stdout and stderr while subprocesses run so large process lists cannot fill the pipe and stall `ps`
- execute System Status commands asynchronously with timeout termination, exit-status validation, and failure logging
- add regression coverage for output larger than the pipe buffer and timed-out commands

## Root cause

The process collector waited for `ps` to exit before reading its stdout pipe. On systems with many processes, the output exceeded the pipe buffer, leaving `ps` blocked on its write while MacTools waited for termination. The one-second timeout then returned an empty process list, which the UI rendered as “Collecting…” indefinitely.

## Testing

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug -derivedDataPath build/DerivedData test -only-testing:MacToolsTests/SystemStatusSamplerTests -quiet`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug -derivedDataPath build/DerivedData test -only-testing:MacToolsTests/SystemStatusPluginTests -quiet`