### PR TITLE
fix(search): keep command palette query synchronized

### DIFF
--- a/Sources/App/UnifiedSearchPaletteView.swift
+++ b/Sources/App/UnifiedSearchPaletteView.swift
@@ -78,13 +78,13 @@ enum UnifiedSearchSelectionPolicy {
 
 @MainActor
 final class UnifiedSearchPaletteModel: ObservableObject {
+    @Published private(set) var query = ""
     @Published private(set) var results: [MacToolsSearchResult]
     @Published private(set) var sections: [MacToolsSearchSection]
 
     private let commandContext: AppHostCommandContext
     private let recentStore: CommandPaletteRecentStore
     private var index: MacToolsSearchIndex
-    private var query = ""
     private var stateCancellables: Set<AnyCancellable> = []
     private var rebuildTask: Task<Void, Never>?
 
@@ -120,6 +120,22 @@ final class UnifiedSearchPaletteModel: ObservableObject {
 
         self.query = query
         updateResults()
+    }
+
+    func queryBinding(
+        onChange: @escaping (_ oldQuery: String, _ newQuery: String) -> Void = { _, _ in }
+    ) -> Binding<String> {
+        Binding(
+            get: { [weak self] in
+                self?.query ?? ""
+            },
+            set: { [weak self] newQuery in
+                guard let self, query != newQuery else { return }
+                let oldQuery = query
+                updateQuery(newQuery)
+                onChange(oldQuery, newQuery)
+            }
+        )
     }
 
     func refresh() {
@@ -350,7 +366,6 @@ struct UnifiedSearchPaletteView: View {
     let actions: UnifiedSearchPaletteActions
     @Environment(\.accessibilityReduceTransparency) private var accessibilityReduceTransparency
     @StateObject private var model: UnifiedSearchPaletteModel
-    @State private var query = ""
     @State private var selectedResultID: String?
     @State private var pendingAlert: PendingAlert?
     @State private var executionFeedback: String?
@@ -429,16 +444,6 @@ struct UnifiedSearchPaletteView: View {
             syncSelection()
             handleQuickSelectionRequest(quickSelectionRequest)
         }
-        .onChange(of: query) { oldQuery, newQuery in
-            executionFeedback = nil
-            model.updateQuery(newQuery)
-            syncSelection(
-                resetToFirst: UnifiedSearchSelectionPolicy.shouldResetForQueryChange(
-                    from: oldQuery,
-                    to: newQuery
-                )
-            )
-        }
         .onChange(of: resultIDs) {
             syncSelection()
         }
@@ -501,7 +506,15 @@ struct UnifiedSearchPaletteView: View {
 
     private var searchField: some View {
         PluginPaletteSearchToolbar(
-            text: $query,
+            text: model.queryBinding { oldQuery, newQuery in
+                executionFeedback = nil
+                syncSelection(
+                    resetToFirst: UnifiedSearchSelectionPolicy.shouldResetForQueryChange(
+                        from: oldQuery,
+                        to: newQuery
+                    )
+                )
+            },
             placeholder: AppL10n.search(
                 "search.prompt",
                 defaultValue: "搜索插件、设置和命令"
@@ -541,7 +554,7 @@ struct UnifiedSearchPaletteView: View {
             }
             .accessibilityElement(children: .combine)
 
-            if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if model.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 recentActionsMenu
             }
         }
@@ -1244,7 +1257,6 @@ struct UnifiedSearchPaletteView: View {
 
     private func resetTransientState() {
         invalidateExecution()
-        query = ""
         pendingAlert = nil
         executionFeedback = nil
         model.updateQuery("")

--- a/Tests/App/MacToolsSearchTests.swift
+++ b/Tests/App/MacToolsSearchTests.swift
@@ -286,6 +286,44 @@ final class MacToolsSearchTests: XCTestCase {
         })
     }
 
+    func testModelQueryBindingKeepsCanonicalQueryAndResultsInSync() {
+        let suiteName = "MacToolsSearchQueryBindingTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let model = UnifiedSearchPaletteModel(
+            commandContext: AppHostCommandContext(
+                pluginHost: makePluginHostForTests(plugins: [SearchableTestPlugin()]),
+                launchAtLoginController: LaunchAtLoginController(
+                    service: SearchTestLaunchAtLoginService()
+                ),
+                appearanceUserDefaults: defaults
+            ),
+            recentStore: CommandPaletteRecentStore(userDefaults: defaults)
+        )
+        var transitions: [(String, String)] = []
+        let binding = model.queryBinding { oldQuery, newQuery in
+            transitions.append((oldQuery, newQuery))
+        }
+
+        binding.wrappedValue = "快捷键目标"
+
+        XCTAssertEqual(model.query, "快捷键目标")
+        XCTAssertEqual(model.sections.map(\.kind), [.results])
+        XCTAssertEqual(model.results.map(\.title), ["快捷键目标"])
+        XCTAssertEqual(transitions.count, 1)
+        XCTAssertEqual(transitions.first?.0, "")
+        XCTAssertEqual(transitions.first?.1, "快捷键目标")
+
+        binding.wrappedValue = "快捷键目标"
+        XCTAssertEqual(transitions.count, 1)
+
+        binding.wrappedValue = ""
+        XCTAssertEqual(model.query, "")
+        XCTAssertFalse(model.sections.contains { $0.kind == .results })
+        XCTAssertEqual(transitions.count, 2)
+    }
+
     func testModelAutomaticallyRebuildsAfterLaunchAtLoginChanges() async {
         let suiteName = "MacToolsSearchLaunchModelTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/changes/unreleased/command-palette-query-sync.md
+++ b/changes/unreleased/command-palette-query-sync.md
@@ -1,0 +1,7 @@
+---
+release: app
+type: fixed
+area: Search
+---
+
+Kept Command Palette results synchronized with the visible search text after reopening and reusing the palette.


### PR DESCRIPTION
## Summary
- make the command-palette model the single source of truth for its query
- update filtering and selection synchronously through the field binding
- remove the lifecycle-sensitive duplicate SwiftUI query state
- add regression coverage for query/result synchronization

## Root cause
The reusable AppKit command-palette panel could leave the visible search field and SwiftUI binding updated while `UnifiedSearchPaletteModel` retained the previous query because model synchronization depended on `.onChange(of:)`.

## Testing
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project MacTools.xcodeproj -scheme MacTools -configuration Debug -derivedDataPath build/DerivedData test -quiet -only-testing:MacToolsTests/MacToolsSearchTests`