### PR TITLE
docs(cli): propose optional stable distribution and record signed validation

### DIFF
--- a/docs/cli/proposals/stable-cli-v1.md
+++ b/docs/cli/proposals/stable-cli-v1.md
@@ -1,0 +1,83 @@
+# Proposal: an optional stable MacTools CLI v1
+
+Status: draft for maintainer discussion; stable publication is not enabled. See the [signed Nightly acceptance report](../validation/2026-09-10-nightly-signed-acceptance.md) for completed checks and remaining gaps.
+
+Proposal discussion: [#417](https://github.com/ggbond268/MacTools/issues/417).
+
+Related work: [RFC #309](https://github.com/ggbond268/MacTools/issues/309), [managed installation #403](https://github.com/ggbond268/MacTools/issues/403), and [merged implementation #409](https://github.com/ggbond268/MacTools/pull/409).
+
+## Decision requested
+
+Offer the existing, limited CLI to regular MacTools users once signed Nightly acceptance is complete. Keep it optional and separately downloaded. Users who do not install it should receive neither a CLI download nor an automatically enabled integration service.
+
+A small stable command surface is useful for scripts, launchers, diagnostics, and local agents. Stable support should commit to predictable installation, documented machine-readable behavior, and compatible upgrades. It should not depend on implementing the entire RFC first.
+
+## User experience
+
+1. Install the regular MacTools app.
+2. Choose **Settings → General → Command Line → Install CLI**.
+3. Confirm the matching download, managed paths, included automatic updates, and whether integration should be enabled.
+4. Use `mactools` from Terminal, or copy its absolute path if the user's PATH does not include the command directory.
+5. MacTools updates an owned CLI with the app. Users can update, remove, or explicitly roll back from Settings.
+
+Required macOS background-item approval remains separate. Disabling integration prevents action access. Removal prevents automatic reinstallation. MacTools does not overwrite manual or Homebrew installations or edit shell startup files.
+
+## Initial supported commands
+
+Promote the existing command surface after auditing its current documentation and compatibility behavior:
+
+- `help`, `version`, and `doctor`.
+- `actions list`, `actions describe`, and `actions availability`.
+- `actions run <action-id> [--timeout SECONDS] [--json]` for currently eligible parameterless actions.
+- Human-readable output and the documented JSON envelope, rejection categories, exit codes, deadlines, and cancellation behavior.
+
+Action execution remains host-owned. Eligibility continues to require safe, background-capable, automatic, portable, CLI-exposed actions without parameters. The host revalidates the action and current availability immediately before dispatch. A stable release does not make every installed plugin action executable through the CLI.
+
+Action IDs come from live discovery. Plugin installation, removal, updates, and provider generation changes can change the catalog; stable CLI syntax does not promise a permanently fixed catalog.
+
+## Distribution and compatibility
+
+- Publish a separately signed and notarized CLI archive for each supported stable app release, with authenticated metadata sealed into the app.
+- Retain strict hash, archive, architecture, signing identity, notarization, embedded version/build, ownership, and protocol checks before activation.
+- Preserve quarantine and the automatic Gatekeeper assessment followed by full verification when a notarization ticket is not cached.
+- Keep stable and Nightly command names, identities, broker services, installation roots, receipts, update feeds, and plugin catalogs isolated. They must coexist without replacing each other's commands or state.
+- Begin with Apple silicon, matching the managed installer already implemented. Intel support is a separate decision requiring its own artifact and acceptance coverage.
+- Align minimum macOS support with the app's supported release policy. Test the oldest advertised version in addition to macOS 26 and 27 before claiming that support.
+- Managed installations follow the app release. Manual installations remain independently managed and may communicate only when supported protocol ranges overlap.
+- Document JSON schema, exit-code, and command compatibility. Additive evolution must preserve documented old-client behavior; incompatible changes require an explicit versioned migration.
+- Do not silently retry action execution after a timeout, cancellation, or uncertain connection failure. Installation retries and action retries are different operations.
+
+Homebrew publication and embedding the CLI in the app bundle are outside this proposal. A later Homebrew package would need to preserve the officially signed binary and coexist with the managed installer.
+
+## Release gates
+
+Before enabling stable publication:
+
+- [ ] Complete the signed Nightly acceptance matrix for the final candidate on macOS 26 and 27: fresh installation, background approval, disabled/enabled integration, actual quarantined execution, app-driven updates, offline recovery, downgrade, rollback persistence, command collisions, and removal.
+- [x] Validate first use in a fresh OS environment before any manual CLI Gatekeeper assessment populates the ticket cache. Passed for the pinned Nightly candidate in clean macOS 26.6.2 and 27.0 RC VMs; see the acceptance report. Repeat for a changed release candidate. A new user account alone does not prove an empty machine-wide cache.
+- [ ] Include migration from the legacy disabled automatic-update preference and users who never installed or previously removed the CLI.
+- [ ] Validate the stable-specific release artifacts and installation/update path; Nightly success alone does not validate stable packaging.
+- [ ] Verify stable/Nightly coexistence with both channels installed and enabled, including manual and Homebrew command collisions.
+- [ ] Agree on supported architectures/macOS versions and test that advertised matrix.
+- [ ] Review and document the compatibility contract, upgrade failure messages, diagnostics, localization, and recovery instructions.
+- [ ] Obtain maintainer approval for the stable distribution policy and release candidate.
+
+Issue #403 should remain open until its signed acceptance criteria pass, or its remaining checks are explicitly transferred to a dedicated release-validation issue before closure. Merging #409 establishes implementation completion, not completion of this matrix.
+
+## Later functionality
+
+After the limited stable CLI is dependable, use focused follow-ups under RFC #309:
+
+1. **Typed parameters for eligible canonical actions.** Describe schemas, validate bounds and types in the host, define bounded JSON input through stdin or an input file, and preserve parameter privacy. Sensitive values must not be placed in ordinary process arguments, logs, or diagnostics. Start with a few concrete user workflows.
+2. **Explicit state operations and structured results.** Prefer reading a state and setting a desired value over toggling when scripts need a known result. Extend shared canonical action/result models first so all invocation surfaces agree. Define unavailable, unsupported, and stale observations explicitly; permission to read one state is not permission to export arbitrary plugin-private data.
+3. **Convenience integrations where demand exists.** Workflow conveniences, completion, and a local MCP adapter can build on the documented CLI. They should not introduce a second execution engine or broaden authorization.
+
+An example future acceptance scenario is: discover the supported brightness action, read its structured state, request a bounded target value, and confirm the result. This describes a proposed capability, not command syntax available today.
+
+## Suggested implementation sequence
+
+1. Finish and record Nightly signed acceptance without expanding commands.
+2. Agree on this stable proposal and its compatibility/platform commitments.
+3. Add stable-channel metadata, packaging, managed installation, and isolation tests in a focused PR.
+4. Validate a signed stable candidate and publish only after the release gates pass.
+5. Scope typed parameters and explicit state/results as separate proposals and PRs, using Nightly for their initial validation.

--- a/docs/cli/validation/2026-09-10-nightly-signed-acceptance.md
+++ b/docs/cli/validation/2026-09-10-nightly-signed-acceptance.md
@@ -1,0 +1,105 @@
+# Signed Nightly CLI acceptance progress — 2026-09-10
+
+Status: partial acceptance. Do not close [#403](https://github.com/ggbond268/MacTools/issues/403) as fully validated or enable stable CLI publication from this report alone.
+
+Signed first installation, uncached-ticket recovery, and background-permission denial, guidance, and recovery passed in clean macOS 26.6.2 and 27.0 RC VMs. Both systems automatically enabled the first background registration; neither presented an initial pending-approval prompt.
+
+The [stable CLI v1 proposal](../proposals/stable-cli-v1.md) is tracked in [#417](https://github.com/ggbond268/MacTools/issues/417) while the remaining signed checks are completed. Environment labels below describe OS versions and test conditions rather than personal devices.
+
+## Candidates and scope
+
+The primary candidate came from a separate signed Nightly distribution:
+
+- App and CLI: `1.3.1 (1789056230.1)`.
+- Source snapshot: `0381daeeb21017e81f0515b7903d3885d2312735`.
+- Reviewed checkout: `bde41c83`, the final PR #409 documentation commit. All six files in `Sources/Core/CLI/Installation/` and `Sources/App/CLIInstallSettingsView.swift` are byte-identical to this candidate's source snapshot.
+- CLI architecture: arm64, as declared in the sealed manifest.
+- App DMG SHA-256: `b1b85ff4cbb6116d8488aec1f8a679b3a46d5396d35d82819ac3ad73aefc80cd`.
+- CLI ZIP SHA-256: `6482f1040ffb08f3b4aa295f275c62dfe17814d89b64af183efcdcd1a0ad78a9`.
+
+The downloaded DMG and CLI ZIP matched the published artifacts. CLI hash and size matched `cli-install.json` sealed inside the signed app. Publisher records reported both artifacts accepted by the notary service. The app passed strict signature verification and Gatekeeper assessment inside the read-only mounted DMG.
+
+Physical macOS 26 UI tests used the separate upstream `nightly-23-1` candidate: app and CLI `1.3.0 (23.1)`, source `2d55ee73961ae1427de8ebfad13407b8eb96a439`. Its six installer files and settings view also match the reviewed implementation. Its published DMG checksum, app signature, Gatekeeper assessment, publisher identity relative to the existing upstream app, and sealed manifest/build binding passed.
+
+These candidates are distinct artifacts. The primary candidate includes other integration changes. Results apply to the identified installer source and tested packages; they do not establish stable-channel packaging acceptance.
+
+## Physical-environment results
+
+The physical macOS 27 environment had an existing installation, prior background approval, and cached notarization tickets. The physical macOS 26 UI environment had no managed CLI when testing began, but already had an upstream background-item grant. A separate existing macOS 26 installation received read-only version and broker checks only.
+
+| Check | Physical macOS 27; primary candidate | Physical macOS 26; upstream 23.1 unless noted |
+| --- | --- | --- |
+| Signed installed app/CLI verification | Passed | Passed |
+| Quarantined CLI `version --json` | Passed | Passed |
+| Enabled integration: `doctor --json` and matching app/broker build | Passed | Passed |
+| Read-only action discovery | Passed; six action summaries | Passed |
+| App-driven CLI upgrade | Passed: verified app replacement and launch upgraded CLI `1788990658.1` to `1789056230.1` | User-reported prior pass; exact builds not recorded |
+| Prior version retained after upgrade | Passed | Not observed |
+| Integration disabled/enabled through Settings | Passed: disabled version exits 0, doctor exits 9 with `hostUnavailable`; re-enabling restores doctor | Passed: disabled version exits 0, doctor and discovery exit 9; re-enabling restores doctor |
+| Explicit rollback | Passed through Restore Previous Version to `1788990658.1` | User-reported prior pass; exact builds not recorded |
+| Rollback across restart of the same app release | Passed; rollback hold retained | Pending |
+| Explicit Update after rollback | Passed | Pending |
+| Removal through Settings | Passed | Passed |
+| No automatic reinstall after removal and app restart | Passed | Passed |
+| Unmanaged regular-file collision | Passed; fixture bytes and inode preserved | Passed; fixture bytes and inode preserved |
+| Retry after removing the test collision | Passed | Passed |
+| Installation confirmation | Observed version, size, paths, integration choice, automatic updates, and possible macOS approval | Passed with matching build and details |
+| First use with an uncached notarization ticket | Covered separately in the clean VM | Passed: static requirement failed before installation and passed afterward on the unchanged probe |
+| Offline update/recovery | Passed with process-only network denial; old CLI preserved and normal-network restart recovered | Fresh-install failure and subsequent online installation passed; existing-CLI offline update pending |
+| Legacy disabled update-preference migration | Passed using a backed-up signed legacy installation with `automaticUpdates=false` | Pending |
+| CLI absent before explicit first installation | Covered separately in the clean VM | Passed |
+| App downgrade and next-release update after rollback hold | Pending | Pending |
+| Other collisions, channel/publisher isolation, and download/activation faults | Automated PR coverage exists; signed runtime matrix incomplete | Automated PR coverage exists; signed runtime matrix incomplete |
+
+The observed app-driven upgrade used manual replacement from a verified DMG followed by normal app launch. It does not validate a complete Sparkle download/relaunch update. User-reported upgrade and rollback results do not establish the unrecorded restart, next-release, or migration variants.
+
+The macOS 27 offline/migration fixture used the real signed legacy executable and receipt, with its update preference set to false and the current store backed up separately. Denying outbound networking only to the signed app caused an update failure while retaining the old executable, command link, and receipt without pending activation. Normal-network relaunch updated the CLI, retained the previous version, and restored successful doctor output. This tests controlled network denial, not the exact error wording of disconnected Wi-Fi or Ethernet.
+
+Physical macOS 26 UI automation used a temporary helper after the user granted Accessibility permission. That permission is separate from MacTools background approval. The uncached CLI probe was neither executed nor manually Gatekeeper-assessed before installation; its unchanged static notarization result changed from exit 3 to exit 0 after the app installed the CLI. Quarantine remained present. A later network-denied fresh installation failed without activation; a confirmed online retry succeeded with integration disabled.
+
+A temporary installer-lock experiment expired before the attempted update and is not counted as a successful busy/error-recovery test.
+
+## Clean VM validation
+
+Two clean OS baselines were installed from Apple restore images using Tart 2.37.0. The downloaded Tart archive matched SHA-256 `d531752c4dad5d4214ac7ff540cefc2647df1fca2338d413d3c01754f54b356b`, and passed strict signature verification and Gatekeeper assessment. Separate APFS clones were used for testing:
+
+- macOS 26.6.2 (`25G83`).
+- macOS 27.0 RC (`26A428`).
+
+Both guests used disposable local accounts without an Apple Account. Each baseline had no MacTools app or CLI. Tests used the same primary candidate identified above.
+
+On each OS, Safari downloaded the pinned DMG. Quarantine and the checksum were verified, strict app signature and Gatekeeper checks passed, and the normal first-launch confirmation was accepted. Launching the app did not install a CLI automatically.
+
+Before in-app installation, a non-executed CLI probe downloaded from the sealed manifest matched the archive checksum and failed the static notarization requirement with exit 3. No manual CLI Gatekeeper assessment was performed. Installation through the actual app confirmation succeeded, and the unchanged probe then passed with exit 0. The installed CLI retained quarantine. Version and doctor reported matching app/CLI/broker build `1789056230.1` and protocol 3. Discovery completed with an empty list because no plugins were installed.
+
+Both OS versions automatically enabled initial background registration. Disabling the MacTools entry through native System Settings caused doctor to return `hostUnavailable`, exit 9, and background-item guidance. MacTools displayed pending-approval text and the **Allow in Background** button. Clicking that button opened the correct Settings page. Re-enabling the item and returning to MacTools restored doctor exit 0 without reinstalling.
+
+| Clean VM check | macOS 26.6.2 | macOS 27.0 RC |
+| --- | --- | --- |
+| CLI absent before explicit installation | Passed | Passed |
+| Signed app installation with Safari quarantine | Passed | Passed |
+| First CLI install with demonstrated uncached ticket | Passed | Passed |
+| Initial background registration | Automatically enabled | Automatically enabled |
+| Disabled background permission blocks app access | Passed; doctor exit 9 | Passed; doctor exit 9 |
+| Pending-approval guidance and Settings button | Passed after disabling permission | Passed after disabling permission |
+| Permission restoration without reinstalling | Passed; doctor exit 0 | Passed; doctor exit 0 |
+
+These tests exercised real native UI and macOS service state. No mock service, TCC database edits, product re-signing, or quarantine removal were used. No separate human permission prompt occurred during the guest background toggles. The observed denial/recovery behavior does not establish a first-registration pending-approval prompt that macOS did not show.
+
+## Final state and evidence retention
+
+The physical macOS 27 installation finished on the matching primary app/CLI candidate with integration enabled, automatic updates enabled, the prior CLI retained, and no pending activation or rollback hold. The separate read-only macOS 26 installation was unchanged. Physical macOS 26 UI testing ended with the test CLI removed, the temporary upstream broker unregistered, and the test app quit; the existing installed app was preserved.
+
+Physical-test recovery backups and evidence were retained separately. Personal device names, account names, private paths, distribution addresses, and signing identities are omitted from this report.
+
+VM logs and screenshots were reviewed to produce the result summary above. Both guests were shut down cleanly, and all four baseline/test VMs were verified stopped. After validation, all four VMs and their isolated tooling, runtime, launch shortcuts, disposable credentials, logs, screenshots, and release metadata were deleted at the user's request. Cleanup recovered approximately 60 GiB of available storage. The durable VM evidence is this sanitized result summary; the raw VM evidence and resettable baselines are no longer retained. Existing app installations, release-publishing infrastructure, unrelated simulators, and physical-test recovery backups were preserved.
+
+## Remaining work before closure
+
+1. Track the unobserved OS-generated first-registration pending-approval case separately from the completed disabled-permission guidance and recovery checks.
+2. Complete the outstanding signed runtime scenarios: macOS 26 existing-CLI offline update and legacy preference migration; rollback persistence where unobserved; app downgrade and next-release rollback-hold behavior; and the remaining collision, isolation, and download/activation fault cases.
+3. Validate the full Sparkle download/relaunch path if it is used for the release candidate.
+4. Validate the oldest advertised macOS version, supported architectures, and stable-specific artifacts and coexistence before stable publication.
+5. Close #403 only after its acceptance criteria pass, or explicitly transfer remaining checks to a dedicated release-validation issue before closing it as implementation-complete.
+
+No product source, GitHub issue state, or publication settings were changed during VM validation. The stable proposal can be discussed while these release gates remain open.


### PR DESCRIPTION
Managed CLI installation is currently Nightly-only. This PR proposes offering the existing limited CLI as an optional stable download, with platform, compatibility, packaging, and coexistence requirements that must be met before publication.

It also records signed Nightly validation on physical environments and clean macOS 26.6.2 / 27.0 RC VMs. The report distinguishes completed checks, user-reported results, and outstanding release checks. Initial background registration was automatically enabled; permission denial and recovery passed, while an initial OS-generated pending-approval prompt was not observed. Personal identifiers are omitted, and raw VM evidence removal is documented.

Proposal discussion: #417. Related: #403, #409, and #309. This documentation PR leaves #403 open and does not enable stable publication.

@ggbond268, please review the proposed stable scope and release requirements before we begin the implementation PR.

Validation: checked both documents for personal machine/account/path identifiers, verified relative links, and ran `git diff --cached --check`. Only two Markdown files change; no product code or release settings change, so builds and runtime tests were not rerun.
