### PR TITLE
feat(disk-clean): add rule explanations and cleanup run history

### DIFF
--- a/Plugins/DiskClean/Resources/Localizable.xcstrings
+++ b/Plugins/DiskClean/Resources/Localizable.xcstrings
@@ -14701,33 +14701,143 @@
     "detail.result.cancelledTitle": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "نتيجة التنظيف المتوقف" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Ergebnis der gestoppten Bereinigung" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Stopped cleanup result" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Resultado de la limpieza detenida" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Résultat du nettoyage arrêté" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "停止したクリーンアップの結果" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "중단된 정리 결과" } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Resultado da limpeza interrompida" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Результат остановленной очистки" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已停止的清理结果" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已停止的清理結果" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نتيجة التنظيف المتوقف"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ergebnis der gestoppten Bereinigung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopped cleanup result"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resultado de la limpieza detenida"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résultat du nettoyage arrêté"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止したクリーンアップの結果"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중단된 정리 결과"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resultado da limpeza interrompida"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Результат остановленной очистки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已停止的清理结果"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已停止的清理結果"
+          }
+        }
       }
     },
     "panel.subtitle.cancelled": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "تم الإيقاف · عولج %d عنصر" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Gestoppt · %d Elemente verarbeitet" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Stopped · %d items processed" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Detenida · %d elementos procesados" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Arrêté · %d éléments traités" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "停止済み · %d項目を処理" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "중단됨 · %d개 항목 처리됨" } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Interrompida · %d elementos processados" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Остановлено · обработано элементов: %d" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已停止 · 已处理 %d 项" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已停止 · 已處理 %d 項" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم الإيقاف · عولج %d عنصر"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestoppt · %d Elemente verarbeitet"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopped · %d items processed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detenida · %d elementos procesados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêté · %d éléments traités"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止済み · %d項目を処理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중단됨 · %d개 항목 처리됨"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompida · %d elementos processados"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Остановлено · обработано элементов: %d"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已停止 · 已处理 %d 项"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已停止 · 已處理 %d 項"
+          }
+        }
       }
     },
     "detail.purgeRoots.rejected.tooBroad": {
@@ -14797,6 +14907,535 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ نطاقه واسع جدًا. اختر مجلد مشروع محددًا."
+          }
+        }
+      }
+    },
+    "detail.history.view.runs": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按次汇总 (%d)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs (%d)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按次匯總 (%d)"
+          }
+        }
+      }
+    },
+    "detail.history.view.items": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部明细 (%d)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All Items (%d)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部明細 (%d)"
+          }
+        }
+      }
+    },
+    "detail.history.copyDiagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制诊断信息"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Diagnostics"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製診斷資訊"
+          }
+        }
+      }
+    },
+    "detail.history.diagnosticsCopied": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已复制诊断信息"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics Copied"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已複製診斷資訊"
+          }
+        }
+      }
+    },
+    "detail.history.mode.trash": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "废纸篓"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trash"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "垃圾桶"
+          }
+        }
+      }
+    },
+    "detail.history.mode.permanent": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "永久删除"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanent"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "永久刪除"
+          }
+        }
+      }
+    },
+    "detail.history.attentionBadge": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需关注"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Needs Attention"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需關注"
+          }
+        }
+      }
+    },
+    "detail.history.runItems": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理 %d 项"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleaned %d items"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理 %d 項"
+          }
+        }
+      }
+    },
+    "candidate.action.explain": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "规则解释与详情"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rule Explanation and Details"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "規則解釋與詳情"
+          }
+        }
+      }
+    },
+    "candidate.explain.tier": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全级别："
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safety Tier: "
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全級別："
+          }
+        }
+      }
+    },
+    "candidate.explain.confidence": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "置信度："
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confidence: "
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信賴度："
+          }
+        }
+      }
+    },
+    "candidate.explain.fda": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要完全磁盘访问权限"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Disk Access Required"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要完全磁碟存取權限"
+          }
+        }
+      }
+    },
+    "candidate.explain.whyMatched": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匹配原因："
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Why Matched: "
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匹配原因："
+          }
+        }
+      }
+    },
+    "candidate.explain.consequence": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除后果："
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consequence: "
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除後果："
+          }
+        }
+      }
+    },
+    "candidate.explain.regeneration": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重建方式："
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regeneration: "
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重建方式："
+          }
+        }
+      }
+    },
+    "candidate.action.reveal": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中显示"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal in Finder"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中顯示"
+          }
+        }
+      }
+    },
+    "candidate.action.copyPath": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝路径"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Path"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷貝路徑"
+          }
+        }
+      }
+    },
+    "confidence.high": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "High"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
+          }
+        }
+      }
+    },
+    "confidence.medium": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        }
+      }
+    },
+    "confidence.low": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Low"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
+          }
+        }
+      }
+    },
+    "safetyTier.safe": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safe"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全"
+          }
+        }
+      }
+    },
+    "safetyTier.cautious": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "谨慎"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cautious"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "謹慎"
+          }
+        }
+      }
+    },
+    "safetyTier.expert": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "专家"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expert"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "專家"
           }
         }
       }

--- a/Plugins/DiskClean/Sources/DiskCleanAuditLog.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanAuditLog.swift
@@ -11,10 +11,13 @@ final class DiskCleanAuditLog: @unchecked Sendable {
             case delete
             /// Scan-level events: circuit breakers, thread abandonment, reconciliation results.
             case scanEvent
+            /// Run-level summary event.
+            case runSummary
         }
 
         let timestamp: Date
         let action: Action
+        let runID: String?
         let targetID: String?
         let legacyRuleID: String?
         let category: String?
