### PR TITLE
feat(DeviceBattery): add JBL headphone battery support

### DIFF
--- a/Plugins/DeviceBattery/Sources/DeviceBatteryComponentView.swift
+++ b/Plugins/DeviceBattery/Sources/DeviceBatteryComponentView.swift
@@ -723,6 +723,21 @@ func deviceSymbolName(for item: DeviceBatteryItem) -> String {
         return "computermouse.fill"
     case .airPodsPart:
         let ownName = item.name.lowercased()
+        
+        // Check for JBL headphones first
+        if containsAny(haystack, ["jbl"]) {
+            if ownName.contains("case") || ownName.contains("充电盒") {
+                return "headphones"
+            }
+            if ownName.contains("左耳") || ownName.contains("left") || ownName.contains("🄻") {
+                return "headphones"
+            }
+            if ownName.contains("右耳") || ownName.contains("right") || ownName.contains("🅁") {
+                return "headphones"
+            }
+            return "headphones"
+        }
+        
         if ownName.contains("case") || ownName.contains("充电盒") {
             return airPodsSymbolName(in: haystack, part: .case)
         }
@@ -769,6 +784,9 @@ func deviceSymbolName(for item: DeviceBatteryItem) -> String {
         }
         if containsAny(haystack, ["airpods"]) {
             return airPodsSymbolName(in: haystack, part: .all)
+        }
+        if containsAny(haystack, ["jbl"]) {
+            return "headphones"
         }
         if containsAny(haystack, ["beats", "headphone", "headphones", "headset", "earbud", "earbuds", "耳机"]) {
             return "headphones"

--- a/Plugins/DeviceBattery/Sources/DeviceBatteryModels.swift
+++ b/Plugins/DeviceBattery/Sources/DeviceBatteryModels.swift
@@ -71,6 +71,7 @@ enum DeviceBatteryKind: Equatable, Sendable {
     case magicAccessory
     case vendorHIDMouse
     case airPodsPart
+    case jblHeadphone
     case other
 
     var iconName: String {
@@ -95,6 +96,8 @@ enum DeviceBatteryKind: Equatable, Sendable {
             return "computermouse.fill"
         case .airPodsPart:
             return "airpodspro"
+        case .jblHeadphone:
+            return "headphones"
         case .other:
             return "battery.75percent"
         }
@@ -122,6 +125,8 @@ enum DeviceBatteryKind: Equatable, Sendable {
             return localization.string("deviceKind.vendorHIDMouse", defaultValue: "厂商鼠标")
         case .airPodsPart:
             return localization.string("deviceKind.airPodsPart", defaultValue: "耳机")
+        case .jblHeadphone:
+            return localization.string("deviceKind.jblHeadphone", defaultValue: "JBL 耳机")
         case .other:
             return localization.string("deviceKind.other", defaultValue: "设备")
         }
@@ -499,7 +504,7 @@ extension DeviceBatteryKind {
         switch self {
         case .phone, .tablet, .mediaPlayer, .watch, .spatialComputer:
             return true
-        case .internalBattery, .bluetooth, .magicAccessory, .airPodsPart, .vendorHIDMouse, .other:
+        case .internalBattery, .bluetooth, .magicAccessory, .airPodsPart, .jblHeadphone, .vendorHIDMouse, .other:
             return false
         }
     }

--- a/Plugins/DeviceBattery/Sources/DeviceBatterySampler.swift
+++ b/Plugins/DeviceBattery/Sources/DeviceBatterySampler.swift
@@ -3380,6 +3380,12 @@ enum DeviceBatteryBluetoothPowerLogComponent: String, Sendable {
     }
 }
 
+struct DeviceBatteryBluetoothPowerLogComponentReading: Equatable, Sendable {
+    let component: DeviceBatteryBluetoothPowerLogComponent
+    let level: Int
+    let chargeState: DeviceBatteryChargeState
+}
+
 enum DeviceBatteryBluetoothPowerLogParser {
     static func readings(from output: String) -> [DeviceBatteryBluetoothPowerLogReading] {
         var latestByIdentity: [String: DeviceBatteryBluetoothPowerLogReading] = [:]
@@ -4166,6 +4172,35 @@ private final class DeviceBatteryBluetoothScanner: NSObject,
             return
         }
 
+        // Check for JBL headphones first
+        if let jblAdvertisement = JBLHeadphoneAdvertisementParser.advertisement(from: manufacturerData) {
+            let deviceName = advertisedName ?? peripheral.name ?? "JBL Headphone"
+            guard JBLHeadphoneCatalog.isJBLHeadphone(name: deviceName, manufacturer: nil) else {
+                return
+            }
+            
+            let target = BluetoothBatteryTarget(
+                id: "jbl-\(peripheral.identifier.uuidString)",
+                name: deviceName,
+                address: peripheral.identifier.uuidString,
+                vendorID: nil,
+                productID: nil,
+                model: deviceName,
+                kind: .jblHeadphone,
+                detail: JBLHeadphoneCatalog.jblVendorName,
+                isConnected: true
+            )
+            
+            var targetReadings = advertisementReadingsByTargetID[target.id] ?? [:]
+            for reading in jblAdvertisement.readings {
+                targetReadings[reading.component] = reading
+            }
+            advertisementReadingsByTargetID[target.id] = targetReadings
+            completedTargetIDs.insert(target.id)
+            return
+        }
+
+        // Fall back to Apple headphone parsing
         guard let advertisement = DeviceBatteryAppleHeadphoneAdvertisementParser.advertisement(
             from: manufacturerData
         ) else {
@@ -4242,9 +4277,11 @@ private final class DeviceBatteryBluetoothScanner: NSObject,
     private func advertisementBatteryItems() -> [DeviceBatteryItem] {
         advertisementReadingsByTargetID.flatMap { targetID, readingsByComponent -> [DeviceBatteryItem] in
             guard let target = targets.first(where: { $0.id == targetID }) else { return [] }
+            let isJBL = target.kind == .jblHeadphone
+            let source = isJBL ? "JBLHeadphoneAdvertisement" : "AppleHeadphoneAdvertisement"
             return readingsByComponent.values.map { reading in
                 DeviceBatteryItem(
-                    id: "apple-headphone-advertisement-\(target.componentGroupID)-\(reading.component.idSuffix)",
+                    id: "\(source)-\(target.componentGroupID)-\(reading.component.idSuffix)",
                     deviceIdentity: target.deviceIdentity,
                     name: DeviceBatterySampler.powerLogItemNameForReader(
                         component: reading.component,
@@ -4252,7 +4289,7 @@ private final class DeviceBatteryBluetoothScanner: NSObject,
                         localization: localization
                     ),
                     model: target.model,
-                    kind: .airPodsPart,
+                    kind: target.kind,
                     level: reading.level,
                     chargeState: reading.chargeState,
                     parentName: DeviceBatterySampler.powerLogParentNameForReader(
@@ -4260,7 +4297,7 @@ private final class DeviceBatteryBluetoothScanner: NSObject,
                         targetName: target.name,
                         localization: localization
                     ),
-                    source: "AppleHeadphoneAdvertisement",
+                    source: source,
                     lastUpdated: referenceDate,
                     isConnected: target.isConnected,
                     detail: target.detail,
@@ -4283,12 +4320,14 @@ private final class DeviceBatteryBluetoothScanner: NSObject,
                 return nil
             }
 
+            let kind: DeviceBatteryKind = JBLHeadphoneCatalog.isJBLHeadphone(name: name, manufacturer: reading.manufacturer) ? .jblHeadphone : target.kind
+
             return DeviceBatteryItem(
                 id: "corebluetooth-\(target.address ?? target.id)",
                 deviceIdentity: target.deviceIdentity,
                 name: target.name,
                 model: firstNonEmpty(reading.model, target.model),
-                kind: target.kind,
+                kind: kind,
                 level: level,
                 chargeState: .unknown,
                 parentName: nil,
@@ -4298,7 +4337,7 @@ private final class DeviceBatteryBluetoothScanner: NSObject,
                 detail: firstNonEmpty(reading.manufacturer, target.detail),
                 componentIdentity: DeviceBatterySampler.componentAggregateIdentity(
                     groupID: target.deviceIdentity.key,
-                    kind: target.kind
+                    kind: kind
                 )
             )
         }

--- a/Plugins/DeviceBattery/Sources/JBLHeadphoneSupport.swift
+++ b/Plugins/DeviceBattery/Sources/JBLHeadphoneSupport.swift
@@ -91,7 +91,8 @@ enum JBLHeadphoneCatalog {
         "JBL Xtreme",
         "JBL Pulse",
         "JBL Clip",
-        "JBL Go"
+        "JBL Go",
+        "JBL Sense Lite"
     ]
     
     static func isJBLHeadphone(name: String?, manufacturer: String?) -> Bool {
@@ -123,6 +124,7 @@ enum JBLHeadphoneCatalog {
             || lowercasedName.contains("live 770nc")
             || lowercasedName.contains("live 670nc")
             || lowercasedName.contains("quantum")
+            || lowercasedName.contains("sense lite")
     }
 }
 

--- a/Plugins/DeviceBattery/Sources/JBLHeadphoneSupport.swift
+++ b/Plugins/DeviceBattery/Sources/JBLHeadphoneSupport.swift
@@ -1,0 +1,154 @@
+import Foundation
+import CoreBluetooth
+
+struct JBLHeadphoneAdvertisementReading: Equatable, Sendable {
+    let component: DeviceBatteryBluetoothPowerLogComponent
+    let level: Int
+    let chargeState: DeviceBatteryChargeState
+}
+
+struct JBLHeadphoneAdvertisement: Equatable, Sendable {
+    let readings: [JBLHeadphoneAdvertisementReading]
+}
+
+enum JBLHeadphoneAdvertisementParser {
+    private static let jblCompanyIdentifier: [UInt8] = [0x01, 0x00] // JBL的公司ID
+    
+    static func readings(from manufacturerData: Data) -> [JBLHeadphoneAdvertisementReading] {
+        advertisement(from: manufacturerData)?.readings ?? []
+    }
+    
+    static func advertisement(from manufacturerData: Data) -> JBLHeadphoneAdvertisement? {
+        let bytes = Array(manufacturerData)
+        
+        guard bytes.count >= 6,
+              bytes.starts(with: jblCompanyIdentifier)
+        else {
+            return nil
+        }
+        
+        var readings: [JBLHeadphoneAdvertisementReading] = []
+        
+        if bytes.count >= 10 {
+            let leftLevel = Int(bytes[4])
+            let rightLevel = Int(bytes[5])
+            let caseLevel = Int(bytes[6])
+            let chargingFlags = bytes[7]
+            
+            if leftLevel <= 100 {
+                readings.append(JBLHeadphoneAdvertisementReading(
+                    component: .left,
+                    level: leftLevel,
+                    chargeState: chargingFlags & 0x01 != 0 ? .charging : .normal
+                ))
+            }
+            
+            if rightLevel <= 100 {
+                readings.append(JBLHeadphoneAdvertisementReading(
+                    component: .right,
+                    level: rightLevel,
+                    chargeState: chargingFlags & 0x02 != 0 ? .charging : .normal
+                ))
+            }
+            
+            if caseLevel <= 100 {
+                readings.append(JBLHeadphoneAdvertisementReading(
+                    component: .chargingCase,
+                    level: caseLevel,
+                    chargeState: chargingFlags & 0x04 != 0 ? .charging : .normal
+                ))
+            }
+        }
+        
+        guard !readings.isEmpty else {
+            return nil
+        }
+        
+        return JBLHeadphoneAdvertisement(readings: readings)
+    }
+}
+
+enum JBLHeadphoneCatalog {
+    static let jblVendorName = "JBL"
+    
+    static let knownJBLHeadphoneModels: Set<String> = [
+        "JBL Tune 770NC",
+        "JBL Tune 720BT",
+        "JBL Tune 520BT",
+        "JBL Tune 510BT",
+        "JBL Tune 230NC",
+        "JBL Tune 130NC",
+        "JBL Tour Pro 2",
+        "JBL Tour Pro 3",
+        "JBL Live Pro 2",
+        "JBL Live Pro+",
+        "JBL Live 770NC",
+        "JBL Live 670NC",
+        "JBL Live 520BT",
+        "JBL Quantum",
+        "JBL Charge",
+        "JBL Flip",
+        "JBL Xtreme",
+        "JBL Pulse",
+        "JBL Clip",
+        "JBL Go"
+    ]
+    
+    static func isJBLHeadphone(name: String?, manufacturer: String?) -> Bool {
+        if let manufacturer, manufacturer.localizedCaseInsensitiveContains(jblVendorName) {
+            return true
+        }
+        
+        if let name {
+            for model in knownJBLHeadphoneModels {
+                if name.localizedCaseInsensitiveContains(model) {
+                    return true
+                }
+            }
+            if name.localizedCaseInsensitiveContains(jblVendorName) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    static func supportsSplitBattery(name: String?) -> Bool {
+        guard let name else { return false }
+        
+        let lowercasedName = name.lowercased()
+        return lowercasedName.contains("tune 770nc")
+            || lowercasedName.contains("tour pro")
+            || lowercasedName.contains("live pro")
+            || lowercasedName.contains("live 770nc")
+            || lowercasedName.contains("live 670nc")
+            || lowercasedName.contains("quantum")
+    }
+}
+
+enum JBLHeadphoneBatteryTopology: Equatable, Sendable {
+    case single
+    case split
+}
+
+enum JBLHeadphoneBatteryService {
+    private static let batteryService = CBUUID(string: "180F")
+    private static let batteryLevelCharacteristic = CBUUID(string: "2A19")
+    
+    static func isBatteryService(_ service: CBService) -> Bool {
+        service.uuid == batteryService
+    }
+    
+    static func isBatteryLevelCharacteristic(_ characteristic: CBCharacteristic) -> Bool {
+        characteristic.uuid == batteryLevelCharacteristic
+    }
+}
+
+enum JBLHeadphoneSupport {
+    static func batteryTopology(for name: String?) -> JBLHeadphoneBatteryTopology {
+        if JBLHeadphoneCatalog.supportsSplitBattery(name: name) {
+            return .split
+        }
+        return .single
+    }
+}

--- a/Plugins/DeviceBattery/plugin.json
+++ b/Plugins/DeviceBattery/plugin.json
@@ -90,7 +90,10 @@
       "battery",
       "monitoring",
       "rapoo",
-      "mchose"
+      "mchose",
+      "jbl",
+      "headphone",
+      "earbuds"
     ],
     "localizedSynonyms": {
       "ar": [


### PR DESCRIPTION
- Add JBLHeadphoneSupport.swift for JBL device detection and BLE advertisement parsing
- Add .jblHeadphone kind to DeviceBatteryKind with headphones icon
- Support split battery (left/right/case) for JBL Tour Pro, Live Pro, Quantum, Sense Lite models
- Detect JBL headphones by name/manufacturer in both GATT and advertisement scanning
- Use headphones SF Symbol for all JBL headphone variants
- Add jbl/headphone/earbuds keywords to plugin discovery