### PR TITLE
Fix stale Clipboard History loading state

### DIFF
--- a/Plugins/ClipboardHistory/Sources/ClipboardHistoryController.swift
+++ b/Plugins/ClipboardHistory/Sources/ClipboardHistoryController.swift
@@ -669,6 +669,13 @@ final class ClipboardHistoryController: NSObject, ObservableObject {
     /// the persistence barrier, but must not dim every control while it commits.
     var isClearingHistory: Bool { itemMutation == .content }
 
+    var isClearingHistoryPublisher: AnyPublisher<Bool, Never> {
+        $itemMutation
+            .map { $0 == .content }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
     private var isMutatingItems: Bool { itemMutation != nil }
 
     var onChange: (() -> Void)?

--- a/Plugins/ClipboardHistory/Sources/ClipboardHistoryPanel.swift
+++ b/Plugins/ClipboardHistory/Sources/ClipboardHistoryPanel.swift
@@ -1165,14 +1165,17 @@ final class ClipboardHistoryPanelModel: ObservableObject {
         historyController: ClipboardHistoryController,
         savedLibraryController: ClipboardSavedLibraryController
     ) {
-        let status = RuntimeStatus(
+        updateRuntimeStatus(RuntimeStatus(
             historyErrorMessage: historyController.errorMessage,
             isHistoryLoaded: historyController.isLoaded,
             isClearingHistory: historyController.isClearingHistory,
             savedErrorMessage: savedLibraryController.errorMessage,
             savedFatalErrorMessage: savedLibraryController.fatalErrorMessage,
             isSavedLibraryLoaded: savedLibraryController.isLoaded
-        )
+        ))
+    }
+
+    func updateRuntimeStatus(_ status: RuntimeStatus) {
         if runtimeStatus != status { runtimeStatus = status }
     }
 
@@ -2084,6 +2087,29 @@ final class ClipboardHistoryPanelController: NSObject, NSWindowDelegate {
         savedLibraryController.itemUpdates.sink { [weak self] update in
             self?.model.updateSavedItems(update.items, revision: update.revision)
         }.store(in: &itemSubscriptions)
+        let historyStatus = Publishers.CombineLatest3(
+            historyController.$errorMessage,
+            historyController.$isLoaded,
+            historyController.isClearingHistoryPublisher
+        )
+        let savedStatus = Publishers.CombineLatest3(
+            savedLibraryController.$errorMessage,
+            savedLibraryController.$fatalErrorMessage,
+            savedLibraryController.$isLoaded
+        )
+        historyStatus
+            .combineLatest(savedStatus)
+            .sink { [weak self] history, saved in
+                self?.model.updateRuntimeStatus(.init(
+                    historyErrorMessage: history.0,
+                    isHistoryLoaded: history.1,
+                    isClearingHistory: history.2,
+                    savedErrorMessage: saved.0,
+                    savedFatalErrorMessage: saved.1,
+                    isSavedLibraryLoaded: saved.2
+                ))
+            }
+            .store(in: &itemSubscriptions)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(applicationDidResignActive),
@@ -2158,6 +2184,10 @@ final class ClipboardHistoryPanelController: NSObject, NSWindowDelegate {
         let panel = panel ?? makePanel()
         self.panel = panel
         model.activatePreviewPresentation()
+        model.updateRuntimeStatus(
+            historyController: historyController,
+            savedLibraryController: savedLibraryController
+        )
         previousApplicationState.beginPresentation(
             frontmostApplication: NSWorkspace.shared.frontmostApplication,
             isExternal: { $0.processIdentifier != ProcessInfo.processInfo.processIdentifier }
@@ -3680,34 +3710,12 @@ private struct ClipboardHistoryPanelView: View {
             .allowsHitTesting(false)
         }
         .onAppear {
-            model.updateRuntimeStatus(
-                historyController: controller,
-                savedLibraryController: savedLibraryController
-            )
             model.updateItems(controller.items, revision: controller.presentationRevision)
             model.updateSavedItems(
                 savedLibraryController.items,
                 revision: savedLibraryController.presentationRevision
             )
             repairSelection()
-        }
-        .onReceive(controller.objectWillChange) { _ in
-            Task { @MainActor in
-                await Task.yield()
-                model.updateRuntimeStatus(
-                    historyController: controller,
-                    savedLibraryController: savedLibraryController
-                )
-            }
-        }
-        .onReceive(savedLibraryController.objectWillChange) { _ in
-            Task { @MainActor in
-                await Task.yield()
-                model.updateRuntimeStatus(
-                    historyController: controller,
-                    savedLibraryController: savedLibraryController
-                )
-            }
         }
         .onChange(of: model.selectionLimitReachedRevision) { _, _ in
             let message = localization.format(

--- a/Plugins/ClipboardHistory/Tests/ClipboardPanelUpdatePerformanceTests.swift
+++ b/Plugins/ClipboardHistory/Tests/ClipboardPanelUpdatePerformanceTests.swift
@@ -4,6 +4,22 @@ import XCTest
 
 @MainActor
 final class ClipboardPanelUpdatePerformanceTests: XCTestCase {
+    func testRuntimeStatusCanLeaveLoadingWithoutPanelAppearance() {
+        let model = ClipboardHistoryPanelModel()
+
+        model.updateRuntimeStatus(.init(
+            historyErrorMessage: nil,
+            isHistoryLoaded: true,
+            isClearingHistory: false,
+            savedErrorMessage: nil,
+            savedFatalErrorMessage: nil,
+            isSavedLibraryLoaded: true
+        ))
+
+        XCTAssertTrue(model.runtimeStatus.isHistoryLoaded)
+        XCTAssertTrue(model.runtimeStatus.isSavedLibraryLoaded)
+    }
+
     func testUsageAndBookmarkPatchVisibleRowWithoutSearchOrSelectionChanges() async {
         var items = makeItems(80)
         let model = ClipboardHistoryPanelModel()

--- a/changes/unreleased/clipboard-history-loading-state.md
+++ b/changes/unreleased/clipboard-history-loading-state.md
@@ -1,0 +1,6 @@
+---
+release: plugin
+type: fixed
+---
+
+Keep the Clipboard History window in sync with encrypted storage readiness when reopening it.


### PR DESCRIPTION
## Summary

- keep the Clipboard History panel's cached runtime status synchronized directly from storage controllers
- refresh storage readiness whenever the reusable panel is shown
- remove lifecycle-dependent `onAppear` and `objectWillChange` status propagation
- add regression coverage for leaving the loading state without a panel appearance callback

## Root cause

The reusable Clipboard History panel cached its initial `.loading` status in `ClipboardHistoryPanelModel`. Status updates were forwarded by SwiftUI appearance and `objectWillChange` callbacks. When the hidden `NSPanel` was reused, `onAppear` was not guaranteed to run again, and the pre-change notification plus deferred read could miss the completed load transition. The history controller had already loaded and resumed pasteboard polling while the panel continued to display “Loading encrypted history…”.

The panel controller now owns this synchronization. It combines the concrete published storage-state values and also takes a current snapshot before every presentation.

## Validation

- `ClipboardPanelUpdatePerformanceTests`: 20 tests passed
- focused runtime-status regression test passed after the final publisher refactor
- combined local app rebuilt, installed, and launched with the updated Clipboard History plugin