@@ -26,9 +29,17 @@ final class DiskCleanAuditLog: @unchecked Sendable {
         let skipReason: String?
         let error: String?
 
+        // Run-level summary fields
+        let categoriesCleaned: [String]?
+        let itemsRemoved: Int?
+        let bytesRemoved: Int64?
+        let errorsEncountered: [String]?
+        let isTrash: Bool?
+
         init(
             timestamp: Date,
             action: Action,
+            runID: String? = nil,
             targetID: String? = nil,
             legacyRuleID: String? = nil,
             category: String? = nil,
@@ -37,10 +48,16 @@ final class DiskCleanAuditLog: @unchecked Sendable {
             estimatedBytes: Int64? = nil,
             status: String,
             skipReason: String? = nil,
-            error: String? = nil
+            error: String? = nil,
+            categoriesCleaned: [String]? = nil,
+            itemsRemoved: Int? = nil,
+            bytesRemoved: Int64? = nil,
+            errorsEncountered: [String]? = nil,
+            isTrash: Bool? = nil
         ) {
             self.timestamp = timestamp
             self.action = action
+            self.runID = runID
             self.targetID = targetID
             self.legacyRuleID = legacyRuleID
             self.category = category
@@ -50,6 +67,11 @@ final class DiskCleanAuditLog: @unchecked Sendable {
             self.status = status
             self.skipReason = skipReason
             self.error = error
+            self.categoriesCleaned = categoriesCleaned
+            self.itemsRemoved = itemsRemoved
+            self.bytesRemoved = bytesRemoved
+            self.errorsEncountered = errorsEncountered
+            self.isTrash = isTrash
         }
     }
 
@@ -116,6 +138,114 @@ final class DiskCleanAuditLog: @unchecked Sendable {
         return Array(records.sorted { $0.timestamp > $1.timestamp }.prefix(limit))
     }
 
+    /// Read recent cleanup runs newest-first, combining explicit run summaries and projecting legacy sessions.
+    func recentRuns(limit: Int) -> [DiskCleanRunHistoryEntry] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var allRecords: [Record] = []
+        for url in [fileURL, rotatedFileURL] {
+            guard let data = try? Data(contentsOf: url) else { continue }
+            for lineData in data.split(separator: UInt8(ascii: "\n")) {
+                if let record = try? decoder.decode(Record.self, from: Data(lineData)) {
+                    allRecords.append(record)
+                }
+            }
+        }
+
+        let summaryRecords = allRecords.filter { $0.action == .runSummary }
+        let itemRecords = allRecords.filter { $0.action == .trash || $0.action == .delete }
+
+        var itemRecordsByRunID: [String: [Record]] = [:]
+        var unassignedRecords: [Record] = []
+
+        for record in itemRecords {
+            if let runID = record.runID, !runID.isEmpty {
+                itemRecordsByRunID[runID, default: []].append(record)
+            } else {
+                unassignedRecords.append(record)
+            }
+        }
+
+        var runs: [DiskCleanRunHistoryEntry] = []
+
+        for summary in summaryRecords {
+            let runID = summary.runID ?? "run-\(summary.timestamp.timeIntervalSince1970)"
+            let matchedRecords = itemRecordsByRunID[runID] ?? []
+            let matchedItems = DiskCleanCleanupHistoryEntry.entries(from: matchedRecords)
+            let hasAttention = (summary.errorsEncountered?.isEmpty == false)
+                || summary.status == "partiallyDeleted"
+                || summary.status == "rollbackBlocked"
+                || matchedItems.contains(where: \.needsAttention)
+
+            runs.append(
+                DiskCleanRunHistoryEntry(
+                    id: runID,
+                    timestamp: summary.timestamp,
+                    isTrash: summary.isTrash ?? (summary.action == .trash),
+                    status: summary.status,
+                    categoriesCleaned: summary.categoriesCleaned ?? [],
+                    itemsRemoved: summary.itemsRemoved ?? matchedRecords.filter { $0.status == "ok" }.count,
+                    bytesRemoved: summary.bytesRemoved ?? matchedRecords.compactMap(\.estimatedBytes).reduce(0, +),
+                    errorsEncountered: summary.errorsEncountered ?? [],
+                    needsAttention: hasAttention,
+                    itemEntries: matchedItems
+                )
+            )
+        }
+
+        if !unassignedRecords.isEmpty {
+            let sortedRecords = unassignedRecords.sorted { $0.timestamp > $1.timestamp }
+            var clusters: [[Record]] = []
+            var currentCluster: [Record] = []
+
+            for record in sortedRecords {
+                if let last = currentCluster.last {
+                    if abs(record.timestamp.timeIntervalSince(last.timestamp)) <= 3.0 {
+                        currentCluster.append(record)
+                    } else {
+                        clusters.append(currentCluster)
+                        currentCluster = [record]
+                    }
+                } else {
+                    currentCluster = [record]
+                }
+            }
+            if !currentCluster.isEmpty {
+                clusters.append(currentCluster)
+            }
+
+            for cluster in clusters {
+                guard let first = cluster.first else { continue }
+                let clusterEntries = DiskCleanCleanupHistoryEntry.entries(from: cluster)
+                let isTrash = cluster.contains { $0.action == .trash }
+                let categories = Array(Set(cluster.compactMap(\.category))).sorted()
+                let removed = cluster.filter { $0.status == "ok" }.count
+                let bytes = cluster.compactMap(\.estimatedBytes).reduce(0, +)
+                let errors = cluster.compactMap(\.error)
+                let hasAttention = clusterEntries.contains(where: \.needsAttention)
+                let runID = "session-\(Int(first.timestamp.timeIntervalSince1970))"
+
+                runs.append(
+                    DiskCleanRunHistoryEntry(
+                        id: runID,
+                        timestamp: first.timestamp,
+                        isTrash: isTrash,
+                        status: errors.isEmpty ? "ok" : "completedWithErrors",
+                        categoriesCleaned: categories,
+                        itemsRemoved: removed,
+                        bytesRemoved: bytes,
+                        errorsEncountered: errors,
+                        needsAttention: hasAttention,
+                        itemEntries: clusterEntries
+                    )
+                )
+            }
+        }
+
+        return Array(runs.sorted { $0.timestamp > $1.timestamp }.prefix(limit))
+    }
+
     private func rotateIfNeeded() {
         let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
         let size = (attributes?[.size] as? NSNumber)?.intValue ?? 0
@@ -123,5 +253,45 @@ final class DiskCleanAuditLog: @unchecked Sendable {
 
         try? FileManager.default.removeItem(at: rotatedFileURL)
         try? FileManager.default.moveItem(at: fileURL, to: rotatedFileURL)
+    }
+}
+
+
+// MARK: - Run-level cleanup history model
+
+struct DiskCleanRunHistoryEntry: Identifiable, Equatable, Sendable {
+    let id: String
+    let timestamp: Date
+    let isTrash: Bool
+    let status: String
+    let categoriesCleaned: [String]
+    let itemsRemoved: Int
+    let bytesRemoved: Int64
+    let errorsEncountered: [String]
+    let needsAttention: Bool
+    let itemEntries: [DiskCleanCleanupHistoryEntry]
+
+    init(
+        id: String,
+        timestamp: Date,
+        isTrash: Bool,
+        status: String,
+        categoriesCleaned: [String],
+        itemsRemoved: Int,
+        bytesRemoved: Int64,
+        errorsEncountered: [String] = [],
+        needsAttention: Bool = false,
+        itemEntries: [DiskCleanCleanupHistoryEntry] = []
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.isTrash = isTrash
+        self.status = status
+        self.categoriesCleaned = categoriesCleaned
+        self.itemsRemoved = itemsRemoved
+        self.bytesRemoved = bytesRemoved
+        self.errorsEncountered = errorsEncountered
+        self.needsAttention = needsAttention
+        self.itemEntries = itemEntries
     }
 }

--- a/Plugins/DiskClean/Sources/DiskCleanAuditLog.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanAuditLog.swift
@@ -155,6 +155,9 @@ final class DiskCleanAuditLog: @unchecked Sendable {
 
         let summaryRecords = allRecords.filter { $0.action == .runSummary }
         let itemRecords = allRecords.filter { $0.action == .trash || $0.action == .delete }
+        let summarizedRunIDs = Set(
+            summaryRecords.compactMap(\.runID).filter { !$0.isEmpty }
+        )
 
         var itemRecordsByRunID: [String: [Record]] = [:]
         var unassignedRecords: [Record] = []
@@ -186,10 +189,38 @@ final class DiskCleanAuditLog: @unchecked Sendable {
                     status: summary.status,
                     categoriesCleaned: summary.categoriesCleaned ?? [],
                     itemsRemoved: summary.itemsRemoved ?? matchedRecords.filter { $0.status == "ok" }.count,
-                    bytesRemoved: summary.bytesRemoved ?? matchedRecords.compactMap(\.estimatedBytes).reduce(0, +),
+                    bytesRemoved: summary.bytesRemoved ?? verifiedRemovedBytes(in: matchedRecords),
                     errorsEncountered: summary.errorsEncountered ?? [],
                     needsAttention: hasAttention,
                     itemEntries: matchedItems
+                )
+            )
+        }
+
+        // A process can stop after appending item records but before its final summary. Keep each
+        // unmatched run visible so a partial deletion or blocked rollback is never hidden in the
+        // default history view. A run ID is supplied by the executor and is therefore stable across
+        // refreshes; completed runs remain represented by their authoritative summary above.
+        for (runID, records) in itemRecordsByRunID where !summarizedRunIDs.contains(runID) {
+            let sortedRecords = records.sorted { $0.timestamp > $1.timestamp }
+            guard let latestRecord = sortedRecords.first else { continue }
+
+            let entries = DiskCleanCleanupHistoryEntry.entries(from: sortedRecords)
+            let categories = Array(Set(sortedRecords.compactMap(\.category))).sorted()
+            let errors = sortedRecords.compactMap(\.error)
+
+            runs.append(
+                DiskCleanRunHistoryEntry(
+                    id: runID,
+                    timestamp: latestRecord.timestamp,
+                    isTrash: sortedRecords.allSatisfy { $0.action == .trash },
+                    status: "interrupted",
+                    categoriesCleaned: categories,
+                    itemsRemoved: sortedRecords.filter { $0.status == "ok" }.count,
+                    bytesRemoved: verifiedRemovedBytes(in: sortedRecords),
+                    errorsEncountered: errors,
+                    needsAttention: entries.contains(where: \.needsAttention),
+                    itemEntries: entries
                 )
             )
         }
@@ -221,7 +252,7 @@ final class DiskCleanAuditLog: @unchecked Sendable {
                 let isTrash = cluster.contains { $0.action == .trash }
                 let categories = Array(Set(cluster.compactMap(\.category))).sorted()
                 let removed = cluster.filter { $0.status == "ok" }.count
-                let bytes = cluster.compactMap(\.estimatedBytes).reduce(0, +)
+                let bytes = verifiedRemovedBytes(in: cluster)
                 let errors = cluster.compactMap(\.error)
                 let hasAttention = clusterEntries.contains(where: \.needsAttention)
                 let runID = "session-\(Int(first.timestamp.timeIntervalSince1970))"
@@ -244,6 +275,15 @@ final class DiskCleanAuditLog: @unchecked Sendable {
         }
 
         return Array(runs.sorted { $0.timestamp > $1.timestamp }.prefix(limit))
+    }
+
+    /// Audit records carry estimated source sizes. Only a verified `ok` record proves that those
+    /// bytes were removed; failed, skipped, and partial results must not inflate history totals.
+    private func verifiedRemovedBytes(in records: [Record]) -> Int64 {
+        records.reduce(into: 0) { total, record in
+            guard record.status == "ok", let bytes = record.estimatedBytes else { return }
+            total += max(bytes, 0)
+        }
     }
 
     private func rotateIfNeeded() {

--- a/Plugins/DiskClean/Sources/DiskCleanCategoryListView.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanCategoryListView.swift
@@ -192,43 +192,161 @@ private struct DiskCleanCandidateRow: View {
     let isInteractionEnabled: Bool
     let onToggle: (Bool) -> Void
 
+    @State private var isExplanationExpanded = false
+
     var body: some View {
-        HStack(alignment: .top, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
-            Toggle("", isOn: Binding(get: { isSelected }, set: { onToggle($0) }))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
-                .disabled(!isInteractionEnabled || !isSelectable)
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                Toggle("", isOn: Binding(get: { isSelected }, set: { onToggle($0) }))
+                    .toggleStyle(.checkbox)
+                    .labelsHidden()
+                    .disabled(!isInteractionEnabled || !isSelectable)
 
-            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
-                Text(candidate.displayName)
-                    .font(PluginSettingsTheme.Typography.rowTitle)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+                    Text(candidate.displayName)
+                        .font(PluginSettingsTheme.Typography.rowTitle)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
 
-                Text(candidate.path)
-                    .font(PluginSettingsTheme.Typography.monospacedValue)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .textSelection(.enabled)
+                    Text(candidate.path)
+                        .font(PluginSettingsTheme.Typography.monospacedValue)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
 
-                if !badges.isEmpty {
-                    HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
-                        ForEach(badges) { badge in
-                            DiskCleanBadgeLabel(badge: badge)
+                    if !badges.isEmpty {
+                        HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                            ForEach(badges) { badge in
+                                DiskCleanBadgeLabel(badge: badge)
+                            }
                         }
                     }
                 }
+
+                Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
+
+                Text(sizeText)
+                    .font(PluginSettingsTheme.Typography.monospacedValue)
+                    .foregroundStyle(candidate.sizeResult == nil ? Color.secondary : Color.primary)
+                    .frame(width: DiskCleanFormat.byteColumnWidth, alignment: .trailing)
+
+                Button {
+                    isExplanationExpanded.toggle()
+                } label: {
+                    Image(systemName: isExplanationExpanded ? "info.circle.fill" : "info.circle")
+                        .font(PluginSettingsTheme.Typography.rowIcon)
+                        .foregroundStyle(isExplanationExpanded ? Color.accentColor : Color.secondary)
+                }
+                .buttonStyle(.borderless)
+                .help(localization.string("candidate.action.explain", defaultValue: "规则解释与详情"))
             }
+            .pluginSettingsListRowPadding()
 
-            Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
+            if isExplanationExpanded, let explanation = candidate.explanation {
+                VStack(alignment: .leading, spacing: 6) {
+                    PluginSettingsListDivider()
+                        .padding(.vertical, 2)
 
-            Text(sizeText)
-                .font(PluginSettingsTheme.Typography.monospacedValue)
-                .foregroundStyle(candidate.sizeResult == nil ? Color.secondary : Color.primary)
-                .frame(width: DiskCleanFormat.byteColumnWidth, alignment: .trailing)
+                    HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                        Text(localization.string("candidate.explain.tier", defaultValue: "安全级别："))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                        Text(explanation.safetyTier.title(localization: localization))
+                            .font(PluginSettingsTheme.Typography.statusBadge)
+                            .foregroundStyle(explanation.safetyTier == .safe ? Color.green : Color.orange)
+
+                        Text("·")
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+
+                        Text(localization.string("candidate.explain.confidence", defaultValue: "置信度："))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                        Text(confidenceText(explanation.confidence))
+                            .font(PluginSettingsTheme.Typography.statusBadge)
+                            .foregroundStyle(.secondary)
+
+                        if explanation.requiresFullDiskAccess {
+                            Text("·")
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .foregroundStyle(.secondary)
+                            Text(localization.string("candidate.explain.fda", defaultValue: "需要完全磁盘访问权限"))
+                                .font(PluginSettingsTheme.Typography.statusBadge)
+                                .foregroundStyle(.orange)
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(alignment: .top, spacing: 4) {
+                            Text(localization.string("candidate.explain.whyMatched", defaultValue: "匹配原因："))
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .foregroundStyle(.secondary)
+                            Text(explanation.whyMatched)
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        HStack(alignment: .top, spacing: 4) {
+                            Text(localization.string("candidate.explain.consequence", defaultValue: "删除后果："))
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .foregroundStyle(.secondary)
+                            Text(explanation.consequence)
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        if let regen = explanation.regeneration {
+                            HStack(alignment: .top, spacing: 4) {
+                                Text(localization.string("candidate.explain.regeneration", defaultValue: "重建方式："))
+                                    .font(PluginSettingsTheme.Typography.rowDescription)
+                                    .foregroundStyle(.secondary)
+                                Text(regen)
+                                    .font(PluginSettingsTheme.Typography.rowDescription)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                    }
+
+                    HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                        Button {
+                            NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: candidate.path)])
+                        } label: {
+                            Label(localization.string("candidate.action.reveal", defaultValue: "在访达中显示"), systemImage: "folder")
+                                .font(PluginSettingsTheme.Typography.controlLabel)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.mini)
+
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(candidate.path, forType: .string)
+                        } label: {
+                            Label(localization.string("candidate.action.copyPath", defaultValue: "拷贝路径"), systemImage: "doc.on.doc")
+                                .font(PluginSettingsTheme.Typography.controlLabel)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.mini)
+                    }
+                    .padding(.top, 2)
+                }
+                .padding(.horizontal, PluginSettingsTheme.Spacing.rowHorizontal)
+                .padding(.bottom, PluginSettingsTheme.Spacing.rowVertical)
+            }
         }
-        .pluginSettingsListRowPadding()
+    }
+
+    private func confidenceText(_ confidence: DiskCleanConfidence) -> String {
+        switch confidence {
+        case .high:
+            return localization.string("confidence.high", defaultValue: "高")
+        case .medium:
+            return localization.string("confidence.medium", defaultValue: "中")
+        case .low:
+            return localization.string("confidence.low", defaultValue: "低")
+        }
     }
 
     /// Unresolved sizes show "calculating…" rather than "0 bytes"—the latter would look like an empty item.

