### PR TITLE
test(cli): fix flaky command task cancellation test on main

### DIFF
--- a/Tests/Core/CLI/CLISignalCoordinatorTests.swift
+++ b/Tests/Core/CLI/CLISignalCoordinatorTests.swift
@@ -6,11 +6,16 @@ final class CLISignalCoordinatorTests: XCTestCase {
     func testCommandTaskStatePersistsCancellationAcrossInstallation() async {
         let cancelledBeforeInstall = CLICommandTaskState()
         cancelledBeforeInstall.cancel()
+        // The gate keeps the task suspended until installation, so the task cannot
+        // reach its cancellation check before the state has a chance to cancel it.
+        let installGate = TaskGate()
         let firstTask = Task<Int32, Error> {
+            await installGate.wait()
             try Task.checkCancellation()
             return 0
         }
         cancelledBeforeInstall.install(firstTask)
+        installGate.open()
         await assertCancellation(firstTask)
 
         let cancelledAfterInstall = CLICommandTaskState()
@@ -58,6 +63,34 @@ final class CLISignalCoordinatorTests: XCTestCase {
         } catch {
             XCTFail("Expected CancellationError, got \(error)")
         }
+    }
+}
+
+private final class TaskGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            guard !isOpen else {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            waiters.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    func open() {
+        lock.lock()
+        isOpen = true
+        let pending = waiters
+        waiters = []
+        lock.unlock()
+        pending.forEach { $0.resume() }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The `Build` workflow on `main` failed in [run 33943971718](https://github.com/ggbond268/MacTools/actions/runs/33943971718) at the `Build and run tests` step. There is no compile error; the only failing test is:

```
Failing tests:
	CLISignalCoordinatorTests.testCommandTaskStatePersistsCancellationAcrossInstallation()
** TEST FAILED **
```

The first half of that test races:

```swift
cancelledBeforeInstall.cancel()          // records a pending cancellation
let firstTask = Task<Int32, Error> {     // starts running immediately
    try Task.checkCancellation()
    return 0
}
cancelledBeforeInstall.install(firstTask) // only here does the task get cancelled
```

The unstructured task starts as soon as it is created, so on a loaded machine it can pass `Task.checkCancellation()` and return `0` before `install(_:)` propagates the pending cancellation. `assertCancellation` then reports `Expected cancellation`. The test failed in 0.008s, which matches this ordering rather than a hang. The test has existed since the Phase 0 CLI prototype and passed many times, so this is test-only flakiness, not a regression from the merged PR.

Production behavior is unaffected: in `CLIApplication.interruptibleRequest`, a task that completes before `install(_:)` has already produced its result, which is the desired outcome.

## What changed

Added a small `TaskGate` helper in the test file and used it to keep the task suspended until `install(_:)` has run, so the cancellation check happens after installation in every interleaving. The second half of the test (cancel after install) was already deterministic and is unchanged.

Ordering is now fully pinned:

- If the task starts first, it parks in `wait()`; `install(_:)` cancels it, then `open()` resumes it and `Task.checkCancellation()` throws.
- If `install(_:)` and `open()` run first, `wait()` returns immediately on an already-cancelled task and `Task.checkCancellation()` throws.

A real regression (`install(_:)` no longer propagating cancellation) still fails immediately with `Expected cancellation` rather than hanging, because the gate is always opened.

## Verification

Xcode is not available to this agent (Linux), so the XCTest bundle could not be built. Instead the exact production type `CLICommandTaskState` and the new `TaskGate` were copied verbatim into a standalone Swift program and exercised with a Swift 6.1 Linux toolchain.

Compilation, both language modes, `-strict-concurrency=complete` (matching `Configs/Debug.xcconfig`): no errors, no warnings.

Behavior, comparing the old and new test bodies over the same number of runs:

| Case | Runs | Cancelled | Completed (i.e. test failure) |
| --- | --- | --- | --- |
| old `cancel-before-install` | 3000 | 2294 | 706 |
| new gated `cancel-before-install` | 3000 | 3000 | 0 |
| unchanged `cancel-after-install` | 3000 | 3000 | 0 |

Repeated with six concurrent processes on four cores to imitate a loaded CI runner: the old body failed in five of six processes (1 to 318 spurious completions per 5000 runs) while one process happened to pass all 5000, which matches the "usually green, occasionally red" behavior seen on CI. The gated body was cancelled in 30000 of 30000 runs, and a second harness shaped like the real test class (async method, unstructured `Task` closure capturing the gate) passed 2000 runs in each language mode.

Suggested local check on macOS:

```bash
make generate
xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug \
  -derivedDataPath build/DerivedData test -quiet \
  -only-testing:MacToolsTests/CLISignalCoordinatorTests
```

No changelog fragment: test-only change with no user-visible impact.

## Note on the earlier `main` failure

The previous `main` failure ([run 33869848751](https://github.com/ggbond268/MacTools/actions/runs/33869848751)) has a different, unrelated cause — a corrupted SwiftPM repository cache on the runner:

```
xcodebuild: error: Could not resolve package dependencies:
  Git command '... repositories/Sparkle-09d89c53 config --get remote.origin.url' failed:
  fatal: cannot change to '.../Sparkle-09d89c53': No such file or directory
```

That one is CI infrastructure flakiness and is not addressed here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06fe4-c81d-72d3-888f-00f95aee0ee2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06fe4-c81d-72d3-888f-00f95aee0ee2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