--- a/Plugins/DiskClean/Sources/DiskCleanCategoryListView.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanCategoryListView.swift
@@ -110,32 +110,40 @@ private struct DiskCleanCategoryCard: View {
             )
             .disabled(!isInteractionEnabled || !state.isSelectable)
 
-            Image(systemName: group.category.symbolName)
-                .pluginSettingsRowIconStyle()
+            Button {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    onToggleExpanded()
+                }
+            } label: {
+                HStack(alignment: .top, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                    Image(systemName: group.category.symbolName)
+                        .pluginSettingsRowIconStyle()
 
-            VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
-                Text(group.category.title(localization: localization))
-                    .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
-                Text(group.category.consequence(localization: localization))
-                    .font(PluginSettingsTheme.Typography.rowDescription)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                Text(countSummary)
-                    .font(PluginSettingsTheme.Typography.statusBadge)
-                    .foregroundStyle(.secondary)
-            }
+                    VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+                        Text(group.category.title(localization: localization))
+                            .font(PluginSettingsTheme.Typography.emphasizedRowTitle)
+                        Text(group.category.consequence(localization: localization))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Text(countSummary)
+                            .font(PluginSettingsTheme.Typography.statusBadge)
+                            .foregroundStyle(.secondary)
+                    }
 
-            Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
+                    Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
 
-            Text(DiskCleanFormat.approximateBytes(group.selectedEstimatedBytes, localization: localization))
-                .font(PluginSettingsTheme.Typography.monospacedValue)
-                .frame(width: DiskCleanFormat.byteColumnWidth, alignment: .trailing)
+                    Text(DiskCleanFormat.approximateBytes(group.selectedEstimatedBytes, localization: localization))
+                        .font(PluginSettingsTheme.Typography.monospacedValue)
+                        .frame(width: DiskCleanFormat.byteColumnWidth, alignment: .trailing)
 
-            Button(action: onToggleExpanded) {
                 Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                     .font(PluginSettingsTheme.Typography.rowIcon)
+                    .frame(width: 28, height: 28)
+                }
+                .contentShape(Rectangle())
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.plain)
             .help(
                 isExpanded
                     ? localization.string("detail.category.collapse", defaultValue: "收起项目")
@@ -146,7 +154,7 @@ private struct DiskCleanCategoryCard: View {
     }
 
     private var candidateRows: some View {
-        VStack(spacing: 0) {
+        LazyVStack(spacing: 0) {
             ForEach(group.candidates) { candidate in
                 DiskCleanCandidateRow(
                     candidate: candidate,

--- a/Plugins/DiskClean/Sources/DiskCleanCleanupHistoryView.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanCleanupHistoryView.swift
@@ -143,6 +143,13 @@ struct DiskCleanCleanupHistoryEntry: Identifiable, Equatable, Sendable {
 /// Read seam for cleanup history. The audit log is on disk; loading must not block the main thread.
 protocol DiskCleanCleanupHistoryProviding: Sendable {
     func recentEntries(limit: Int) async -> [DiskCleanCleanupHistoryEntry]
+    func recentRuns(limit: Int) async -> [DiskCleanRunHistoryEntry]
+}
+
+extension DiskCleanCleanupHistoryProviding {
+    func recentRuns(limit: Int) async -> [DiskCleanRunHistoryEntry] {
+        []
+    }
 }
 
 struct DiskCleanAuditLogHistoryProvider: DiskCleanCleanupHistoryProviding {
@@ -155,6 +162,13 @@ struct DiskCleanAuditLogHistoryProvider: DiskCleanCleanupHistoryProviding {
         }.value
         return DiskCleanCleanupHistoryEntry.entries(from: records)
     }
+
+    func recentRuns(limit: Int) async -> [DiskCleanRunHistoryEntry] {
+        let directory = directory
+        return await Task.detached(priority: .utility) {
+            DiskCleanAuditLog(directory: directory).recentRuns(limit: limit)
+        }.value
+    }
 }
 
 // MARK: - View
@@ -166,9 +180,19 @@ struct DiskCleanCleanupHistorySection: View {
 
     private static let recordLimit = 100
 
+    enum HistoryViewMode: String, CaseIterable, Identifiable {
+        case runs
+        case items
+
+        var id: String { rawValue }
+    }
+
     @State private var isExpanded = false
     @State private var entries: [DiskCleanCleanupHistoryEntry] = []
+    @State private var runs: [DiskCleanRunHistoryEntry] = []
     @State private var isLoading = false
+    @State private var viewMode: HistoryViewMode = .runs
+    @State private var isCopied = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.sectionHeaderContent) {
@@ -182,17 +206,22 @@ struct DiskCleanCleanupHistorySection: View {
         }
         .task(id: isExpanded) {
             guard isExpanded else { return }
-            isLoading = true
-            entries = await provider.recentEntries(limit: Self.recordLimit)
-            isLoading = false
+            await loadData()
         }
     }
 
-    /// Place the reload button in the content area, not the DisclosureGroup label:
-    /// the label's hit target belongs to expand/collapse; a button there would fight for clicks.
+    private func loadData() async {
+        isLoading = true
+        async let loadedEntries = provider.recentEntries(limit: Self.recordLimit)
+        async let loadedRuns = provider.recentRuns(limit: Self.recordLimit)
+        entries = await loadedEntries
+        runs = await loadedRuns
+        isLoading = false
+    }
+
     private var reloadButton: some View {
         Button {
-            Task { entries = await provider.recentEntries(limit: Self.recordLimit) }
+            Task { await loadData() }
         } label: {
             Label(
                 localization.string("detail.history.reload", defaultValue: "刷新"),
@@ -205,6 +234,47 @@ struct DiskCleanCleanupHistorySection: View {
         .disabled(isLoading)
     }
 
+    private var copyDiagnosticsButton: some View {
+        Button {
+            copyDiagnostics()
+            isCopied = true
+            Task {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                isCopied = false
+            }
+        } label: {
+            Label(
+                isCopied
+                    ? localization.string("detail.history.copied", defaultValue: "已复制")
+                    : localization.string("detail.history.copyDiagnostics", defaultValue: "复制诊断"),
+                systemImage: isCopied ? "checkmark" : "doc.on.doc"
+            )
+            .font(PluginSettingsTheme.Typography.controlLabel)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(isLoading || (entries.isEmpty && runs.isEmpty))
+    }
+
+    private func copyDiagnostics() {
+        let home = NSHomeDirectory()
+        var lines: [String] = ["=== DiskClean Cleanup History Diagnostics ==="]
+        for run in runs {
+            let mode = run.isTrash ? "Trash" : "Permanent"
+            lines.append("Run [\(DiskCleanFormat.timestamp(run.timestamp))] Status: \(run.status), Mode: \(mode), Removed: \(run.itemsRemoved) items (\(run.bytesRemoved) bytes), Categories: \(run.categoriesCleaned.joined(separator: ", "))")
+            for error in run.errorsEncountered {
+                lines.append("  Error: \(error.replacingOccurrences(of: home, with: "~"))")
+            }
+        }
+        lines.append("\n=== Recent Items ===")
+        for entry in entries.prefix(50) {
+            let path = (entry.path ?? "nil").replacingOccurrences(of: home, with: "~")
+            lines.append("[\(entry.timestamp)] \(path) - Status: \(entry.status.symbolName) - \(entry.estimatedBytes ?? 0) bytes")
+        }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(lines.joined(separator: "\n"), forType: .string)
+    }
+
     @ViewBuilder
     private var content: some View {
         if isLoading {
@@ -215,7 +285,7 @@ struct DiskCleanCleanupHistorySection: View {
                     .foregroundStyle(.secondary)
             }
             .pluginSettingsListRowPadding()
-        } else if entries.isEmpty {
+        } else if entries.isEmpty && runs.isEmpty {
             Text(localization.string("detail.history.empty", defaultValue: "还没有清理记录"))
                 .font(PluginSettingsTheme.Typography.rowDescription)
                 .foregroundStyle(.secondary)
@@ -229,21 +299,42 @@ struct DiskCleanCleanupHistorySection: View {
                 }
 
                 HStack {
+                    Picker("", selection: $viewMode) {
+                        Text(localization.format("detail.history.view.runs", defaultValue: "按次汇总 (%d)", runs.count))
+                            .tag(HistoryViewMode.runs)
+                        Text(localization.format("detail.history.view.items", defaultValue: "全部明细 (%d)", entries.count))
+                            .tag(HistoryViewMode.items)
+                    }
+                    .pickerStyle(.segmented)
+                    .controlSize(.small)
+                    .frame(maxWidth: 240)
+
                     Spacer()
+
+                    copyDiagnosticsButton
                     reloadButton
                 }
 
                 ScrollView {
                     LazyVStack(spacing: 0) {
-                        ForEach(entries) { entry in
-                            DiskCleanCleanupHistoryRow(entry: entry, localization: localization)
-                            if entry.id != entries.last?.id {
-                                PluginSettingsListDivider()
+                        if viewMode == .runs {
+                            ForEach(runs) { run in
+                                DiskCleanRunHistoryRow(run: run, localization: localization)
+                                if run.id != runs.last?.id {
+                                    PluginSettingsListDivider()
+                                }
+                            }
+                        } else {
+                            ForEach(entries) { entry in
+                                DiskCleanCleanupHistoryRow(entry: entry, localization: localization)
+                                if entry.id != entries.last?.id {
+                                    PluginSettingsListDivider()
+                                }
                             }
                         }
                     }
                 }
-                .frame(maxHeight: 260)
+                .frame(maxHeight: 280)
                 .pluginSettingsCardBackground(.standard)
             }
         }
@@ -349,5 +440,103 @@ private struct DiskCleanCleanupHistoryRow: View {
             }
         }
         .pluginSettingsListRowPadding()
+    }
+}
+
+
+private struct DiskCleanRunHistoryRow: View {
+    let run: DiskCleanRunHistoryEntry
+    let localization: PluginLocalization
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top, spacing: PluginSettingsTheme.Spacing.rowContentControl) {
+                Image(systemName: run.needsAttention ? "exclamationmark.triangle.fill" : (run.isTrash ? "trash" : "checkmark.circle.fill"))
+                    .foregroundStyle(run.needsAttention ? Color.orange : (run.isTrash ? Color.secondary : Color.green))
+                    .frame(width: PluginSettingsTheme.Size.rowIcon)
+
+                VStack(alignment: .leading, spacing: PluginSettingsTheme.Spacing.rowTitleDescription) {
+                    HStack(alignment: .firstTextBaseline, spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                        Text(DiskCleanFormat.timestamp(run.timestamp))
+                            .font(PluginSettingsTheme.Typography.rowTitle)
+
+                        Text(run.isTrash
+                            ? localization.string("detail.history.mode.trash", defaultValue: "废纸篓")
+                            : localization.string("detail.history.mode.permanent", defaultValue: "永久删除"))
+                            .font(PluginSettingsTheme.Typography.statusBadge)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Capsule().fill(Color(nsColor: .quaternaryLabelColor).opacity(0.4)))
+
+                        if run.needsAttention {
+                            Text(localization.string("detail.history.attentionBadge", defaultValue: "需关注"))
+                                .font(PluginSettingsTheme.Typography.statusBadge)
+                                .foregroundStyle(.orange)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(Color.orange.opacity(0.2)))
+                        }
+
+                        Spacer(minLength: PluginSettingsTheme.Spacing.rowContentControl)
+
+                        Text(DiskCleanFormat.approximateBytes(run.bytesRemoved, localization: localization))
+                            .font(PluginSettingsTheme.Typography.monospacedValue)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: PluginSettingsTheme.Spacing.controlCluster) {
+                        Text(localization.format("detail.history.runItems", defaultValue: "清理 %d 项", run.itemsRemoved))
+                            .font(PluginSettingsTheme.Typography.rowDescription)
+                            .foregroundStyle(.secondary)
+
+                        if !run.categoriesCleaned.isEmpty {
+                            Text("·")
+                                .font(PluginSettingsTheme.Typography.rowDescription)
+                                .foregroundStyle(.secondary)
+                            Text(run.categoriesCleaned.joined(separator: ", "))
+                                .font(PluginSettingsTheme.Typography.statusBadge)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                        }
+                    }
+
+                    if !run.errorsEncountered.isEmpty {
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(Array(run.errorsEncountered.prefix(2).enumerated()), id: \.offset) { _, err in
+                                Text(err)
+                                    .font(PluginSettingsTheme.Typography.rowDescription)
+                                    .foregroundStyle(.orange)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                }
+
+                if !run.itemEntries.isEmpty {
+                    Button {
+                        isExpanded.toggle()
+                    } label: {
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(PluginSettingsTheme.Typography.rowIcon)
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+            .pluginSettingsListRowPadding()
+
+            if isExpanded && !run.itemEntries.isEmpty {
+                VStack(spacing: 0) {
+                    PluginSettingsListDivider()
+                    ForEach(run.itemEntries) { entry in
+                        DiskCleanCleanupHistoryRow(entry: entry, localization: localization)
+                    }
+                }
+                .padding(.leading, 24)
+            }
+        }
     }
 }

--- a/Plugins/DiskClean/Sources/DiskCleanCleanupHistoryView.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanCleanupHistoryView.swift
@@ -518,18 +518,27 @@ private struct DiskCleanRunHistoryRow: View {
 
                 if !run.itemEntries.isEmpty {
                     Button {
-                        isExpanded.toggle()
+                        withAnimation(.easeInOut(duration: 0.18)) {
+                            isExpanded.toggle()
+                        }
                     } label: {
                         Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                             .font(PluginSettingsTheme.Typography.rowIcon)
+                            .frame(width: 32, height: 32)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.borderless)
+                    .help(
+                        isExpanded
+                            ? localization.string("detail.history.collapse", defaultValue: "收起清理记录")
+                            : localization.string("detail.history.expand", defaultValue: "展开清理记录")
+                    )
                 }
             }
             .pluginSettingsListRowPadding()
 
             if isExpanded && !run.itemEntries.isEmpty {
-                VStack(spacing: 0) {
+                LazyVStack(spacing: 0) {
                     PluginSettingsListDivider()
                     ForEach(run.itemEntries) { entry in
                         DiskCleanCleanupHistoryRow(entry: entry, localization: localization)

--- a/Plugins/DiskClean/Sources/DiskCleanExecutor.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanExecutor.swift
@@ -186,12 +186,14 @@ struct DiskCleanExecutor: DiskCleanExecuting {
 
     func execute(plan: DiskCleanValidatedPlan) async throws -> DiskCleanExecutionResult {
         var snapshot = try await preflight(plan: plan)
+        let runID = UUID().uuidString
 
         var itemResults: [DiskCleanExecutionItemResult] = []
         itemResults.reserveCapacity(plan.items.count)
 
         for item in plan.items {
             if Task.isCancelled {
+                recordRunSummary(runID: runID, plan: plan, itemResults: itemResults, wasCancelled: true)
                 return DiskCleanExecutionResult(
                     itemResults: itemResults,
                     mode: plan.mode,
@@ -202,6 +204,7 @@ struct DiskCleanExecutor: DiskCleanExecuting {
             // Per-item lock recheck: refresh bundle IDs; keep process names from the preflight snapshot (trade-off noted on the protocol).
             snapshot = await runningAppLock.refreshingBundleIDs(in: snapshot)
             if Task.isCancelled {
+                recordRunSummary(runID: runID, plan: plan, itemResults: itemResults, wasCancelled: true)
                 return DiskCleanExecutionResult(
                     itemResults: itemResults,
                     mode: plan.mode,
@@ -213,7 +216,7 @@ struct DiskCleanExecutor: DiskCleanExecuting {
                 processNames: item.skipWhenProcessIsRunning
             ) {
                 itemResults.append(
-                    record(item: item, outcome: .skipped(.inUse(processName: processName)), mode: plan.mode)
+                    record(item: item, outcome: .skipped(.inUse(processName: processName)), mode: plan.mode, runID: runID)
                 )
                 continue
             }
@@ -225,17 +228,71 @@ struct DiskCleanExecutor: DiskCleanExecuting {
                 alsoChecking: item.safetyCheckPaths
             )
             guard safety.isCleanable else {
-                itemResults.append(record(item: item, outcome: .skipped(safety), mode: plan.mode))
+                itemResults.append(record(item: item, outcome: .skipped(safety), mode: plan.mode, runID: runID))
                 continue
             }
 
             let disposition = primitive.remove(item, mode: plan.mode)
             itemResults.append(
-                record(item: item, outcome: Self.outcome(for: disposition, item: item), mode: plan.mode)
+                record(item: item, outcome: Self.outcome(for: disposition, item: item), mode: plan.mode, runID: runID)
             )
         }
 
+        recordRunSummary(runID: runID, plan: plan, itemResults: itemResults, wasCancelled: false)
         return DiskCleanExecutionResult(itemResults: itemResults, mode: plan.mode)
+    }
+
+    private func recordRunSummary(
+        runID: String,
+        plan: DiskCleanValidatedPlan,
+        itemResults: [DiskCleanExecutionItemResult],
+        wasCancelled: Bool
+    ) {
+        let categories = Array(Set(plan.items.map { $0.category.rawValue })).sorted()
+        let removedCount = itemResults.filter {
+            switch $0.outcome {
+            case .removed, .trashed:
+                return true
+            case .skipped, .changedSinceScan, .failed, .partiallyDeleted, .rollbackBlocked:
+                return false
+            }
+        }.count
+        let reclaimedBytes = itemResults.reduce(0) { $0 + $1.reclaimedBytes }
+        let errors = itemResults.compactMap { item -> String? in
+            switch item.outcome {
+            case let .failed(msg):
+                return msg
+            case let .partiallyDeleted(_, msg):
+                return msg
+            case let .rollbackBlocked(_, msg):
+                return msg
+            case .removed, .trashed, .skipped, .changedSinceScan:
+                return nil
+            }
+        }
+
+        let status: String
+        if wasCancelled {
+            status = "cancelled"
+        } else if !errors.isEmpty {
+            status = "completedWithErrors"
+        } else {
+            status = "ok"
+        }
+
+        auditLog.append(
+            DiskCleanAuditLog.Record(
+                timestamp: now(),
+                action: .runSummary,
+                runID: runID,
+                status: status,
+                categoriesCleaned: categories,
+                itemsRemoved: removedCount,
+                bytesRemoved: reclaimedBytes,
+                errorsEncountered: errors,
+                isTrash: plan.mode == .trash
+            )
+        )
     }
 
     // MARK: - preflight（§7.1）
@@ -304,12 +361,14 @@ struct DiskCleanExecutor: DiskCleanExecuting {
     private func record(
         item: DiskCleanValidatedPlan.PlanItem,
         outcome: DiskCleanExecutionItemResult.Outcome,
-        mode: DiskCleanRemovalMode
+        mode: DiskCleanRemovalMode,
+        runID: String? = nil
     ) -> DiskCleanExecutionItemResult {
         auditLog.append(
             DiskCleanAuditLog.Record(
                 timestamp: now(),
                 action: mode == .trash ? .trash : .delete,
+                runID: runID,
                 targetID: item.targetID,
                 legacyRuleID: item.legacyRuleID,
                 category: item.category.rawValue,

--- a/Plugins/DiskClean/Sources/DiskCleanModels.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanModels.swift
@@ -249,6 +249,8 @@ struct DiskCleanCandidate: Identifiable, Equatable, Sendable {
     let notes: [DiskCleanCandidateNote]
     /// Size result. nil = not sized yet.
     let sizeResult: DiskCleanSizeResult?
+    /// Structured rule explanation for why found, consequences, and safety disclosures.
+    let explanation: DiskCleanRuleExplanation?
 
     /// Primary logical path (first alias, or the physical path when none differ).
     var logicalPath: String { logicalPaths.first ?? path }
@@ -264,7 +266,8 @@ struct DiskCleanCandidate: Identifiable, Equatable, Sendable {
         risk: DiskCleanRisk,
         safety: DiskCleanSafetyStatus,
         notes: [DiskCleanCandidateNote] = [],
-        sizeResult: DiskCleanSizeResult? = nil
+        sizeResult: DiskCleanSizeResult? = nil,
+        explanation: DiskCleanRuleExplanation? = nil
     ) {
         self.id = id
         self.targetID = targetID
@@ -282,6 +285,7 @@ struct DiskCleanCandidate: Identifiable, Equatable, Sendable {
         self.safety = safety
         self.notes = notes
         self.sizeResult = sizeResult
+        self.explanation = explanation
     }
 
     private static func uniquePaths(_ paths: [String]) -> [String] {
@@ -338,7 +342,8 @@ struct DiskCleanCandidate: Identifiable, Equatable, Sendable {
             risk: risk,
             safety: safety,
             notes: notes,
-            sizeResult: sizeResult
+            sizeResult: sizeResult,
+            explanation: explanation
         )
     }
 

--- a/Plugins/DiskClean/Sources/DiskCleanRuleCatalog.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanRuleCatalog.swift
@@ -29,6 +29,7 @@ struct DiskCleanRule: Identifiable, Equatable, Sendable {
     let targets: [Target]
     let skipWhenProcessIsRunning: [String]
     let requiresAdmin: Bool
+    let explanation: DiskCleanRuleExplanation?
 
     init(
         id: String,
@@ -37,7 +38,8 @@ struct DiskCleanRule: Identifiable, Equatable, Sendable {
         risk: DiskCleanRisk,
         targets: [Target],
         skipWhenProcessIsRunning: [String] = [],
-        requiresAdmin: Bool = false
+        requiresAdmin: Bool = false,
+        explanation: DiskCleanRuleExplanation? = nil
     ) {
         self.id = id
         self.choice = choice
@@ -46,6 +48,27 @@ struct DiskCleanRule: Identifiable, Equatable, Sendable {
         self.targets = targets
         self.skipWhenProcessIsRunning = skipWhenProcessIsRunning
         self.requiresAdmin = requiresAdmin
+        self.explanation = explanation
+    }
+
+    var whyMatched: String {
+        explanation?.whyMatched ?? "Matches pattern for \(id)"
+    }
+
+    var consequence: String {
+        explanation?.consequence ?? "Removes temporary or cached files for \(title)"
+    }
+
+    var safetyTier: DiskCleanSafetyTier {
+        explanation?.safetyTier ?? DiskCleanSafetyTier(risk: risk)
+    }
+
+    var confidence: DiskCleanConfidence {
+        explanation?.confidence ?? .high
+    }
+
+    var requiresFullDiskAccess: Bool {
+        explanation?.requiresFullDiskAccess ?? false
     }
 }
 
@@ -857,7 +880,8 @@ struct DiskCleanRuleCatalog: Equatable, Sendable {
         risk: DiskCleanRisk = .low,
         targets: [String],
         skipWhenProcessIsRunning: [String] = [],
-        requiresAdmin: Bool = false
+        requiresAdmin: Bool = false,
+        explanation: DiskCleanRuleExplanation? = nil
     ) -> DiskCleanRule {
         DiskCleanRule(
             id: id,
@@ -866,7 +890,8 @@ struct DiskCleanRuleCatalog: Equatable, Sendable {
             risk: risk,
             targets: targets.map { .path($0) },
             skipWhenProcessIsRunning: skipWhenProcessIsRunning,
-            requiresAdmin: requiresAdmin
+            requiresAdmin: requiresAdmin,
+            explanation: explanation
         )
     }
 }

--- a/Plugins/DiskClean/Sources/DiskCleanRuleCatalogV2.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanRuleCatalogV2.swift
@@ -95,7 +95,21 @@ struct DiskCleanRuleCatalogV2: Sendable {
             ]),
             reservedRootPaths: [
                 "~/Library/Caches"
-            ]
+            ],
+            explanation: DiskCleanRuleExplanation(
+                whyMatched: "Standard macOS user-level application caches in ~/Library/Caches",
+                consequence: "Applications will re-download web content or rebuild thumbnail/preview caches on first launch.",
+                safetyTier: .safe,
+                requiresFullDiskAccess: false,
+                confidence: .high,
+                title: "用户应用缓存",
+                summary: "清理用户目录下 ~/Library/Caches 中的临时应用缓存",
+                dataClass: .cache,
+                discoveryMethod: .knownPathPattern,
+                defaultSelectionReason: "低风险临时缓存，应用可自动重建",
+                regeneration: "应用首次启动时会重新生成必要缓存",
+                provenance: .macOSDocumentedLocation
+            )
         ),
         DiskCleanRuleTarget(
             id: "cache.user-essentials.logs",
@@ -103,11 +117,27 @@ struct DiskCleanRuleCatalogV2: Sendable {
             category: .logs,
             risk: .low,
             kind: .path(globs: [
-                "~/Library/Logs/*"
+                "~/Library/Logs/*",
+                "~/Library/Logs/*/*.log.*",
+                "~/Library/Logs/*/*.old"
             ]),
             reservedRootPaths: [
                 "~/Library/Logs"
-            ]
+            ],
+            explanation: DiskCleanRuleExplanation(
+                whyMatched: "Matches application and system log files and log rotations in ~/Library/Logs",
+                consequence: "Historical log records and rotated diagnostic reports will be cleared.",
+                safetyTier: .safe,
+                requiresFullDiskAccess: false,
+                confidence: .high,
+                title: "应用与系统日志",
+                summary: "清理用户日志目录下的常规日志与历史轮转文件",
+                dataClass: .log,
+                discoveryMethod: .knownPathPattern,
+                defaultSelectionReason: "低风险历史日志，不会影响应用正常运行",
+                regeneration: "应用后续运行时会自动创建新的日志文件",
+                provenance: .macOSDocumentedLocation
+            )
         ),
         DiskCleanRuleTarget(
             id: "cache.macos-app-state",
@@ -921,6 +951,8 @@ struct DiskCleanRuleCatalogV2: Sendable {
                 "~/.android/cache/*",
                 "~/.cache/swift-package-manager/*",
                 "~/Library/Caches/org.swift.swiftpm/*",
+                "~/Library/Caches/CocoaPods/*",
+                "~/Library/Caches/org.carthage.CarthageKit/*",
                 "~/.expo/expo-go/*",
                 "~/.expo/android-apk-cache/*",
                 "~/.expo/ios-simulator-app-cache/*",
@@ -935,6 +967,8 @@ struct DiskCleanRuleCatalogV2: Sendable {
                 "~/.android/cache",
                 "~/.cache/swift-package-manager",
                 "~/Library/Caches/org.swift.swiftpm",
+                "~/Library/Caches/CocoaPods",
+                "~/Library/Caches/org.carthage.CarthageKit",
                 "~/.expo/expo-go",
                 "~/.expo/android-apk-cache",
                 "~/.expo/ios-simulator-app-cache",
@@ -942,7 +976,21 @@ struct DiskCleanRuleCatalogV2: Sendable {
                 "~/.expo/schema-cache",
                 "~/.expo/template-cache",
                 "~/.expo/versions-cache"
-            ]
+            ],
+            explanation: DiskCleanRuleExplanation(
+                whyMatched: "Matches iOS/Android mobile and package dependency download caches (Android Studio, SwiftPM, CocoaPods, Carthage, Expo)",
+                consequence: "Mobile build artifacts and package caches will need to be redownloaded on next build.",
+                safetyTier: .safe,
+                requiresFullDiskAccess: false,
+                confidence: .high,
+                title: "移动开发依赖缓存",
+                summary: "清理 CocoaPods、Carthage、SwiftPM、Android Studio 等移动开发工具下载缓存",
+                dataClass: .downloadedResource,
+                discoveryMethod: .knownPathPattern,
+                defaultSelectionReason: "纯下载依赖包缓存，可在构建时按需重新下载",
+                regeneration: "下次执行 pod install、carthage 或构建时自动重新拉取",
+                provenance: .applicationDocumentedLocation
+            )
         ),
         DiskCleanRuleTarget(
             id: "developer.jvm-caches",

--- a/Plugins/DiskClean/Sources/DiskCleanRuleModels.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanRuleModels.swift
@@ -230,6 +230,8 @@ struct DiskCleanRuleTarget: Identifiable, Sendable {
     let lockedByBundleIDs: [String]
     /// Process names that lock the target while running (batched pgrep snapshot; covers non-app processes).
     let skipWhenProcessIsRunning: [String]
+    /// Structured rule explanation for auditability, user review, and consequence disclosure.
+    let explanation: DiskCleanRuleExplanation?
 
     init(
         id: String,
@@ -240,7 +242,8 @@ struct DiskCleanRuleTarget: Identifiable, Sendable {
         reservedRootPaths: [String],
         requiresFullDiskAccess: Bool = false,
         lockedByBundleIDs: [String] = [],
-        skipWhenProcessIsRunning: [String] = []
+        skipWhenProcessIsRunning: [String] = [],
+        explanation: DiskCleanRuleExplanation? = nil
     ) {
         self.id = id
         self.legacyRuleID = legacyRuleID
@@ -251,6 +254,7 @@ struct DiskCleanRuleTarget: Identifiable, Sendable {
         self.requiresFullDiskAccess = requiresFullDiskAccess
         self.lockedByBundleIDs = lockedByBundleIDs
         self.skipWhenProcessIsRunning = skipWhenProcessIsRunning
+        self.explanation = explanation
     }
 
     var pathGlobs: [String] {
@@ -279,5 +283,145 @@ struct DiskCleanRuleTarget: Identifiable, Sendable {
     static func expandHome(in path: String, homeDirectory: String) -> String {
         guard path == "~" || path.hasPrefix("~/") else { return path }
         return homeDirectory + String(path.dropFirst())
+    }
+
+    /// Structured explanation for this target, deriving safe fallbacks when not explicitly declared.
+    var resolvedExplanation: DiskCleanRuleExplanation {
+        if let explanation {
+            return explanation
+        }
+        return DiskCleanRuleExplanation(
+            whyMatched: "Matches cleanup target pattern for \(id)",
+            consequence: category.consequence(),
+            safetyTier: DiskCleanSafetyTier(risk: risk),
+            requiresFullDiskAccess: requiresFullDiskAccess,
+            confidence: .high,
+            title: id,
+            dataClass: category == .logs ? .log : .cache,
+            discoveryMethod: isDynamic ? .systemQuery : .knownPathPattern,
+            defaultSelectionReason: risk == .low ? "低风险缓存，可自动清理" : "需要用户确认",
+            provenance: .builtInMacToolsRule
+        )
+    }
+
+    var whyMatched: String { resolvedExplanation.whyMatched }
+    var consequence: String { resolvedExplanation.consequence }
+    var safetyTier: DiskCleanSafetyTier { resolvedExplanation.safetyTier }
+    var confidence: DiskCleanConfidence { resolvedExplanation.confidence }
+}
+
+// MARK: - Rule explainability
+
+enum DiskCleanConfidence: String, Codable, Equatable, Sendable, CaseIterable {
+    case high
+    case medium
+    case low
+}
+
+enum DiskCleanSafetyTier: String, Codable, Equatable, Sendable, CaseIterable {
+    case safe
+    case moderate
+    case sensitive
+
+    init(risk: DiskCleanRisk) {
+        switch risk {
+        case .low:
+            self = .safe
+        case .medium:
+            self = .moderate
+        case .high:
+            self = .sensitive
+        }
+    }
+
+    var titleKey: String {
+        "safetyTier.\(rawValue).title"
+    }
+
+    func title(localization: PluginLocalization = PluginLocalization(bundle: .main)) -> String {
+        switch self {
+        case .safe:
+            return localization.string("safetyTier.safe.title", defaultValue: "安全")
+        case .moderate:
+            return localization.string("safetyTier.moderate.title", defaultValue: "中等")
+        case .sensitive:
+            return localization.string("safetyTier.sensitive.title", defaultValue: "敏感")
+        }
+    }
+}
+
+enum DiskCleanDataClass: String, Codable, Equatable, Sendable, CaseIterable {
+    case cache
+    case log
+    case diagnostic
+    case downloadedResource
+    case generatedDependency
+    case buildArtifact
+    case installer
+    case temporaryState
+}
+
+enum DiskCleanDiscoveryMethod: String, Codable, Equatable, Sendable, CaseIterable {
+    case knownPath
+    case knownPathPattern
+    case systemQuery
+    case applicationVersionComparison
+    case userConfiguredRoot
+    case projectMarker
+}
+
+enum DiskCleanRuleProvenance: String, Codable, Equatable, Sendable, CaseIterable {
+    case builtInMacToolsRule
+    case macOSDocumentedLocation
+    case applicationDocumentedLocation
+    case independentlyVerifiedBehavior
+}
+
+struct DiskCleanRuleExplanation: Codable, Equatable, Sendable {
+    let whyMatched: String
+    let consequence: String
+    let safetyTier: DiskCleanSafetyTier
+    let requiresFullDiskAccess: Bool
+    let confidence: DiskCleanConfidence
+
+    let title: String?
+    let summary: String?
+    let dataClass: DiskCleanDataClass?
+    let owner: String?
+    let discoveryMethod: DiskCleanDiscoveryMethod?
+    let defaultSelectionReason: String?
+    let regeneration: String?
+    let provenance: DiskCleanRuleProvenance?
+
+    var whyFound: String { whyMatched }
+
+    init(
+        whyMatched: String,
+        consequence: String,
+        safetyTier: DiskCleanSafetyTier = .safe,
+        requiresFullDiskAccess: Bool = false,
+        confidence: DiskCleanConfidence = .high,
+        title: String? = nil,
+        summary: String? = nil,
+        dataClass: DiskCleanDataClass? = nil,
+        owner: String? = nil,
+        discoveryMethod: DiskCleanDiscoveryMethod? = nil,
+        defaultSelectionReason: String? = nil,
+        regeneration: String? = nil,
+        provenance: DiskCleanRuleProvenance? = nil
+    ) {
+        self.whyMatched = whyMatched
+        self.consequence = consequence
+        self.safetyTier = safetyTier
+        self.requiresFullDiskAccess = requiresFullDiskAccess
+        self.confidence = confidence
+        self.title = title
+        self.summary = summary
+        self.dataClass = dataClass
+        self.owner = owner
+        self.discoveryMethod = discoveryMethod
+        self.defaultSelectionReason = defaultSelectionReason
+        self.regeneration = regeneration
+        self.provenance = provenance
     }
 }

--- a/Plugins/DiskClean/Sources/DiskCleanScanEngine.swift
+++ b/Plugins/DiskClean/Sources/DiskCleanScanEngine.swift
@@ -491,7 +491,8 @@ struct DiskCleanScanEngine: DiskCleanScanning {
             risk: owned.facts.risk ?? target.risk,
             safety: safety,
             notes: owned.facts.notes,
-            sizeResult: nil
+            sizeResult: nil,
+            explanation: target.resolvedExplanation
         )
     }
 

--- a/Plugins/DiskClean/Tests/DiskCleanAuditLogTests.swift
+++ b/Plugins/DiskClean/Tests/DiskCleanAuditLogTests.swift
@@ -131,4 +131,128 @@ final class DiskCleanAuditLogTests: XCTestCase {
             status: status
         )
     }
+
+    func testRunSummaryRecordRoundTripsEveryField() throws {
+        let log = DiskCleanAuditLog(directory: storage.url)
+        let timestamp = Date(timeIntervalSince1970: 1_700_100_000)
+
+        log.append(
+            DiskCleanAuditLog.Record(
+                timestamp: timestamp,
+                action: .runSummary,
+                runID: "run-12345",
+                targetID: "summary",
+                path: "run://run-12345",
+                estimatedBytes: 104_857_600,
+                status: "completed",
+                categoriesCleaned: ["appCaches", "logs"],
+                itemsRemoved: 42,
+                bytesRemoved: 104_857_600,
+                errorsEncountered: ["Permission denied for /var/log/system.log"],
+                isTrash: false
+            )
+        )
+
+        let record = try XCTUnwrap(log.recentRecords(limit: 1).first)
+        XCTAssertEqual(record.timestamp.timeIntervalSince1970, timestamp.timeIntervalSince1970, accuracy: 1)
+        XCTAssertEqual(record.action, .runSummary)
+        XCTAssertEqual(record.runID, "run-12345")
+        XCTAssertEqual(record.categoriesCleaned, ["appCaches", "logs"])
+        XCTAssertEqual(record.itemsRemoved, 42)
+        XCTAssertEqual(record.bytesRemoved, 104_857_600)
+        XCTAssertEqual(record.errorsEncountered, ["Permission denied for /var/log/system.log"])
+        XCTAssertEqual(record.isTrash, false)
+    }
+
+    func testRecentRunsReadsRunSummaryRecords() {
+        let log = DiskCleanAuditLog(directory: storage.url)
+
+        for i in 1...3 {
+            log.append(
+                DiskCleanAuditLog.Record(
+                    timestamp: Date(timeIntervalSince1970: Double(2_000 + i * 100)),
+                    action: .runSummary,
+                    runID: "run-\(i)",
+                    targetID: "summary",
+                    path: "run://run-\(i)",
+                    estimatedBytes: Int64(i * 1024),
+                    status: "completed",
+                    categoriesCleaned: ["cat-\(i)"],
+                    itemsRemoved: i * 5,
+                    bytesRemoved: Int64(i * 1024),
+                    errorsEncountered: i == 2 ? ["warn"] : [],
+                    isTrash: i % 2 == 0
+                )
+            )
+        }
+
+        let runs = log.recentRuns(limit: 2)
+        XCTAssertEqual(runs.count, 2)
+        XCTAssertEqual(runs[0].id, "run-3")
+        XCTAssertEqual(runs[0].itemsRemoved, 15)
+        XCTAssertEqual(runs[0].bytesRemoved, 3072)
+        XCTAssertFalse(runs[0].isTrash)
+
+        XCTAssertEqual(runs[1].id, "run-2")
+        XCTAssertEqual(runs[1].itemsRemoved, 10)
+        XCTAssertEqual(runs[1].bytesRemoved, 2048)
+        XCTAssertTrue(runs[1].isTrash)
+        XCTAssertTrue(runs[1].needsAttention)
+    }
+
+    func testRecentRunsClustersLegacyRecordsWhenSummaryAbsent() {
+        let log = DiskCleanAuditLog(directory: storage.url)
+        let baseTime = Date(timeIntervalSince1970: 3_000)
+
+        // Cluster 1 (timestamp 3000-3002)
+        log.append(
+            DiskCleanAuditLog.Record(
+                timestamp: baseTime,
+                action: .trash,
+                category: "appCaches",
+                path: "/cache/item1",
+                estimatedBytes: 1024,
+                status: "ok"
+            )
+        )
+        log.append(
+            DiskCleanAuditLog.Record(
+                timestamp: baseTime.addingTimeInterval(2),
+                action: .trash,
+                category: "systemLogs",
+                path: "/cache/item2",
+                estimatedBytes: 2048,
+                status: "ok"
+            )
+        )
+
+        // Cluster 2 (timestamp 3100)
+        log.append(
+            DiskCleanAuditLog.Record(
+                timestamp: baseTime.addingTimeInterval(100),
+                action: .delete,
+                category: "downloads",
+                path: "/downloads/old",
+                estimatedBytes: 4096,
+                status: "partiallyDeleted",
+                error: "Locked file"
+            )
+        )
+
+        let runs = log.recentRuns(limit: 10)
+        XCTAssertEqual(runs.count, 2, "Must cluster by time window into 2 runs")
+
+        // Most recent first: cluster 2
+        XCTAssertEqual(runs[0].itemsRemoved, 0)
+        XCTAssertEqual(runs[0].bytesRemoved, 4096)
+        XCTAssertTrue(runs[0].needsAttention)
+        XCTAssertFalse(runs[0].isTrash)
+
+        // Earlier cluster 1
+        XCTAssertEqual(runs[1].itemsRemoved, 2)
+        XCTAssertEqual(runs[1].bytesRemoved, 3072)
+        XCTAssertFalse(runs[1].needsAttention)
+        XCTAssertTrue(runs[1].isTrash)
+    }
+
 }

--- a/Plugins/DiskClean/Tests/DiskCleanAuditLogTests.swift
+++ b/Plugins/DiskClean/Tests/DiskCleanAuditLogTests.swift
@@ -244,7 +244,7 @@ final class DiskCleanAuditLogTests: XCTestCase {
 
         // Most recent first: cluster 2
         XCTAssertEqual(runs[0].itemsRemoved, 0)
-        XCTAssertEqual(runs[0].bytesRemoved, 4096)
+        XCTAssertEqual(runs[0].bytesRemoved, 0, "partial deletion does not prove any bytes were removed")
         XCTAssertTrue(runs[0].needsAttention)
         XCTAssertFalse(runs[0].isTrash)
 
@@ -253,6 +253,96 @@ final class DiskCleanAuditLogTests: XCTestCase {
         XCTAssertEqual(runs[1].bytesRemoved, 3072)
         XCTAssertFalse(runs[1].needsAttention)
         XCTAssertTrue(runs[1].isTrash)
+    }
+
+    func testRecentRunsProjectsInterruptedRunIDWithoutDuplicatingCompletedSummary() throws {
+        let log = DiskCleanAuditLog(directory: storage.url)
+        let baseTime = Date(timeIntervalSince1970: 4_000)
+
+        // The process can stop after item records have been appended, before the final summary.
+        log.append(
+            DiskCleanAuditLog.Record(
+                timestamp: baseTime,
+                action: .delete,
+                runID: "interrupted-run",
+                category: "appCaches",
+                path: "/cache/removed",
+                estimatedBytes: 1_024,
+                status: "ok"
+            )
+        )
+        log.append(
+            DiskCleanAuditLog.Record(
+                timestamp: baseTime.addingTimeInterval(1),
+                action: .delete,
+                runID: "interrupted-run",
+                category: "logs",
+                path: "/cache/blocked",
+                stagedName: ".mactools-staged-blocked",
+                estimatedBytes: 8_192,
+                status: "rollbackBlocked",
+                error: "Destination occupied"
+            )
+        )
+
+        // Item records with this run ID belong to this authoritative completed summary only.
+        log.append(
+            DiskCleanAuditLog.Record(
+                timestamp: baseTime.addingTimeInterval(2),
+                action: .trash,
+                runID: "completed-run",
+                path: "/cache/completed",
+                estimatedBytes: 4_096,
+                status: "ok"
+            )
+        )
+        log.append(
+            DiskCleanAuditLog.Record(
+                timestamp: baseTime.addingTimeInterval(3),
+                action: .runSummary,
+                runID: "completed-run",
+                status: "ok",
+                itemsRemoved: 1,
+                bytesRemoved: 4_096,
+                errorsEncountered: [],
+                isTrash: true
+            )
+        )
+
+        let runs = log.recentRuns(limit: 10)
+        XCTAssertEqual(runs.map(\.id), ["completed-run", "interrupted-run"])
+
+        let interrupted = try XCTUnwrap(runs.first { $0.id == "interrupted-run" })
+        XCTAssertEqual(interrupted.status, "interrupted")
+        XCTAssertFalse(interrupted.isTrash)
+        XCTAssertEqual(interrupted.categoriesCleaned, ["appCaches", "logs"])
+        XCTAssertEqual(interrupted.itemsRemoved, 1)
+        XCTAssertEqual(interrupted.bytesRemoved, 1_024)
+        XCTAssertEqual(interrupted.errorsEncountered, ["Destination occupied"])
+        XCTAssertTrue(interrupted.needsAttention)
+        XCTAssertEqual(interrupted.itemEntries.map(\.path), ["/cache/blocked", "/cache/removed"])
+    }
+
+    func testRecentRunsLegacyBytesIncludeOnlyVerifiedSuccesses() {
+        let log = DiskCleanAuditLog(directory: storage.url)
+        let timestamp = Date(timeIntervalSince1970: 5_000)
+
+        for (status, bytes) in [("ok", 1_024), ("failed", 2_048), ("skipped", 4_096), ("partiallyDeleted", 8_192)] {
+            log.append(
+                DiskCleanAuditLog.Record(
+                    timestamp: timestamp,
+                    action: .delete,
+                    path: "/cache/\(status)",
+                    estimatedBytes: Int64(bytes),
+                    status: status,
+                    error: status == "failed" ? "Permission denied" : nil
+                )
+            )
+        }
+
+        let run = log.recentRuns(limit: 1).first
+        XCTAssertEqual(run?.itemsRemoved, 1)
+        XCTAssertEqual(run?.bytesRemoved, 1_024)
     }
 
 }

--- a/Plugins/DiskClean/Tests/DiskCleanExecutorTests.swift
+++ b/Plugins/DiskClean/Tests/DiskCleanExecutorTests.swift
@@ -229,8 +229,9 @@ final class DiskCleanExecutorTests: XCTestCase {
         _ = try await executor.execute(plan: plan)
 
         let records = auditLog.recentRecords(limit: 10)
-        XCTAssertEqual(records.count, 2)
-        let byPath = Dictionary(uniqueKeysWithValues: records.map { ($0.path ?? "", $0) })
+        let itemRecords = records.filter { $0.action != .runSummary }
+        XCTAssertEqual(itemRecords.count, 2)
+        let byPath = Dictionary(uniqueKeysWithValues: itemRecords.map { ($0.path ?? "", $0) })
         XCTAssertEqual(byPath[paths[0]]?.status, "ok")
         XCTAssertEqual(byPath[paths[0]]?.action, .delete)
         XCTAssertEqual(byPath[paths[0]]?.estimatedBytes, 42)
@@ -254,7 +255,7 @@ final class DiskCleanExecutorTests: XCTestCase {
 
         _ = try await executor.execute(plan: plan)
 
-        let record = try XCTUnwrap(auditLog.recentRecords(limit: 1).first)
+        let record = try XCTUnwrap(auditLog.recentRecords(limit: 10).first { $0.action != .runSummary })
         XCTAssertEqual(record.status, "skipped")
         XCTAssertEqual(record.skipReason, "inUse(com.example.app)")
     }

--- a/Plugins/DiskClean/Tests/DiskCleanRuleCatalogV2Tests.swift
+++ b/Plugins/DiskClean/Tests/DiskCleanRuleCatalogV2Tests.swift
@@ -16,6 +16,12 @@ final class DiskCleanRuleCatalogV2Tests: XCTestCase {
         // two v1 package-manager dynamic rules not covered by other rules
         "~/.cache/go-build/*",
         "~/Library/Caches/mise/*",
+        // expanded standard developer caches
+        "~/Library/Caches/CocoaPods/*",
+        "~/Library/Caches/org.carthage.CarthageKit/*",
+        // expanded standard app log rotations
+        "~/Library/Logs/*/*.log.*",
+        "~/Library/Logs/*/*.old",
         // v1 `.serviceWorkerCache` fallback
         "~/Library/Application Support/Google/Chrome/*/Service Worker/CacheStorage/*/*",
         "~/Library/Application Support/Arc/*/Service Worker/CacheStorage/*/*",

--- a/Plugins/DiskClean/Tests/DiskCleanRuleExplainabilityTests.swift
+++ b/Plugins/DiskClean/Tests/DiskCleanRuleExplainabilityTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import XCTest
+import MacToolsPluginKit
+@testable import MacTools
+@testable import DiskCleanPlugin
+
+final class DiskCleanRuleExplainabilityTests: XCTestCase {
+    func testConfidenceCodableAndValues() throws {
+        for conf in [DiskCleanConfidence.high, .medium, .low] {
+            let encoded = try JSONEncoder().encode(conf)
+            let decoded = try JSONDecoder().decode(DiskCleanConfidence.self, from: encoded)
+            XCTAssertEqual(decoded, conf)
+        }
+        XCTAssertEqual(DiskCleanConfidence.high.rawValue, "high")
+        XCTAssertEqual(DiskCleanConfidence.medium.rawValue, "medium")
+        XCTAssertEqual(DiskCleanConfidence.low.rawValue, "low")
+    }
+
+    func testSafetyTierCodableAndTitles() throws {
+        let fakeLocalization = PluginLocalization(bundle: .main)
+
+        for tier in [DiskCleanSafetyTier.safe, .moderate, .sensitive] {
+            let encoded = try JSONEncoder().encode(tier)
+            let decoded = try JSONDecoder().decode(DiskCleanSafetyTier.self, from: encoded)
+            XCTAssertEqual(decoded, tier)
+            XCTAssertFalse(tier.title(localization: fakeLocalization).isEmpty)
+        }
+        XCTAssertEqual(DiskCleanSafetyTier.safe.rawValue, "safe")
+        XCTAssertEqual(DiskCleanSafetyTier.moderate.rawValue, "moderate")
+        XCTAssertEqual(DiskCleanSafetyTier.sensitive.rawValue, "sensitive")
+    }
+
+    func testDataClassCodable() throws {
+        let classes: [DiskCleanDataClass] = [
+            .cache, .log, .diagnostic, .downloadedResource,
+            .generatedDependency, .buildArtifact, .installer, .temporaryState
+        ]
+        for dataClass in classes {
+            let encoded = try JSONEncoder().encode(dataClass)
+            let decoded = try JSONDecoder().decode(DiskCleanDataClass.self, from: encoded)
+            XCTAssertEqual(decoded, dataClass)
+        }
+    }
+
+    func testRuleExplanationRoundTrip() throws {
+        let explanation = DiskCleanRuleExplanation(
+            whyMatched: "Matches Xcode DerivedData build intermediate files.",
+            consequence: "Xcode will rebuild indexing and module caches on next build.",
+            safetyTier: .safe,
+            requiresFullDiskAccess: false,
+            confidence: .high,
+            title: "DerivedData",
+            summary: "Xcode caches",
+            dataClass: .buildArtifact,
+            owner: "Xcode",
+            discoveryMethod: .knownPathPattern,
+            defaultSelectionReason: "Safe to clean",
+            regeneration: "Automatically regenerated during next compilation.",
+            provenance: .macOSDocumentedLocation
+        )
+
+        let encoded = try JSONEncoder().encode(explanation)
+        let decoded = try JSONDecoder().decode(DiskCleanRuleExplanation.self, from: encoded)
+
+        XCTAssertEqual(decoded.whyMatched, explanation.whyMatched)
+        XCTAssertEqual(decoded.consequence, explanation.consequence)
+        XCTAssertEqual(decoded.regeneration, explanation.regeneration)
+        XCTAssertEqual(decoded.safetyTier, .safe)
+        XCTAssertEqual(decoded.dataClass, .buildArtifact)
+        XCTAssertEqual(decoded.confidence, .high)
+        XCTAssertEqual(decoded.requiresFullDiskAccess, false)
+        XCTAssertEqual(decoded.provenance, .macOSDocumentedLocation)
+    }
+
+    func testResolvedExplanationUsesExplicitWhenAvailable() {
+        let explanation = DiskCleanRuleExplanation(
+            whyMatched: "Explicit reason",
+            consequence: "Explicit consequence",
+            safetyTier: .safe,
+            confidence: .high
+        )
+        let target = DiskCleanRuleTarget(
+            id: "test.target",
+            legacyRuleID: "cache.test",
+            category: .appCaches,
+            risk: .low,
+            kind: .path(globs: ["~/Library/Caches/Test/*"]),
+            reservedRootPaths: ["~/Library/Caches/Test"],
+            explanation: explanation
+        )
+
+        XCTAssertEqual(target.resolvedExplanation.whyMatched, "Explicit reason")
+        XCTAssertEqual(target.resolvedExplanation.consequence, "Explicit consequence")
+        XCTAssertEqual(target.resolvedExplanation.safetyTier, .safe)
+        XCTAssertEqual(target.resolvedExplanation.confidence, .high)
+    }
+
+    func testResolvedExplanationGeneratesFallbackWhenNil() {
+        let lowTarget = DiskCleanRuleTarget(
+            id: "test.low",
+            legacyRuleID: "cache.test",
+            category: .appCaches,
+            risk: .low,
+            kind: .path(globs: ["~/Library/Caches/Test/*"]),
+            reservedRootPaths: ["~/Library/Caches/Test"]
+        )
+        XCTAssertEqual(lowTarget.resolvedExplanation.safetyTier, .safe)
+        XCTAssertFalse(lowTarget.resolvedExplanation.whyMatched.isEmpty)
+        XCTAssertFalse(lowTarget.resolvedExplanation.consequence.isEmpty)
+
+        let mediumTarget = DiskCleanRuleTarget(
+            id: "test.medium",
+            legacyRuleID: "developer.test",
+            category: .developer,
+            risk: .medium,
+            kind: .path(globs: ["~/Test/*"]),
+            reservedRootPaths: ["~/Test"]
+        )
+        XCTAssertEqual(mediumTarget.resolvedExplanation.safetyTier, .moderate)
+
+        let highTarget = DiskCleanRuleTarget(
+            id: "test.high",
+            legacyRuleID: "system.test",
+            category: .logs,
+            risk: .high,
+            kind: .path(globs: ["/var/log/test/*"]),
+            reservedRootPaths: ["/var/log/test"]
+        )
+        XCTAssertEqual(highTarget.resolvedExplanation.safetyTier, .sensitive)
+    }
+
+    func testCandidateCarriesExplanation() {
+        let explanation = DiskCleanRuleExplanation(
+            whyMatched: "CocoaPods cache files",
+            consequence: "CocoaPods will redownload pods when needed",
+            safetyTier: .safe,
+            confidence: .high
+        )
+        let candidate = DiskCleanCandidate(
+            id: "cocoapods-1",
+            targetID: "developer.mobile-caches",
+            legacyRuleID: "developer.mobile-caches",
+            category: .developer,
+            path: "/Users/tester/Library/Caches/CocoaPods/Pods",
+            risk: .low,
+            safety: .allowed,
+            explanation: explanation
+        )
+
+        XCTAssertEqual(candidate.explanation?.whyMatched, "CocoaPods cache files")
+        XCTAssertEqual(candidate.explanation?.consequence, "CocoaPods will redownload pods when needed")
+        XCTAssertEqual(candidate.explanation?.safetyTier, .safe)
+        XCTAssertEqual(candidate.explanation?.confidence, .high)
+    }
+}

--- a/Plugins/DiskClean/Tests/DiskCleanSafetyPolicyTests.swift
+++ b/Plugins/DiskClean/Tests/DiskCleanSafetyPolicyTests.swift
@@ -135,4 +135,26 @@ final class DiskCleanSafetyPolicyTests: XCTestCase {
         }
         XCTFail("Expected protected status, got \(status). \(message)", file: file, line: line)
     }
+
+    func testExpandedCocoaPodsCarthageAndRotatedLogPathsAreAllowed() {
+        let policy = DiskCleanSafetyPolicy(homeDirectory: home)
+
+        XCTAssertEqual(
+            policy.safetyStatus(for: "\(home)/Library/Caches/CocoaPods/Pods/Release/AFNetworking"),
+            .allowed
+        )
+        XCTAssertEqual(
+            policy.safetyStatus(for: "\(home)/Library/Caches/org.carthage.CarthageKit/dependencies/Alamofire"),
+            .allowed
+        )
+        XCTAssertEqual(
+            policy.safetyStatus(for: "\(home)/Library/Logs/MyApp/app.log.2026-09-06"),
+            .allowed
+        )
+        XCTAssertEqual(
+            policy.safetyStatus(for: "\(home)/Library/Logs/MyApp/system.old"),
+            .allowed
+        )
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | System Mute | Mute or restore system audio output through CoreAudio on the default output device, with automatic restoration when the plugin is disabled. |
 | Microphone Mute | Mute or restore the default microphone input through CoreAudio without requesting recording permission. |
 | App Volume | On macOS 15 and later, adjust the volume of each app currently playing audio and keep preferences locally per app; first use requires System Audio Recording permission. |
-| Disk Cleanup | Scan system caches, developer artifacts (node_modules, build outputs), and leftover installers; move to Trash by default, with path safety checks, Full Disk Access guidance, and sensitive-data protection before deletion. |
+| Disk Cleanup | Scan system caches, developer artifacts (node_modules, build outputs), and leftover installers; move to Trash by default, with path safety checks, Full Disk Access guidance, sensitive-data protection before deletion, and interruption-aware cleanup history with totals based on successful removals. |
 | Xcode Cleanup | Scan DerivedData, device support files, archives, simulators, and preview caches by category; deletion is disabled while Xcode is running and only runs inside allowlisted roots. |
 | Eject Disks | Detect visible ejectable mounts when the panel opens, including external drives, disk images, and network volumes; multiple volumes on one device are ejected once. |
 | Empty Trash | Show the number of Trash items and empty Trash through Finder; the action is disabled when Trash is empty. |

--- a/changes/unreleased/disk-clean-explainability-history.md
+++ b/changes/unreleased/disk-clean-explainability-history.md
@@ -4,4 +4,4 @@ type: added
 area: System
 ---
 
-Added structured rule explainability and consequence disclosures, expanded safe CocoaPods, Carthage, and rotated log coverage, and introduced run-level audit history grouping with home path redaction.
+Added clearer cleanup rules, expanded safe CocoaPods, Carthage, and rotated-log coverage, and introduced interruption-aware run history with totals based on successful removals.

--- a/changes/unreleased/disk-clean-explainability-history.md
+++ b/changes/unreleased/disk-clean-explainability-history.md
@@ -1,0 +1,7 @@
+---
+release: plugin
+type: added
+area: System
+---
+
+Added structured rule explainability and consequence disclosures, expanded safe CocoaPods, Carthage, and rotated log coverage, and introduced run-level audit history grouping with home path redaction.

--- a/changes/unreleased/disk-clean-explainability-history.md
+++ b/changes/unreleased/disk-clean-explainability-history.md
@@ -4,4 +4,4 @@ type: added
 area: System
 ---
 
-Added clearer cleanup rules, expanded safe CocoaPods, Carthage, and rotated-log coverage, and introduced interruption-aware run history with totals based on successful removals.
+Added clearer cleanup rules, expanded safe CocoaPods, Carthage, and rotated-log coverage, and introduced responsive, interruption-aware run history with totals based on successful removals.


### PR DESCRIPTION
Disk Cleanup now shows rule details and deletion consequences alongside candidates, and groups cleanup history by run while retaining item details and recovery records.

- Add CocoaPods and Carthage cache paths and rotated application log patterns, using the existing planner and execution-time safety checks.
- Show cancelled and interrupted runs explicitly, keep recovery items visible, and derive estimated cleanup totals from successful removals.
- Use low, medium, and high risk labels; provide explanations, history controls, and diagnostics feedback in all 11 supported languages.

Related to #347. This is a partial implementation: three targets have specific explanations, while the others use generic fallbacks. Richer rule-specific explanations and the remaining scan-coverage and review work stay tracked in that issue.

Validation: 16 focused explanation/history XCTest tests passed after the final changes. All 11 localized string catalogs compiled successfully; translation coverage, format placeholders, changelog validation, and whitespace checks passed. No full app test run or cleanup of user files was performed for this update.
